### PR TITLE
Improve strlen implementation and remove stdlib calls

### DIFF
--- a/CMA/cma_realloc.cpp
+++ b/CMA/cma_realloc.cpp
@@ -1,6 +1,5 @@
 #include <cstdlib>
 #include <cstddef>
-#include <cstring>
 #include <cstdio>
 #include <cassert>
 #include <new>
@@ -8,6 +7,7 @@
 #include <csignal>
 #include "CMA.hpp"
 #include "CMA_internal.hpp"
+#include "../Libft/libft.hpp"
 #include "../CPP_class/nullptr.hpp"
 
 static int reallocate_block(void *ptr, size_t new_size)
@@ -43,7 +43,7 @@ void *cma_realloc(void* ptr, size_t new_size)
             Block* old_block = reinterpret_cast<Block*> ((static_cast<char*> (ptr)
 						- sizeof(Block)));
             size_t copy_size = old_block->size < new_size ? old_block->size : new_size;
-            memcpy(new_ptr, ptr, copy_size);
+            ft_memcpy(new_ptr, ptr, copy_size);
         }
         ::operator delete(ptr, std::align_val_t(8), std::nothrow);
         return (new_ptr);
@@ -77,7 +77,7 @@ void *cma_realloc(void* ptr, size_t new_size)
         return (ft_nullptr);
 	}
     size_t copy_size = old_block->size < new_size ? old_block->size : new_size;
-    memcpy(new_ptr, ptr, copy_size);
+    ft_memcpy(new_ptr, ptr, copy_size);
     cma_free(ptr);
 	g_malloc_mutex.unlock(THREAD_ID);
     return (new_ptr);

--- a/CPP_class/data_buffer.cpp
+++ b/CPP_class/data_buffer.cpp
@@ -1,4 +1,5 @@
 #include "data_buffer.hpp"
+#include "../Libft/libft.hpp"
 
 DataBuffer::DataBuffer() : _readPos(0), _ok(true)
 {
@@ -37,7 +38,7 @@ DataBuffer& DataBuffer::operator>>(size_t& len)
         this->_ok = false;
         return (*this);
     }
-    std::memcpy(&len, this->_buffer.data() + this->_readPos, sizeof(size_t));
+    ft_memcpy(&len, this->_buffer.data() + this->_readPos, sizeof(size_t));
     this->_readPos += sizeof(size_t);
     this->_ok = true;
     return (*this);

--- a/CPP_class/string_constructors.cpp
+++ b/CPP_class/string_constructors.cpp
@@ -1,5 +1,4 @@
 #include "string_class.hpp"
-#include <cstring>
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
 #include "../Errno/errno.hpp"
@@ -16,7 +15,7 @@ ft_string::ft_string(const char* init_str) noexcept
 {
     if (init_str)
     {
-        this->_length = std::strlen(init_str);
+        this->_length = ft_strlen_size_t(init_str);
         this->_capacity = this->_length + 1;
         this->_data = static_cast<char*>(cma_calloc(this->_capacity + 1, sizeof(char)));
         if (!this->_data)

--- a/CPP_class/string_methods.cpp
+++ b/CPP_class/string_methods.cpp
@@ -1,5 +1,4 @@
 #include "string_class.hpp"
-#include <cstring>
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
 #include "../Errno/errno.hpp"
@@ -54,7 +53,7 @@ void ft_string::append(const ft_string& string) noexcept
         if (this->_errorCode)
             return ;
     }
-    std::memcpy(this->_data + this->_length, string._data, string._length);
+    ft_memcpy(this->_data + this->_length, string._data, string._length);
     this->_length = new_length;
     this->_data[this->_length] = '\0';
 	return ;
@@ -64,7 +63,7 @@ void ft_string::append(const char *string) noexcept
 {
     if (!string)
         return ;
-    size_t string_length = std::strlen(string);
+    size_t string_length = ft_strlen_size_t(string);
     if (this->_length + string_length >= this->_capacity)
     {
         size_t new_capacity;
@@ -78,7 +77,7 @@ void ft_string::append(const char *string) noexcept
         if (this->_errorCode)
             return ;
     }
-    std::memcpy(this->_data + this->_length, string, string_length);
+    ft_memcpy(this->_data + this->_length, string, string_length);
     this->_length += string_length;
     this->_data[this->_length] = '\0';
     return ;

--- a/Libft/ft_strlen.cpp
+++ b/Libft/ft_strlen.cpp
@@ -1,14 +1,34 @@
 #include "libft.hpp"
-#include <stddef.h>
+#include <cstddef>
+#include <cstdint>
+
+static inline bool has_zero(size_t value)
+{
+    const size_t mask01 = ~(size_t)0 / 0xFF;
+    const size_t mask80 = mask01 << 7;
+    return ((value - mask01) & (~value) & mask80) != 0;
+}
 
 int ft_strlen(const char *string)
 {
-	int	index;
+    if (!string)
+        return (0);
 
-	if (!string)
-		return (0);
-	index = 0;
-	while (string[index])
-		index++;
-	return (index);
+    const char *ptr = string;
+    while (reinterpret_cast<uintptr_t>(ptr) & (sizeof(size_t) - 1))
+    {
+        if (*ptr == '\0')
+            return (ptr - string);
+        ++ptr;
+    }
+
+    const size_t *word_ptr = reinterpret_cast<const size_t*>(ptr);
+    while (!has_zero(*word_ptr))
+        ++word_ptr;
+
+    ptr = reinterpret_cast<const char*>(word_ptr);
+    while (*ptr)
+        ++ptr;
+
+    return (ptr - string);
 }

--- a/Libft/ft_strlen_size_t.cpp
+++ b/Libft/ft_strlen_size_t.cpp
@@ -1,12 +1,34 @@
 #include "libft.hpp"
 #include <cstddef>
+#include <cstdint>
+
+static inline bool has_zero_size_t(size_t value)
+{
+    const size_t mask01 = ~(size_t)0 / 0xFF;
+    const size_t mask80 = mask01 << 7;
+    return ((value - mask01) & (~value) & mask80) != 0;
+}
 
 size_t ft_strlen_size_t(const char *string)
 {
-	if (!string)
-		return (0);
-	size_t index = 0;
-	while (string[index])
-		index++;
-	return (index);
+    if (!string)
+        return (0);
+
+    const char *ptr = string;
+    while (reinterpret_cast<uintptr_t>(ptr) & (sizeof(size_t) - 1))
+    {
+        if (*ptr == '\0')
+            return (ptr - string);
+        ++ptr;
+    }
+
+    const size_t *word_ptr = reinterpret_cast<const size_t*>(ptr);
+    while (!has_zero_size_t(*word_ptr))
+        ++word_ptr;
+
+    ptr = reinterpret_cast<const char*>(word_ptr);
+    while (*ptr)
+        ++ptr;
+
+    return (ptr - string);
 }

--- a/Networking/setup_server.cpp
+++ b/Networking/setup_server.cpp
@@ -1,12 +1,12 @@
 #include "networking.hpp"
 #include "socket_class.hpp"
 #include "../Errno/errno.hpp"
-#include <cstring>
 #include <cerrno>
 #include <fcntl.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <sys/socket.h>
+#include "../Libft/libft.hpp"
 
 int ft_socket::create_socket(const SocketConfig &config)
 {
@@ -90,7 +90,7 @@ int ft_socket::set_timeouts(const SocketConfig &config)
 
 int ft_socket::configure_address(const SocketConfig &config)
 {
-    std::memset(&this->_address, 0, sizeof(this->_address));
+    ft_memset(&this->_address, 0, sizeof(this->_address));
 
     if (config.address_family == AF_INET)
 	{

--- a/ReadLine/utilities.cpp
+++ b/ReadLine/utilities.cpp
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 #include "../Linux/linux_file.hpp"
 #include "../CPP_class/nullptr.hpp"
@@ -17,7 +16,7 @@ char *rl_resize_buffer(char *old_buffer, int current_size, int new_size)
         pf_printf_fd(2, "Allocation error\n");
         return (ft_nullptr);
     }
-    memcpy(new_buffer, old_buffer, current_size);
+    ft_memcpy(new_buffer, old_buffer, current_size);
     cma_free(old_buffer);
     return (new_buffer);
 }
@@ -59,7 +58,7 @@ void rl_update_history(const char *buffer)
     else
     {
         cma_free(history[0]);
-        memmove(&history[0], &history[1], sizeof(char *) * (MAX_HISTORY - 1));
+        ft_memmove(&history[0], &history[1], sizeof(char *) * (MAX_HISTORY - 1));
         history[MAX_HISTORY - 1] = cma_strdup(buffer);
     }
 	return ;


### PR DESCRIPTION
## Summary
- optimize string length calculations using word-sized checks
- avoid standard library memcpy/memmove in readline utilities
- switch custom classes from std::memcpy/strlen to internal helpers
- remove `std::memset` usage when configuring networking addresses

## Testing
- `make` *(fails: No rule to make target 'objs/json_parsing.o', needed by 'JSon.a')*

------
https://chatgpt.com/codex/tasks/task_e_685efb3043b88331a39ca67d2e55ea9b