### PR TITLE
Optimize memory operations

### DIFF
--- a/Libft/ft_bzero.cpp
+++ b/Libft/ft_bzero.cpp
@@ -1,15 +1,6 @@
 #include "libft.hpp"
 
-void	ft_bzero(void *pointer, size_t size)
+void    ft_bzero(void *pointer, size_t size)
 {
-	size_t	i;
-	char	*string;
-
-	string = static_cast<char *>(pointer);
-	i = 0;
-	while (i < size)
-	{
-		string[i] = 0;
-		i++;
-	}
+    ft_memset(pointer, 0, size);
 }

--- a/Libft/ft_memcpy.cpp
+++ b/Libft/ft_memcpy.cpp
@@ -1,17 +1,38 @@
 #include "libft.hpp"
 #include "../CPP_class/nullptr.hpp"
+#include <cstdint>
 
 void* ft_memcpy(void* destination, const void* source, size_t size)
 {
     if (destination == ft_nullptr || source == ft_nullptr)
         return (ft_nullptr);
-    char* dest = static_cast<char*>(destination);
-    const char* src = static_cast<const char*>(source);
-	std::size_t index = 0;
-    while (index < size)
+
+    unsigned char*       dest = static_cast<unsigned char*>(destination);
+    const unsigned char* src = static_cast<const unsigned char*>(source);
+
+    while (size && (reinterpret_cast<uintptr_t>(dest) & (sizeof(size_t) - 1)))
     {
-        dest[index] = src[index];
-		index++;
+        *dest++ = *src++;
+        --size;
     }
-    return destination;
+
+    size_t*       dest_word = reinterpret_cast<size_t*>(dest);
+    const size_t* src_word  = reinterpret_cast<const size_t*>(src);
+
+    while (size >= sizeof(size_t))
+    {
+        *dest_word++ = *src_word++;
+        size -= sizeof(size_t);
+    }
+
+    dest = reinterpret_cast<unsigned char*>(dest_word);
+    src  = reinterpret_cast<const unsigned char*>(src_word);
+
+    while (size)
+    {
+        *dest++ = *src++;
+        --size;
+    }
+
+    return (destination);
 }

--- a/Libft/ft_memset.cpp
+++ b/Libft/ft_memset.cpp
@@ -1,16 +1,40 @@
 #include "libft.hpp"
 #include "../CPP_class/nullptr.hpp"
+#include <cstdint>
 
 void *ft_memset(void *destination, int value, size_t number_of_bytes)
 {
     if (destination == ft_nullptr)
         return (ft_nullptr);
-    unsigned char *byte_pointer = static_cast<unsigned char *>(destination);
-    size_t index = 0;
-    while (index < number_of_bytes)
+
+    unsigned char *dest = static_cast<unsigned char *>(destination);
+    unsigned char byte  = static_cast<unsigned char>(value);
+
+    while (number_of_bytes && (reinterpret_cast<uintptr_t>(dest) & (sizeof(size_t) - 1)))
     {
-        byte_pointer[index] = static_cast<unsigned char>(value);
-        index++;
+        *dest++ = byte;
+        --number_of_bytes;
     }
+
+    size_t pattern = byte;
+    pattern |= pattern << 8;
+    pattern |= pattern << 16;
+    if (sizeof(size_t) == 8)
+        pattern |= pattern << 32;
+
+    size_t *dest_word = reinterpret_cast<size_t *>(dest);
+    while (number_of_bytes >= sizeof(size_t))
+    {
+        *dest_word++ = pattern;
+        number_of_bytes -= sizeof(size_t);
+    }
+
+    dest = reinterpret_cast<unsigned char *>(dest_word);
+    while (number_of_bytes)
+    {
+        *dest++ = byte;
+        --number_of_bytes;
+    }
+
     return (destination);
 }


### PR DESCRIPTION
## Summary
- optimize `ft_memcpy` with word-sized copying
- optimize `ft_memset` using pattern writes
- simplify `ft_bzero` using `ft_memset`

## Testing
- `make`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_685f0d82ad448331aa2cda802fa45620