### PR TITLE
Add HTML parser skeleton

### DIFF
--- a/HTML/Makefile
+++ b/HTML/Makefile
@@ -1,0 +1,64 @@
+TARGET         := HTMLParser.a
+DEBUG_TARGET   := HTMLParser_debug.a
+
+SRCS := html_parser.cpp
+
+HEADERS := html_parser.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+clean:
+	-$(RM) $(CLEAN_OBJS)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/HTML/html_parser.cpp
+++ b/HTML/html_parser.cpp
@@ -1,0 +1,191 @@
+#include <new>
+#include <fcntl.h>
+#include "html_parser.hpp"
+#include "../CMA/CMA.hpp"
+#include "../Printf/printf.hpp"
+#include "../Linux/linux_file.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include "../Errno/errno.hpp"
+
+#define HTML_MALLOC_FAIL 1001
+
+html_node *html_create_node(const char *tag, const char *text)
+{
+    html_node *node = new(std::nothrow) html_node;
+    if (!node)
+    {
+        ft_errno = HTML_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    node->tag = cma_strdup(tag);
+    if (!node->tag)
+    {
+        delete node;
+        ft_errno = HTML_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    if (text)
+        node->text = cma_strdup(text);
+    else
+        node->text = ft_nullptr;
+    if (text && !node->text)
+    {
+        delete[] node->tag;
+        delete node;
+        ft_errno = HTML_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    node->attributes = ft_nullptr;
+    node->children = ft_nullptr;
+    node->next = ft_nullptr;
+    return (node);
+}
+
+html_attr *html_create_attr(const char *key, const char *value)
+{
+    html_attr *attr = new(std::nothrow) html_attr;
+    if (!attr)
+    {
+        ft_errno = HTML_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    attr->key = cma_strdup(key);
+    if (!attr->key)
+    {
+        delete attr;
+        ft_errno = HTML_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    attr->value = cma_strdup(value);
+    if (!attr->value)
+    {
+        delete[] attr->key;
+        delete attr;
+        ft_errno = HTML_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    attr->next = ft_nullptr;
+    return (attr);
+}
+
+void html_add_attr(html_node *node, html_attr *attr)
+{
+    if (!node->attributes)
+        node->attributes = attr;
+    else
+    {
+        html_attr *current = node->attributes;
+        while (current->next)
+            current = current->next;
+        current->next = attr;
+    }
+    return ;
+}
+
+void html_add_child(html_node *parent, html_node *child)
+{
+    if (!parent->children)
+        parent->children = child;
+    else
+    {
+        html_node *current = parent->children;
+        while (current->next)
+            current = current->next;
+        current->next = child;
+    }
+    return ;
+}
+
+void html_append_node(html_node **head, html_node *new_node)
+{
+    if (!(*head))
+        *head = new_node;
+    else
+    {
+        html_node *current = *head;
+        while (current->next)
+            current = current->next;
+        current->next = new_node;
+    }
+    return ;
+}
+
+static void html_write_attrs(int fd, html_attr *attr)
+{
+    while (attr)
+    {
+        pf_printf_fd(fd, " %s=\"%s\"", attr->key, attr->value);
+        attr = attr->next;
+    }
+}
+
+static void html_write_node(int fd, html_node *node, int indent)
+{
+    for (int i = 0; i < indent; ++i)
+        pf_printf_fd(fd, "  ");
+    pf_printf_fd(fd, "<%s", node->tag);
+    html_write_attrs(fd, node->attributes);
+    if (!node->text && !node->children)
+    {
+        pf_printf_fd(fd, "/>\n");
+        return ;
+    }
+    pf_printf_fd(fd, ">");
+    if (node->text)
+        pf_printf_fd(fd, "%s", node->text);
+    if (node->children)
+    {
+        pf_printf_fd(fd, "\n");
+        html_node *child = node->children;
+        while (child)
+        {
+            html_write_node(fd, child, indent + 1);
+            child = child->next;
+        }
+        for (int i = 0; i < indent; ++i)
+            pf_printf_fd(fd, "  ");
+    }
+    pf_printf_fd(fd, "</%s>\n", node->tag);
+}
+
+int html_write_to_file(const char *filename, html_node *nodes)
+{
+    int fd = ft_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0)
+        return (-1);
+    html_node *current = nodes;
+    while (current)
+    {
+        html_write_node(fd, current, 0);
+        current = current->next;
+    }
+    ft_close(fd);
+    return (0);
+}
+
+void html_free_nodes(html_node *node)
+{
+    while (node)
+    {
+        html_node *next = node->next;
+        if (node->tag)
+            delete[] node->tag;
+        if (node->text)
+            delete[] node->text;
+        html_attr *attr = node->attributes;
+        while (attr)
+        {
+            html_attr *next_attr = attr->next;
+            if (attr->key)
+                delete[] attr->key;
+            if (attr->value)
+                delete[] attr->value;
+            delete attr;
+            attr = next_attr;
+        }
+        html_free_nodes(node->children);
+        delete node;
+        node = next;
+    }
+}
+

--- a/HTML/html_parser.hpp
+++ b/HTML/html_parser.hpp
@@ -1,0 +1,30 @@
+#ifndef HTML_PARSER_HPP
+#define HTML_PARSER_HPP
+
+#include <cstddef>
+
+typedef struct html_attr
+{
+    char *key;
+    char *value;
+    struct html_attr *next;
+} html_attr;
+
+typedef struct html_node
+{
+    char *tag;
+    char *text;
+    html_attr *attributes;
+    struct html_node *children;
+    struct html_node *next;
+} html_node;
+
+html_node   *html_create_node(const char *tag, const char *text);
+void        html_add_child(html_node *parent, html_node *child);
+void        html_append_node(html_node **head, html_node *new_node);
+html_attr   *html_create_attr(const char *key, const char *value);
+void        html_add_attr(html_node *node, html_attr *attr);
+int         html_write_to_file(const char *filename, html_node *nodes);
+void        html_free_nodes(html_node *node);
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ SUBDIRS :=  CMA \
             encryption \
             RNG \
 			JSon \
-			file
+			file \
+            HTML
 
 LIB_BASES := \
   CMA/CustomMemoryAllocator \
@@ -34,7 +35,8 @@ LIB_BASES := \
   encryption/encryption \
   RNG/RNG \
   JSon/JSon \
-  file/file
+  file/file \
+  HTML/HTMLParser
 
 LIBS       := $(addsuffix .a, $(LIB_BASES))
 DEBUG_LIBS := $(addsuffix _debug.a, $(LIB_BASES))


### PR DESCRIPTION
## Summary
- add initial HTML parser submodule with header, implementation, and Makefile
- register HTML parser library in main Makefile

## Testing
- `make -C HTML`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6860459db6108331ab85b515d9a5db43