### PR TITLE
Add HTML tag search function

### DIFF
--- a/HTML/Makefile
+++ b/HTML/Makefile
@@ -1,7 +1,7 @@
 TARGET         := HTMLParser.a
 DEBUG_TARGET   := HTMLParser_debug.a
 
-SRCS := html_node.cpp html_writer.cpp html_cleanup.cpp
+SRCS := html_node.cpp html_writer.cpp html_cleanup.cpp html_search.cpp
 
 HEADERS := html_parser.hpp
 

--- a/HTML/html_parser.hpp
+++ b/HTML/html_parser.hpp
@@ -26,5 +26,6 @@ html_attr   *html_create_attr(const char *key, const char *value);
 void        html_add_attr(html_node *targetNode, html_attr *newAttribute);
 int         html_write_to_file(const char *filePath, html_node *nodeList);
 void        html_free_nodes(html_node *nodeList);
+html_node   *html_find_by_tag(html_node *nodeList, const char *tagName);
 
 #endif

--- a/HTML/html_search.cpp
+++ b/HTML/html_search.cpp
@@ -1,0 +1,18 @@
+#include <cstring>
+#include "html_parser.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+html_node *html_find_by_tag(html_node *nodeList, const char *tagName)
+{
+    html_node *currentNode = nodeList;
+    while (currentNode)
+    {
+        if (currentNode->tag && std::strcmp(currentNode->tag, tagName) == 0)
+            return (currentNode);
+        html_node *found = html_find_by_tag(currentNode->children, tagName);
+        if (found)
+            return (found);
+        currentNode = currentNode->next;
+    }
+    return (ft_nullptr);
+}


### PR DESCRIPTION
## Summary
- extend the HTML parser with a search helper
- compile new source file as part of the HTML parser library

## Testing
- `make -C HTML`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68604d76261083319646a76636091220