### PR TITLE
Add CMA substring

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -12,6 +12,8 @@ char	**cma_split(char const *s, char c) __attribute__ ((warn_unused_result));
 char	*cma_itoa(int n) __attribute__ ((warn_unused_result));
 char	*cma_strjoin(char const *string_1, char const *string_2)
 						__attribute__ ((warn_unused_result));
+char    *cma_substr(const char *s, unsigned int start, size_t len)
+                                                __attribute__ ((warn_unused_result));
 void	cma_free_double(char **content);
 void	cma_cleanup();
 

--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -9,6 +9,7 @@ SRCS := cma_calloc.cpp \
         cma_itoa.cpp \
         cma_split.cpp \
         cma_strjoin.cpp \
+        cma_substr.cpp \
         cma_free_double.cpp \
         cma_utils.cpp \
         cma_cleanup.cpp \

--- a/CMA/cma_substr.cpp
+++ b/CMA/cma_substr.cpp
@@ -1,0 +1,29 @@
+#include "CMA.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+char    *cma_substr(const char *s, unsigned int start, size_t len)
+{
+    size_t  s_len;
+    size_t  i;
+    char    *sub;
+
+    if (!s)
+        return (ft_nullptr);
+    s_len = ft_strlen(s);
+    if (start >= s_len)
+        return (cma_strdup(""));
+    if (len > s_len - start)
+        len = s_len - start;
+    sub = static_cast<char *>(cma_malloc(len + 1));
+    if (!sub)
+        return (ft_nullptr);
+    i = 0;
+    while (i < len && s[start + i])
+    {
+        sub[i] = s[start + i];
+        i++;
+    }
+    sub[i] = '\0';
+    return (sub);
+}


### PR DESCRIPTION
## Summary
- implement `cma_substr` for CMA-based substring allocation
- expose new function in `CMA.hpp`
- compile new file by updating CMA Makefile

## Testing
- `make -C CMA`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_686051342f288331a2ef85531af17d7c