### PR TITLE
Add multi-string join helper

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -13,6 +13,8 @@ char	**cma_split(char const *s, char c) __attribute__ ((warn_unused_result));
 char	*cma_itoa(int n) __attribute__ ((warn_unused_result));
 char	*cma_strjoin(char const *string_1, char const *string_2)
 						__attribute__ ((warn_unused_result));
+char    *cma_strjoin_multiple(int count, ...)
+                                                __attribute__ ((warn_unused_result));
 char    *cma_substr(const char *s, unsigned int start, size_t len)
                                                 __attribute__ ((warn_unused_result));
 void	cma_free_double(char **content);

--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -10,6 +10,7 @@ SRCS := cma_calloc.cpp \
         cma_itoa.cpp \
         cma_split.cpp \
         cma_strjoin.cpp \
+        cma_strjoin_multiple.cpp \
         cma_substr.cpp \
         cma_free_double.cpp \
         cma_utils.cpp \

--- a/CMA/cma_strjoin_multiple.cpp
+++ b/CMA/cma_strjoin_multiple.cpp
@@ -1,0 +1,38 @@
+#include "CMA.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <stdarg.h>
+
+char    *cma_strjoin_multiple(int count, ...)
+{
+    if (count <= 0)
+        return (ft_nullptr);
+    va_list args;
+    va_start(args, count);
+    size_t total_len = 0;
+    for (int i = 0; i < count; ++i)
+    {
+        const char *str = va_arg(args, const char *);
+        if (str)
+            total_len += ft_strlen(str);
+    }
+    va_end(args);
+    char *result = static_cast<char*>(cma_malloc(total_len + 1));
+    if (!result)
+        return (ft_nullptr);
+    va_start(args, count);
+    size_t index = 0;
+    for (int i = 0; i < count; ++i)
+    {
+        const char *str = va_arg(args, const char *);
+        if (str)
+        {
+            size_t len = ft_strlen(str);
+            ft_memcpy(result + index, str, len);
+            index += len;
+        }
+    }
+    va_end(args);
+    result[index] = '\0';
+    return (result);
+}


### PR DESCRIPTION
## Summary
- extend CMA allocator with `cma_strjoin_multiple`
- update CMA build and headers for the new file

## Testing
- `make CMA/CustomMemoryAllocator.a`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6860560d93e483319d5f4724c1c06dd5