### PR TITLE
Add strtrim and isspace utility

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -17,7 +17,9 @@ char    *cma_strjoin_multiple(int count, ...)
                                                 __attribute__ ((warn_unused_result));
 char    *cma_substr(const char *s, unsigned int start, size_t len)
                                                 __attribute__ ((warn_unused_result));
-void	cma_free_double(char **content);
-void	cma_cleanup();
+char    *cma_strtrim(const char *s1, const char *set)
+                                                __attribute__ ((warn_unused_result));
+void    cma_free_double(char **content);
+void    cma_cleanup();
 
 #endif

--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -12,6 +12,7 @@ SRCS := cma_calloc.cpp \
         cma_strjoin.cpp \
         cma_strjoin_multiple.cpp \
         cma_substr.cpp \
+        cma_strtrim.cpp \
         cma_free_double.cpp \
         cma_utils.cpp \
         cma_cleanup.cpp \

--- a/CMA/cma_strtrim.cpp
+++ b/CMA/cma_strtrim.cpp
@@ -1,0 +1,38 @@
+#include "CMA.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+static bool is_in_set(char c, const char *set)
+{
+    while (set && *set)
+    {
+        if (*set == c)
+            return true;
+        ++set;
+    }
+    return false;
+}
+
+char    *cma_strtrim(const char *s1, const char *set)
+{
+    if (!s1 || !set)
+        return (ft_nullptr);
+    size_t start = 0;
+    size_t end = ft_strlen_size_t(s1);
+    while (s1[start] && is_in_set(s1[start], set))
+        ++start;
+    while (end > start && is_in_set(s1[end - 1], set))
+        --end;
+    size_t len = end - start;
+    char *trimmed = static_cast<char *>(cma_malloc(len + 1));
+    if (!trimmed)
+        return (ft_nullptr);
+    size_t i = 0;
+    while (i < len)
+    {
+        trimmed[i] = s1[start + i];
+        ++i;
+    }
+    trimmed[i] = '\0';
+    return (trimmed);
+}

--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -23,6 +23,7 @@ SRCS := ft_atoi.cpp \
 	ft_toupper.cpp \
 	ft_tolower.cpp \
 	ft_strncpy.cpp \
+        ft_isspace.cpp \
 	ft_strlen_size_t.cpp
 
 ifeq ($(OS),Windows_NT)

--- a/Libft/ft_isspace.cpp
+++ b/Libft/ft_isspace.cpp
@@ -1,0 +1,7 @@
+#include "libft.hpp"
+
+int ft_isspace(int character)
+{
+    return (character == ' ' || character == '\f' || character == '\n' ||
+            character == '\r' || character == '\t' || character == '\v');
+}

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -35,5 +35,6 @@ void		ft_to_lower(char *string);
 void		ft_to_upper(char *string);
 char 		*ft_strncpy(char *destination, const char *source, size_t number_of_characters);
 void 		*ft_memset(void *destination, int value, size_t number_of_bytes);
+        int ft_isspace(int character);
 
 #endif


### PR DESCRIPTION
## Summary
- implement `cma_strtrim` to trim characters from both ends of a string
- add new helper `ft_isspace` in libft
- expose new prototypes in headers
- compile new objects via Makefiles

## Testing
- `make`
- `make fclean`

------
https://chatgpt.com/codex/tasks/task_e_6860578f7cd08331bb56e7498c339599