### PR TITLE
Add base conversion to CMA

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -11,6 +11,7 @@ void	*cma_calloc(std::size_t, std::size_t size) __attribute__ ((warn_unused_resu
 void	*cma_realloc(void* ptr, std::size_t new_size) __attribute__ ((warn_unused_result));
 char	**cma_split(char const *s, char c) __attribute__ ((warn_unused_result));
 char	*cma_itoa(int n) __attribute__ ((warn_unused_result));
+char    *cma_itoa_base(int n, int base) __attribute__ ((warn_unused_result));
 char	*cma_strjoin(char const *string_1, char const *string_2)
 			__attribute__ ((warn_unused_result));
 char    *cma_strjoin_multiple(int count, ...)

--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -8,6 +8,7 @@ SRCS := cma_calloc.cpp \
         cma_free.cpp \
         cma_realloc.cpp \
         cma_itoa.cpp \
+        cma_itoa_base.cpp \
         cma_split.cpp \
         cma_strjoin.cpp \
         cma_strjoin_multiple.cpp \

--- a/CMA/cma_itoa_base.cpp
+++ b/CMA/cma_itoa_base.cpp
@@ -1,0 +1,45 @@
+#include "CMA.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+static int	calculate_length(int n, int base)
+{
+    int len = 0;
+    unsigned int num = (n < 0) ? -n : n;
+    if (num == 0)
+        return (1);
+    while (num)
+    {
+        num /= base;
+        len++;
+    }
+    return (len);
+}
+
+char    *cma_itoa_base(int n, int base)
+{
+    const char digits[] = "0123456789ABCDEF";
+    int negative = 0;
+    int len;
+    char *str;
+    unsigned int num;
+
+    if (base < 2 || base > 16)
+        return (ft_nullptr);
+    if (n < 0 && base == 10)
+        negative = 1;
+    num = (n < 0) ? -n : n;
+    len = calculate_length(n, base);
+    str = static_cast<char*>(cma_malloc(len + negative + 1));
+    if (!str)
+        return (ft_nullptr);
+    str[len + negative] = '\0';
+    while (len > 0)
+    {
+        str[len + negative - 1] = digits[num % base];
+        num /= base;
+        len--;
+    }
+    if (negative)
+        str[0] = '-';
+    return (str);
+}


### PR DESCRIPTION
## Summary
- implement `cma_itoa_base` for integer to string conversion in arbitrary base
- expose new prototype in `CMA.hpp`
- compile new source in `CMA` makefile

## Testing
- `make -C CMA`
- `make`
- `make clean`
- `make fclean`


------
https://chatgpt.com/codex/tasks/task_e_68605a34223c8331a4bc845cc5751074