### PR TITLE
Fix Windows compilation of directory functions

### DIFF
--- a/file/open_dir.hpp
+++ b/file/open_dir.hpp
@@ -7,6 +7,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#ifdef _WIN32
+# include <windows.h>
+#endif
 
 struct linux_dirent64
 {
@@ -31,6 +34,10 @@ struct FT_DIR
     size_t  buffer_size;
     ssize_t buffer_used;
     size_t  buffer_offset;
+#ifdef _WIN32
+    WIN32_FIND_DATAA w_findData;
+    bool             first_read;
+#endif
 };
 
 FT_DIR* 	ft_opendir(const char* directoryPath);


### PR DESCRIPTION
## Summary
- support Windows directory reading by including windows headers
- extend `FT_DIR` with Win32 fields
- implement Windows-specific `ft_opendir` and closing logic

## Testing
- `make -B`

------
https://chatgpt.com/codex/tasks/task_e_6860f063455483318c1cb3df08457a98