### PR TITLE
Fix Windows clean paths

### DIFF
--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -68,8 +68,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/CPP_class/Makefile
+++ b/CPP_class/Makefile
@@ -58,8 +58,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/Errno/Makefile
+++ b/Errno/Makefile
@@ -52,8 +52,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/GetNextLine/Makefile
+++ b/GetNextLine/Makefile
@@ -52,8 +52,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/HTML/Makefile
+++ b/HTML/Makefile
@@ -51,8 +51,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/JSon/Makefile
+++ b/JSon/Makefile
@@ -53,8 +53,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -73,8 +73,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -58,8 +58,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/Networking/Makefile
+++ b/Networking/Makefile
@@ -56,8 +56,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/PThread/Makefile
+++ b/PThread/Makefile
@@ -56,8 +56,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/Printf/Makefile
+++ b/Printf/Makefile
@@ -54,8 +54,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -51,8 +51,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/ReadLine/Makefile
+++ b/ReadLine/Makefile
@@ -61,8 +61,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/Windows/Makefile
+++ b/Windows/Makefile
@@ -51,8 +51,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/encryption/Makefile
+++ b/encryption/Makefile
@@ -52,8 +52,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)

--- a/file/Makefile
+++ b/file/Makefile
@@ -52,8 +52,14 @@ $(OBJDIR) $(DEBUG_OBJDIR):
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
 clean:
-	-$(RM) $(CLEAN_OBJS)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
 	-$(RM) $(TARGET) $(DEBUG_TARGET)


### PR DESCRIPTION
## Summary
- handle Windows path separators in clean rules
- keep command indentation correct for make

## Testing
- `make -C CMA clean`
- `make -j4`
- `make clean`
- `make fclean`

------
https://chatgpt.com/codex/tasks/task_e_6860f79079148331a428237cf2b6efb7