### PR TITLE
Fix send/recv signatures for Windows builds

### DIFF
--- a/Networking/socket_class.cpp
+++ b/Networking/socket_class.cpp
@@ -155,7 +155,13 @@ ssize_t ft_socket::send_data(const void *data, size_t size, int flags)
         this->_error = ft_errno;
         return (-1);
     }
+#ifdef _WIN32
+    ssize_t bytes_sent = ::send(this->_socket_fd,
+                                static_cast<const char*>(data),
+                                static_cast<int>(size), flags);
+#else
     ssize_t bytes_sent = ::send(this->_socket_fd, data, size, flags);
+#endif
     if (bytes_sent < 0)
 	{
         ft_errno = errno + ERRNO_OFFSET;
@@ -174,7 +180,13 @@ ssize_t ft_socket::receive_data(void *buffer, size_t size, int flags)
         this->_error = ft_errno;
         return (-1);
 	} 
+#ifdef _WIN32
+    ssize_t bytes_received = ::recv(this->_socket_fd,
+                                   static_cast<char*>(buffer),
+                                   static_cast<int>(size), flags);
+#else
     ssize_t bytes_received = ::recv(this->_socket_fd, buffer, size, flags);
+#endif
     if (bytes_received < 0)
 	{
         ft_errno = errno + ERRNO_OFFSET;


### PR DESCRIPTION
## Summary
- fix invalid pointer type conversions in `send_data` and `receive_data`
- adjust to Windows' `send` and `recv` signatures

## Testing
- `make`
- `make clean`
- `make fclean`


------
https://chatgpt.com/codex/tasks/task_e_6860f94d084c83318d44ceace8cae1b7