### PR TITLE
Improve cross-platform socket functions

### DIFF
--- a/Networking/socket_class.cpp
+++ b/Networking/socket_class.cpp
@@ -155,13 +155,7 @@ ssize_t ft_socket::send_data(const void *data, size_t size, int flags)
         this->_error = ft_errno;
         return (-1);
     }
-#ifdef _WIN32
-    ssize_t bytes_sent = ::send(this->_socket_fd,
-                                static_cast<const char*>(data),
-                                static_cast<int>(size), flags);
-#else
-    ssize_t bytes_sent = ::send(this->_socket_fd, data, size, flags);
-#endif
+    ssize_t bytes_sent = nw_send(this->_socket_fd, data, size, flags);
     if (bytes_sent < 0)
 	{
         ft_errno = errno + ERRNO_OFFSET;
@@ -180,13 +174,7 @@ ssize_t ft_socket::receive_data(void *buffer, size_t size, int flags)
         this->_error = ft_errno;
         return (-1);
 	} 
-#ifdef _WIN32
-    ssize_t bytes_received = ::recv(this->_socket_fd,
-                                   static_cast<char*>(buffer),
-                                   static_cast<int>(size), flags);
-#else
-    ssize_t bytes_received = ::recv(this->_socket_fd, buffer, size, flags);
-#endif
+    ssize_t bytes_received = nw_recv(this->_socket_fd, buffer, size, flags);
     if (bytes_received < 0)
 	{
         ft_errno = errno + ERRNO_OFFSET;

--- a/Networking/socket_class.hpp
+++ b/Networking/socket_class.hpp
@@ -19,6 +19,8 @@ int nw_listen(ssize_t sockfd, int backlog);
 int nw_accept(ssize_t sockfd, struct sockaddr *addr, socklen_t *addrlen);
 int nw_socket(int domain, int type, int protocol);
 int nw_connect(ssize_t sockfd, const struct sockaddr *addr, socklen_t addrlen);
+ssize_t nw_send(ssize_t sockfd, const void *buf, size_t len, int flags);
+ssize_t nw_recv(ssize_t sockfd, void *buf, size_t len, int flags);
 
 class ft_socket
 {

--- a/Networking/socket_wrapper_functions.cpp
+++ b/Networking/socket_wrapper_functions.cpp
@@ -85,3 +85,33 @@ int nw_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 #endif
     return (0);
 }
+
+ssize_t nw_send(int sockfd, const void *buf, size_t len, int flags)
+{
+#ifdef _WIN32
+    int ret = ::send((SOCKET)sockfd,
+                     static_cast<const char*>(buf),
+                     static_cast<int>(len), flags);
+    if (ret == SOCKET_ERROR)
+        return (-1);
+    return (ret);
+#else
+    ssize_t ret = ::send(sockfd, buf, len, flags);
+    return (ret);
+#endif
+}
+
+ssize_t nw_recv(int sockfd, void *buf, size_t len, int flags)
+{
+#ifdef _WIN32
+    int ret = ::recv((SOCKET)sockfd,
+                     static_cast<char*>(buf),
+                     static_cast<int>(len), flags);
+    if (ret == SOCKET_ERROR)
+        return (-1);
+    return (ret);
+#else
+    ssize_t ret = ::recv(sockfd, buf, len, flags);
+    return (ret);
+#endif
+}


### PR DESCRIPTION
## Summary
- add new `nw_send` and `nw_recv` helpers in `socket_wrapper_functions.cpp`
- expose these helpers in `socket_class.hpp`
- use wrappers inside `ft_socket::send_data` and `ft_socket::receive_data`

## Testing
- `make -C Networking clean`
- `make -C Networking`
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6860fa522a808331a8bec2299c41f319