### PR TITLE
Fix Makefile to include Linux objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ LIB_BASES += encryption/encryption \
   HTML/HTMLParser
 
 ifeq ($(OS),Windows_NT)
-OS_EXTRACT := $(call EXTRACT,Windows/Windows.a)
-DEBUG_OS_EXTRACT := $(call EXTRACT,Windows/Windows_debug.a)
+OS_EXTRACT = $(call EXTRACT,Windows/Windows.a)
+DEBUG_OS_EXTRACT = $(call EXTRACT,Windows/Windows_debug.a)
 OS_CLEAN := $(MAKE) -C Windows clean
 OS_FCLEAN := $(MAKE) -C Windows fclean
 else
-OS_EXTRACT := $(call EXTRACT,Linux/Linux.a)
-DEBUG_OS_EXTRACT := $(call EXTRACT,Linux/Linux_debug.a)
+OS_EXTRACT = $(call EXTRACT,Linux/Linux.a)
+DEBUG_OS_EXTRACT = $(call EXTRACT,Linux/Linux_debug.a)
 OS_CLEAN := $(MAKE) -C Linux clean
 OS_FCLEAN := $(MAKE) -C Linux fclean
 endif


### PR DESCRIPTION
## Summary
- allow Linux library extraction even when `OS` env var isn't defined

## Testing
- `make`
- `make fclean`

------
https://chatgpt.com/codex/tasks/task_e_6861089b53608331977faff99a9bb27f