### PR TITLE
Fix printf type conversions

### DIFF
--- a/Printf/format.cpp
+++ b/Printf/format.cpp
@@ -60,13 +60,13 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
 			{
 				if (len_mod == LEN_L)
 				{
-                    unsigned long num = va_arg(args, unsigned long);
+                    uintmax_t num = va_arg(args, unsigned long);
                     ft_putunsigned_fd(num, fd, &count);
                 }
 				else if (len_mod == LEN_Z)
 				{
                     size_t num = va_arg(args, size_t);
-                    ft_putunsigned_fd(static_cast<unsigned long>(num), fd, &count);
+                    ft_putunsigned_fd(num, fd, &count);
                 }
 				else
 				{
@@ -79,13 +79,13 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
                 bool uppercase = (spec == 'X');
 				if (len_mod == LEN_L)
 				{
-                    unsigned long num = va_arg(args, unsigned long);
+                    uintmax_t num = va_arg(args, unsigned long);
                     ft_puthex_fd(num, fd, uppercase, &count);
 				}
 				else if (len_mod == LEN_Z)
 				{
                     size_t num = va_arg(args, size_t);
-                                        ft_puthex_fd(static_cast<unsigned long>(num), fd, uppercase, &count);
+                                        ft_puthex_fd(num, fd, uppercase, &count);
 				}
 				else
 				{

--- a/Printf/print_args.cpp
+++ b/Printf/print_args.cpp
@@ -62,7 +62,7 @@ void ft_putnbr_fd(long n, int fd, size_t *count)
     return ;
 }
 
-void ft_putunsigned_fd_recursive(unsigned long n, int fd, size_t *count)
+void ft_putunsigned_fd_recursive(uintmax_t n, int fd, size_t *count)
 {
     char c;
     if (n >= 10)
@@ -72,13 +72,13 @@ void ft_putunsigned_fd_recursive(unsigned long n, int fd, size_t *count)
     return;
 }
 
-void ft_putunsigned_fd(unsigned long n, int fd, size_t *count)
+void ft_putunsigned_fd(uintmax_t n, int fd, size_t *count)
 {
     ft_putunsigned_fd_recursive(n, fd, count);
     return ;
 }
 
-void ft_puthex_fd_recursive(unsigned long n, int fd, bool uppercase, size_t *count)
+void ft_puthex_fd_recursive(uintmax_t n, int fd, bool uppercase, size_t *count)
 {
     char c;
 
@@ -97,7 +97,7 @@ void ft_puthex_fd_recursive(unsigned long n, int fd, bool uppercase, size_t *cou
     return ;
 }
 
-void ft_puthex_fd(unsigned long n, int fd, bool uppercase, size_t *count)
+void ft_puthex_fd(uintmax_t n, int fd, bool uppercase, size_t *count)
 {
     ft_puthex_fd_recursive(n, fd, uppercase, count);
     return ;

--- a/Printf/printf_internal.hpp
+++ b/Printf/printf_internal.hpp
@@ -21,10 +21,10 @@ void ft_putchar_fd(const char c, int fd, size_t *count);
 void ft_putstr_fd(const char *s, int fd, size_t *count);
 void ft_putnbr_fd_recursive(long n, int fd, size_t *count);
 void ft_putnbr_fd(long n, int fd, size_t *count);
-void ft_putunsigned_fd_recursive(unsigned long n, int fd, size_t *count);
-void ft_putunsigned_fd(unsigned long n, int fd, size_t *count);
-void ft_puthex_fd_recursive(unsigned long n, int fd, bool uppercase, size_t *count);
-void ft_puthex_fd(unsigned long n, int fd, bool uppercase, size_t *count);
+void ft_putunsigned_fd_recursive(uintmax_t n, int fd, size_t *count);
+void ft_putunsigned_fd(uintmax_t n, int fd, size_t *count);
+void ft_puthex_fd_recursive(uintmax_t n, int fd, bool uppercase, size_t *count);
+void ft_puthex_fd(uintmax_t n, int fd, bool uppercase, size_t *count);
 void ft_putptr_fd(void *ptr, int fd, size_t *count);
 int pf_printf_fd_v(int fd, const char *format, va_list args);
 


### PR DESCRIPTION
## Summary
- use `uintmax_t` for unsigned formatting functions
- update call sites to avoid conversions

## Testing
- `make -C Printf`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686117a269a08331b7b3488825ce97e2