### PR TITLE
Fix Windows socket casting warnings

### DIFF
--- a/Networking/socket_wrapper_functions.cpp
+++ b/Networking/socket_wrapper_functions.cpp
@@ -15,7 +15,7 @@
 int nw_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
 #ifdef _WIN32
-    if (bind((SOCKET)sockfd, addr, addrlen) == SOCKET_ERROR)
+    if (bind(static_cast<SOCKET>(sockfd), addr, addrlen) == SOCKET_ERROR)
         return (-1);
 #else
     if (bind(sockfd, addr, addrlen) == -1)
@@ -27,7 +27,7 @@ int nw_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 int nw_listen(int sockfd, int backlog)
 {
 #ifdef _WIN32
-    if (listen((SOCKET)sockfd, backlog) == SOCKET_ERROR)
+    if (listen(static_cast<SOCKET>(sockfd), backlog) == SOCKET_ERROR)
         return (-1);
 #else
     if (listen(sockfd, backlog) == -1)
@@ -39,10 +39,10 @@ int nw_listen(int sockfd, int backlog)
 int nw_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
 #ifdef _WIN32
-    SOCKET new_fd = accept((SOCKET)sockfd, addr, addrlen);
+    SOCKET new_fd = accept(static_cast<SOCKET>(sockfd), addr, addrlen);
     if (new_fd == INVALID_SOCKET)
         return (-1);
-    return (int)new_fd;
+    return static_cast<int>(new_fd);
 #else
     int new_fd = accept(sockfd, addr, addrlen);
     if (new_fd == -1)
@@ -65,7 +65,7 @@ int nw_socket(int domain, int type, int protocol)
     SOCKET sockfd = socket(domain, type, protocol);
     if (sockfd == INVALID_SOCKET)
         return (-1);
-    return (int)sockfd;
+    return static_cast<int>(sockfd);
 #else
     int sockfd = socket(domain, type, protocol);
     if (sockfd == -1)
@@ -77,7 +77,7 @@ int nw_socket(int domain, int type, int protocol)
 int nw_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
 #ifdef _WIN32
-    if (connect((SOCKET)sockfd, addr, addrlen) == SOCKET_ERROR)
+    if (connect(static_cast<SOCKET>(sockfd), addr, addrlen) == SOCKET_ERROR)
         return (-1);
 #else
     if (connect(sockfd, addr, addrlen) == -1)
@@ -89,7 +89,7 @@ int nw_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 ssize_t nw_send(int sockfd, const void *buf, size_t len, int flags)
 {
 #ifdef _WIN32
-    int ret = ::send((SOCKET)sockfd,
+    int ret = ::send(static_cast<SOCKET>(sockfd),
                      static_cast<const char*>(buf),
                      static_cast<int>(len), flags);
     if (ret == SOCKET_ERROR)
@@ -104,7 +104,7 @@ ssize_t nw_send(int sockfd, const void *buf, size_t len, int flags)
 ssize_t nw_recv(int sockfd, void *buf, size_t len, int flags)
 {
 #ifdef _WIN32
-    int ret = ::recv((SOCKET)sockfd,
+    int ret = ::recv(static_cast<SOCKET>(sockfd),
                      static_cast<char*>(buf),
                      static_cast<int>(len), flags);
     if (ret == SOCKET_ERROR)


### PR DESCRIPTION
## Summary
- clean up C-style casts in `socket_wrapper_functions.cpp`
- use `static_cast` for Windows `SOCKET` conversions

## Testing
- `make -C Networking`

------
https://chatgpt.com/codex/tasks/task_e_686148ff6434833183c999f270f9ce5e