### PR TITLE
Ensure void functions return explicitly

### DIFF
--- a/CMA/cma_utils.cpp
+++ b/CMA/cma_utils.cpp
@@ -177,12 +177,12 @@ static inline void print_block_info_impl(Block *block)
 {
 #ifdef _WIN32
     (void)block;
-    return;
+    return ;
 #else
     if (!block)
     {
         pf_printf_fd(2, "Block pointer is NULL.\n");
-        return;
+        return ;
     }
     const char* free_status = block->free ? "Yes" : "No";
     pf_printf_fd(3, "---- Block Information ----\n");
@@ -194,9 +194,11 @@ static inline void print_block_info_impl(Block *block)
     pf_printf_fd(2, "Previous Block: %p\n", static_cast<void*>(block->prev));
     pf_printf_fd(2, "---------------------------\n");
 #endif
+    return ;
 }
 
 void print_block_info(Block *block)
 {
     print_block_info_impl(block);
+    return ;
 }

--- a/HTML/html_cleanup.cpp
+++ b/HTML/html_cleanup.cpp
@@ -24,4 +24,5 @@ void html_free_nodes(html_node *nodeList)
         delete nodeList;
         nodeList = nextNode;
     }
+    return ;
 }

--- a/HTML/html_node.cpp
+++ b/HTML/html_node.cpp
@@ -76,6 +76,7 @@ void html_add_attr(html_node *targetNode, html_attr *newAttribute)
             currentAttribute = currentAttribute->next;
         currentAttribute->next = newAttribute;
     }
+    return ;
 }
 
 void html_add_child(html_node *parentNode, html_node *childNode)
@@ -89,6 +90,7 @@ void html_add_child(html_node *parentNode, html_node *childNode)
             lastChild = lastChild->next;
         lastChild->next = childNode;
     }
+    return ;
 }
 
 void html_append_node(html_node **headNode, html_node *newNode)
@@ -102,4 +104,5 @@ void html_append_node(html_node **headNode, html_node *newNode)
             lastNode = lastNode->next;
         lastNode->next = newNode;
     }
+    return ;
 }

--- a/Libft/ft_bzero.cpp
+++ b/Libft/ft_bzero.cpp
@@ -3,4 +3,5 @@
 void    ft_bzero(void *pointer, size_t size)
 {
     ft_memset(pointer, 0, size);
+    return ;
 }

--- a/Printf/print_args.cpp
+++ b/Printf/print_args.cpp
@@ -42,7 +42,7 @@ void ft_putstr_fd(const char *s, int fd, size_t *count)
     {
         return_value = ft_write(fd, "(null)", 6);
         *count += 6;
-        return;
+        return ;
     }
     size_t len = ft_strlen_printf(s);
     return_value = ft_platform_write(fd, s, len);
@@ -63,7 +63,7 @@ void ft_putnbr_fd_recursive(long n, int fd, size_t *count)
         ft_putnbr_fd_recursive(n / 10, fd, count);
     c = static_cast<char>('0' + (n % 10));
     ft_putchar_fd(c, fd, count);
-    return;
+    return ;
 }
 
 void ft_putnbr_fd(long n, int fd, size_t *count)
@@ -79,7 +79,7 @@ void ft_putunsigned_fd_recursive(uintmax_t n, int fd, size_t *count)
         ft_putunsigned_fd_recursive(n / 10, fd, count);
     c = static_cast<char>('0' + (n % 10));
     ft_putchar_fd(c, fd, count);
-    return;
+    return ;
 }
 
 void ft_putunsigned_fd(uintmax_t n, int fd, size_t *count)

--- a/ReadLine/raw_mode.cpp
+++ b/ReadLine/raw_mode.cpp
@@ -25,11 +25,13 @@ static inline void disable_raw_mode_platform()
 #else
     tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
 #endif
+    return ;
 }
 
 void rl_disable_raw_mode()
 {
     disable_raw_mode_platform();
+    return ;
 }
 
 static inline int enable_raw_mode_platform()

--- a/Template/shared_ptr.hpp
+++ b/Template/shared_ptr.hpp
@@ -106,7 +106,7 @@ ft_sharedptr<ManagedType>::ft_sharedptr(Args&&... args)
     if (!_referenceCount)
     {
         this->set_error(SHARED_PTR_ALLOCATION_FAILED);
-        return;
+        return ;
     }
     *_referenceCount = 1;
     _managedPointer = new (std::nothrow) ManagedType(std::forward<Args>(args)...);
@@ -115,7 +115,7 @@ ft_sharedptr<ManagedType>::ft_sharedptr(Args&&... args)
         this->set_error(SHARED_PTR_ALLOCATION_FAILED);
         delete _referenceCount;
         _referenceCount = ft_nullptr;
-        return;
+        return ;
     }
 }
 
@@ -221,6 +221,7 @@ void ft_sharedptr<ManagedType>::release()
     }
     _managedPointer = ft_nullptr;
     _referenceCount = ft_nullptr;
+    return ;
 }
 
 template <typename ManagedType>
@@ -469,6 +470,7 @@ void ft_sharedptr<ManagedType>::set_error(int error) const
 {
     ft_errno = error;
     _errorCode = error;
+    return ;
 }
 
 template <typename ManagedType>
@@ -502,6 +504,7 @@ void ft_sharedptr<ManagedType>::reset(ManagedType* pointer, size_t size, bool ar
         }
         _managedPointer = ft_nullptr;
     }
+    return ;
 }
 
 template <typename ManagedType>
@@ -512,6 +515,7 @@ void ft_sharedptr<ManagedType>::swap(ft_sharedptr<ManagedType>& other)
     std::swap(_arraySize, other._arraySize);
     std::swap(_isArrayType, other._isArrayType);
     std::swap(_errorCode, other._errorCode);
+    return ;
 }
 
 template <typename ManagedType>
@@ -520,14 +524,14 @@ void ft_sharedptr<ManagedType>::add(const ManagedType& element)
     if (!_isArrayType)
     {
         this->set_error(SHARED_PTR_INVALID_OPERATION);
-        return;
+        return ;
     }
     size_t newSize = _arraySize + 1;
     ManagedType* newArray = new (std::nothrow) ManagedType[newSize];
     if (!newArray)
     {
         this->set_error(SHARED_PTR_ALLOCATION_FAILED);
-        return;
+        return ;
     }
     for (size_t i = 0; i < _arraySize; ++i)
         newArray[i] = _managedPointer[i];
@@ -535,6 +539,7 @@ void ft_sharedptr<ManagedType>::add(const ManagedType& element)
     delete[] _managedPointer;
     _managedPointer = newArray;
     _arraySize = newSize;
+    return ;
 }
 
 template <typename ManagedType>
@@ -543,19 +548,19 @@ void ft_sharedptr<ManagedType>::remove(int index)
     if (!_isArrayType)
     {
         this->set_error(SHARED_PTR_INVALID_OPERATION);
-        return;
+        return ;
     }
     if (!_managedPointer || static_cast<size_t>(index) >= _arraySize || index < 0)
     {
         this->set_error(SHARED_PTR_OUT_OF_BOUNDS);
-        return;
+        return ;
     }
     size_t newSize = _arraySize - 1;
     ManagedType* newArray = (newSize > 0) ? new (std::nothrow) ManagedType[newSize] : nullptr;
     if (newSize > 0 && !newArray)
     {
         this->set_error(SHARED_PTR_ALLOCATION_FAILED);
-        return;
+        return ;
     }
     for (size_t i = 0; i < static_cast<size_t>(index); ++i)
         newArray[i] = _managedPointer[i];
@@ -564,6 +569,7 @@ void ft_sharedptr<ManagedType>::remove(int index)
     delete[] _managedPointer;
     _managedPointer = newArray;
     _arraySize = newSize;
+    return ;
 }
 
 #endif

--- a/Template/unordened_map.hpp
+++ b/Template/unordened_map.hpp
@@ -210,7 +210,7 @@ ft_unord_map<Key, MappedType>::ft_unord_map(size_t initialCapacity)
         setError(UNORD_MAP_MEMORY);
         _data = ft_nullptr;
         _occupied = ft_nullptr;
-        return;
+        return ;
     }
     _data = static_cast<ft_pair<Key, MappedType>*>(rawData);
     void* rawOccupied = cma_malloc(sizeof(bool) * _capacity);
@@ -220,7 +220,7 @@ ft_unord_map<Key, MappedType>::ft_unord_map(size_t initialCapacity)
         cma_free(_data);
         _data = ft_nullptr;
         _occupied = ft_nullptr;
-        return;
+        return ;
     }
     _occupied = static_cast<bool*>(rawOccupied);
     size_t i = 0;
@@ -245,7 +245,7 @@ ft_unord_map<Key, MappedType>::ft_unord_map(const ft_unord_map<Key, MappedType>&
             _occupied = ft_nullptr;
             _size = 0;
             _capacity = 0;
-            return;
+            return ;
         }
         _data = static_cast<ft_pair<Key, MappedType>*>(rawData);
         void* rawOccupied = cma_malloc(sizeof(bool) * _capacity);
@@ -257,7 +257,7 @@ ft_unord_map<Key, MappedType>::ft_unord_map(const ft_unord_map<Key, MappedType>&
             _occupied = ft_nullptr;
             _size = 0;
             _capacity = 0;
-            return;
+            return ;
         }
         _occupied = static_cast<bool*>(rawOccupied);
         size_t i = 0;
@@ -472,7 +472,7 @@ void ft_unord_map<Key, MappedType>::resize(size_t newCapacity)
     if (!rawData)
     {
         setError(UNORD_MAP_MEMORY);
-        return;
+        return ;
     }
     ft_pair<Key, MappedType>* newData = static_cast<ft_pair<Key, MappedType>*>(rawData);
     void* rawOccupied = cma_malloc(sizeof(bool) * newCapacity);
@@ -480,7 +480,7 @@ void ft_unord_map<Key, MappedType>::resize(size_t newCapacity)
     {
         setError(UNORD_MAP_MEMORY);
         cma_free(newData);
-        return;
+        return ;
     }
     bool* newOcc = static_cast<bool*>(rawOccupied);
     size_t i = 0;
@@ -511,6 +511,7 @@ void ft_unord_map<Key, MappedType>::resize(size_t newCapacity)
     }
     cma_free(oldData);
     cma_free(oldOcc);
+    return ;
 }
 
 template <typename Key, typename MappedType>
@@ -521,13 +522,13 @@ void ft_unord_map<Key, MappedType>::insert(const Key& key, const MappedType& val
     if (idx != _capacity)
     {
         _data[idx].second = value;
-        return;
+        return ;
     }
     if ((_size * 2) >= _capacity)
     {
         resize(_capacity * 2);
         if (_error != ER_SUCCESS)
-            return;
+            return ;
     }
     size_t start = hashKey(key);
     size_t i = start;
@@ -538,12 +539,13 @@ void ft_unord_map<Key, MappedType>::insert(const Key& key, const MappedType& val
             construct_at(&_data[i], ft_pair<Key, MappedType>(key, value));
             _occupied[i] = true;
             ++_size;
-            return;
+            return ;
         }
         i = (i + 1) % _capacity;
         if (i == start)
-            return;
+            return ;
     }
+    return ;
 }
 
 template <typename Key, typename MappedType>
@@ -569,7 +571,7 @@ void ft_unord_map<Key, MappedType>::remove(const Key& key)
 {
     size_t idx = findIndex(key);
     if (idx == _capacity)
-        return;
+        return ;
     destroy_at(&_data[idx]);
     _occupied[idx] = false;
     --_size;
@@ -587,6 +589,7 @@ void ft_unord_map<Key, MappedType>::remove(const Key& key)
         }
         next = (next + 1) % _capacity;
     }
+    return ;
 }
 
 template <typename Key, typename MappedType>
@@ -611,6 +614,7 @@ void ft_unord_map<Key, MappedType>::clear()
         i++;
     }
     _size = 0;
+    return ;
 }
 
 template <typename Key, typename MappedType>

--- a/file/file_check_directory.cpp
+++ b/file/file_check_directory.cpp
@@ -16,7 +16,7 @@ static inline void normalize_slashes(char *data)
 {
 #if defined(_WIN32) || defined(_WIN64)
     if (!data)
-        return;
+        return ;
     for (size_t i = 0; data[i] != '\0'; ++i)
     {
         if (data[i] == '/')
@@ -25,6 +25,7 @@ static inline void normalize_slashes(char *data)
 #else
     (void)data;
 #endif
+    return ;
 }
 
 static inline int dir_exists_platform(const char *path)


### PR DESCRIPTION
## Summary
- add `return ;` to normalize_slashes
- enforce final returns in raw_mode helpers
- add missing returns in CMA utilities
- return in HTML cleanup helpers
- append returns to html node helpers
- finalize return statements in unordered map operations
- ensure shared_ptr methods return
- add return in ft_bzero
- normalize return style throughout Printf

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68619546ede48331beda361cea7f5681