### PR TITLE
Add search utilities for JSON structures

### DIFF
--- a/JSon/Makefile
+++ b/JSon/Makefile
@@ -3,7 +3,8 @@ DEBUG_TARGET := JSon_debug.a
 
 SRCS := 		json_parsing.cpp \
                 json_create_item.cpp \
-                json_reader.cpp
+                json_reader.cpp \
+                json_utils.cpp
 
 HEADERS := json.hpp
 

--- a/JSon/json.hpp
+++ b/JSon/json.hpp
@@ -25,5 +25,7 @@ int 		json_write_to_file(const char *filename, json_group *groups);
 json_group  *json_read_from_file(const char *filename);
 void 		json_free_items(json_item *item);
 void 		json_free_groups(json_group *group);
+json_group      *json_find_group(json_group *head, const char *name);
+json_item       *json_find_item(json_group *group, const char *key);
 
 #endif

--- a/JSon/json_utils.cpp
+++ b/JSon/json_utils.cpp
@@ -1,0 +1,29 @@
+#include <cstring>
+#include "json.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+json_group *json_find_group(json_group *head, const char *name)
+{
+    json_group *current = head;
+    while (current)
+    {
+        if (current->name && std::strcmp(current->name, name) == 0)
+            return current;
+        current = current->next;
+    }
+    return ft_nullptr;
+}
+
+json_item *json_find_item(json_group *group, const char *key)
+{
+    if (!group)
+        return ft_nullptr;
+    json_item *current = group->items;
+    while (current)
+    {
+        if (current->key && std::strcmp(current->key, key) == 0)
+            return current;
+        current = current->next;
+    }
+    return ft_nullptr;
+}


### PR DESCRIPTION
## Summary
- add functions to locate groups and items by name
- include the new source file in the JSON Makefile
- expose the search functions via `json.hpp`

## Testing
- `make -C JSon`

------
https://chatgpt.com/codex/tasks/task_e_6862df270e1483318eacbeab80ab7549