### PR TITLE
Add client count and disconnect-all methods

### DIFF
--- a/Networking/socket_class.cpp
+++ b/Networking/socket_class.cpp
@@ -145,6 +145,23 @@ bool ft_socket::disconnect_client(int fd)
     return (false);
 }
 
+void ft_socket::disconnect_all_clients()
+{
+    size_t index = 0;
+    while (index < this->_connected.size())
+    {
+        this->_connected[index].close_socket();
+        index++;
+    }
+    this->_connected.clear();
+    return ;
+}
+
+size_t ft_socket::get_client_count() const
+{
+    return (this->_connected.size());
+}
+
 ft_socket::ft_socket(int fd, const sockaddr_storage &addr) : _address(addr), _socket_fd(fd),
 						_error(ER_SUCCESS)
 {

--- a/Networking/socket_class.hpp
+++ b/Networking/socket_class.hpp
@@ -66,6 +66,8 @@ class ft_socket
 		ssize_t 	broadcast_data(const void *data, size_t size, int flags, int exception);
 		ssize_t 	send_data(const void *data, size_t size, int flags, int fd);
         bool        disconnect_client(int fd);
+        void        disconnect_all_clients();
+        size_t      get_client_count() const;
 		int			get_fd() const;
 };
 


### PR DESCRIPTION
## Summary
- extend socket class with helper methods
- add `disconnect_all_clients` to close every connected client
- add `get_client_count` to report how many connections are active

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6862eb5405808331a771f3b28c954c75