### PR TITLE
Add client connection query to networking

### DIFF
--- a/Networking/socket_class.cpp
+++ b/Networking/socket_class.cpp
@@ -162,6 +162,19 @@ size_t ft_socket::get_client_count() const
     return (this->_connected.size());
 }
 
+bool ft_socket::is_client_connected(int fd) const
+{
+    size_t index = 0;
+
+    while (index < this->_connected.size())
+    {
+        if (this->_connected[index].get_fd() == fd)
+            return (true);
+        index++;
+    }
+    return (false);
+}
+
 ft_socket::ft_socket(int fd, const sockaddr_storage &addr) : _address(addr), _socket_fd(fd),
 						_error(ER_SUCCESS)
 {
@@ -245,6 +258,11 @@ bool ft_socket::close_socket()
     }
     this->_error = ER_SUCCESS;
     return (true);
+}
+
+int ft_socket::get_error() const
+{
+    return (this->_error);
 }
 
 const char* ft_socket::get_error_message() const

--- a/Networking/socket_class.hpp
+++ b/Networking/socket_class.hpp
@@ -68,6 +68,7 @@ class ft_socket
         bool        disconnect_client(int fd);
         void        disconnect_all_clients();
         size_t      get_client_count() const;
+        bool        is_client_connected(int fd) const;
 		int			get_fd() const;
 };
 


### PR DESCRIPTION
## Summary
- expose method to check if a client is connected
- implement missing `get_error` accessor

## Testing
- `make -C Networking`
- `make -C Networking clean`

------
https://chatgpt.com/codex/tasks/task_e_6862ee5ec190833183ccc28c258f375d