### PR TITLE
Add item update feature to JSON library

### DIFF
--- a/JSon/json.hpp
+++ b/JSon/json.hpp
@@ -28,5 +28,8 @@ void 		json_free_groups(json_group *group);
 json_group  *json_find_group(json_group *head, const char *name);
 json_item   *json_find_item(json_group *group, const char *key);
 void            json_remove_item(json_group *group, const char *key);
+void            json_update_item(json_group *group, const char *key, const char *value);
+void            json_update_item(json_group *group, const char *key, const int value);
+void            json_update_item(json_group *group, const char *key, const bool value);
 
 #endif

--- a/JSon/json_reader.cpp
+++ b/JSon/json_reader.cpp
@@ -9,6 +9,7 @@ static void skip_ws(const std::string &s, size_t &i)
 {
     while (i < s.size() && std::isspace(static_cast<unsigned char>(s[i])))
         i++;
+    return ;
 }
 
 static std::string parse_string(const std::string &s, size_t &i)

--- a/JSon/json_utils.cpp
+++ b/JSon/json_utils.cpp
@@ -2,6 +2,8 @@
 #include "json.hpp"
 #include "../CPP_class/nullptr.hpp"
 #include "../Libft/libft.hpp"
+#include "../CMA/CMA.hpp"
+#include "../Errno/errno.hpp"
 
 json_group *json_find_group(json_group *head, const char *name)
 {
@@ -52,6 +54,63 @@ void json_remove_item(json_group *group, const char *key)
         }
         previous = current;
         current = current->next;
+    }
+    return ;
+}
+
+void json_update_item(json_group *group, const char *key, const char *value)
+{
+    if (!group)
+        return ;
+    json_item *item = json_find_item(group, key);
+    if (!item)
+        return ;
+    if (item->value)
+        delete[] item->value;
+    item->value = cma_strdup(value);
+    if (!item->value)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
+        return ;
+    }
+    return ;
+}
+
+void json_update_item(json_group *group, const char *key, const int value)
+{
+    if (!group)
+        return ;
+    json_item *item = json_find_item(group, key);
+    if (!item)
+        return ;
+    if (item->value)
+        delete[] item->value;
+    item->value = cma_itoa(value);
+    if (!item->value)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
+        return ;
+    }
+    return ;
+}
+
+void json_update_item(json_group *group, const char *key, const bool value)
+{
+    if (!group)
+        return ;
+    json_item *item = json_find_item(group, key);
+    if (!item)
+        return ;
+    if (item->value)
+        delete[] item->value;
+    if (value == true)
+        item->value = cma_strdup("true");
+    else
+        item->value = cma_strdup("false");
+    if (!item->value)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
+        return ;
     }
     return ;
 }


### PR DESCRIPTION
## Summary
- support updating JSON items by key
- ensure void helper skip_ws returns
- expose update API in header

## Testing
- `make -C JSon`
- `make`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_6862f4c400a4833185b3525da21a2aa1