### PR TITLE
Add group removal to JSON utilities

### DIFF
--- a/JSon/json.hpp
+++ b/JSon/json.hpp
@@ -27,6 +27,7 @@ void 		json_free_items(json_item *item);
 void 		json_free_groups(json_group *group);
 json_group  *json_find_group(json_group *head, const char *name);
 json_item   *json_find_item(json_group *group, const char *key);
+void        json_remove_group(json_group **head, const char *name);
 void        json_remove_item(json_group *group, const char *key);
 void        json_update_item(json_group *group, const char *key, const char *value);
 void        json_update_item(json_group *group, const char *key, const int value);

--- a/JSon/json_utils.cpp
+++ b/JSon/json_utils.cpp
@@ -114,3 +114,29 @@ void json_update_item(json_group *group, const char *key, const bool value)
     }
     return ;
 }
+
+void json_remove_group(json_group **head, const char *name)
+{
+    if (!head || !(*head))
+        return ;
+    json_group *current = *head;
+    json_group *previous = ft_nullptr;
+    while (current)
+    {
+        if (current->name && ft_strcmp(current->name, name) == 0)
+        {
+            if (previous)
+                previous->next = current->next;
+            else
+                *head = current->next;
+            if (current->name)
+                delete[] current->name;
+            json_free_items(current->items);
+            delete current;
+            return ;
+        }
+        previous = current;
+        current = current->next;
+    }
+    return ;
+}


### PR DESCRIPTION
## Summary
- extend JSON utilities with `json_remove_group`
- declare new function in header

## Testing
- `make -C JSon`

------
https://chatgpt.com/codex/tasks/task_e_6862f6700cd48331989e26d8f995e857