### PR TITLE
Unify directory creation API across platforms

### DIFF
--- a/file/Makefile
+++ b/file/Makefile
@@ -2,7 +2,8 @@ TARGET         := file.a
 DEBUG_TARGET   := file_debug.a
 
 SRCS := file_opendir.cpp \
-		file_check_directory.cpp
+                file_check_directory.cpp \
+                file_mkdir.cpp
 
 HEADERS := open_dir.hpp
 

--- a/file/file_mkdir.cpp
+++ b/file/file_mkdir.cpp
@@ -1,0 +1,26 @@
+#include "open_dir.hpp"
+
+#ifdef _WIN32
+# include <windows.h>
+# include <sys/stat.h>
+# include <sys/types.h>
+
+int file_create_directory(const char* path, mode_t mode)
+{
+    (void)mode;
+    if (CreateDirectoryA(path, NULL))
+        return (0);
+    return (-1);
+}
+
+#else
+# include <sys/stat.h>
+# include <sys/types.h>
+
+int file_create_directory(const char* path, mode_t mode)
+{
+    if (mkdir(path, mode) == 0)
+        return (0);
+    return (-1);
+}
+#endif

--- a/file/open_dir.hpp
+++ b/file/open_dir.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -54,6 +55,7 @@ FT_DIR* 	ft_opendir(const char* directoryPath);
 int 		ft_closedir(FT_DIR* directoryStream);
 ft_dirent	*ft_readdir(FT_DIR* directoryStream);
 
-int 		dir_exists(const char *rel_path);
+int             dir_exists(const char *rel_path);
+int             file_create_directory(const char* path, mode_t mode);
 
 #endif


### PR DESCRIPTION
## Summary
- use same prototype for `file_create_directory` on all systems
- ignore the mode argument on Windows

## Testing
- `make -C file file.a`


------
https://chatgpt.com/codex/tasks/task_e_68640c142b188331804ddaebf9e759ce