### PR TITLE
Add json_read_from_string function

### DIFF
--- a/JSon/json.hpp
+++ b/JSon/json.hpp
@@ -24,6 +24,7 @@ void 		json_append_group(json_group **head, json_group *new_group);
 int 		json_write_to_file(const char *filename, json_group *groups);
 char        *json_write_to_string(json_group *groups);
 json_group  *json_read_from_file(const char *filename);
+json_group  *json_read_from_string(const char *content);
 void 		json_free_items(json_item *item);
 void 		json_free_groups(json_group *group);
 json_group  *json_find_group(json_group *head, const char *name);

--- a/JSon/json_reader.cpp
+++ b/JSon/json_reader.cpp
@@ -241,3 +241,69 @@ json_group *json_read_from_file(const char *filename)
     return (head);
 }
 
+json_group *json_read_from_string(const char *content)
+{
+    if (!content)
+        return (ft_nullptr);
+    size_t i = 0;
+    skip_ws(content, i);
+    size_t len = ft_strlen_size_t(content);
+    if (i >= len || content[i] != '{')
+        return (ft_nullptr);
+    i++;
+    json_group *head = ft_nullptr;
+    json_group *tail = ft_nullptr;
+    while (i < len)
+    {
+        skip_ws(content, i);
+        if (i < len && content[i] == '}')
+        {
+            i++;
+            break;
+        }
+        char *group_name = parse_string(content, i);
+        if (!group_name)
+        {
+            json_free_groups(head);
+            return (ft_nullptr);
+        }
+        skip_ws(content, i);
+        if (i >= len || content[i] != ':')
+        {
+            cma_free(group_name);
+            break;
+        }
+        i++;
+        json_item *items = parse_items(content, i);
+        if (!items)
+        {
+            cma_free(group_name);
+            json_free_groups(head);
+            return (ft_nullptr);
+        }
+        json_group *group = json_create_json_group(group_name);
+        cma_free(group_name);
+        if (!group)
+        {
+            json_free_items(items);
+            json_free_groups(head);
+            return (ft_nullptr);
+        }
+        group->items = items;
+        if (!head)
+            head = tail = group;
+        else
+        {
+            tail->next = group;
+            tail = group;
+        }
+        skip_ws(content, i);
+        if (i < len && content[i] == ',')
+        {
+            i++;
+            continue;
+        }
+    }
+    return (head);
+}
+


### PR DESCRIPTION
## Summary
- add `json_read_from_string` API to parse JSON data directly from a string
- expose new function in `json.hpp`

## Testing
- `make -C JSon`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6864edc6f4e88331bfca71dec94afc11