### PR TITLE
Add HTML attribute search

### DIFF
--- a/HTML/html_parser.hpp
+++ b/HTML/html_parser.hpp
@@ -27,5 +27,6 @@ void        html_add_attr(html_node *targetNode, html_attr *newAttribute);
 int         html_write_to_file(const char *filePath, html_node *nodeList);
 void        html_free_nodes(html_node *nodeList);
 html_node   *html_find_by_tag(html_node *nodeList, const char *tagName);
+html_node   *html_find_by_attr(html_node *nodeList, const char *key, const char *value);
 
 #endif

--- a/HTML/html_search.cpp
+++ b/HTML/html_search.cpp
@@ -1,15 +1,38 @@
-#include <cstring>
 #include "html_parser.hpp"
 #include "../CPP_class/nullptr.hpp"
+#include "../Libft/libft.hpp"
 
 html_node *html_find_by_tag(html_node *nodeList, const char *tagName)
 {
     html_node *currentNode = nodeList;
     while (currentNode)
     {
-        if (currentNode->tag && std::strcmp(currentNode->tag, tagName) == 0)
+        if (currentNode->tag && ft_strcmp(currentNode->tag, tagName) == 0)
             return (currentNode);
         html_node *found = html_find_by_tag(currentNode->children, tagName);
+        if (found)
+            return (found);
+        currentNode = currentNode->next;
+    }
+    return (ft_nullptr);
+}
+
+html_node *html_find_by_attr(html_node *nodeList, const char *key, const char *value)
+{
+    html_node *currentNode = nodeList;
+    while (currentNode)
+    {
+        html_attr *attribute = currentNode->attributes;
+        while (attribute)
+        {
+            if (attribute->key && ft_strcmp(attribute->key, key) == 0)
+            {
+                if (!value || (attribute->value && ft_strcmp(attribute->value, value) == 0))
+                    return (currentNode);
+            }
+            attribute = attribute->next;
+        }
+        html_node *found = html_find_by_attr(currentNode->children, key, value);
         if (found)
             return (found);
         currentNode = currentNode->next;


### PR DESCRIPTION
## Summary
- add new `html_find_by_attr` function for searching nodes by attribute
- use `ft_strcmp` instead of standard library compare in the HTML search implementation

## Testing
- `make` in `HTML`


------
https://chatgpt.com/codex/tasks/task_e_68658f313ae88331ab04903a936f8970