### PR TITLE
Standardize error method names

### DIFF
--- a/CPP_class/file.cpp
+++ b/CPP_class/file.cpp
@@ -124,12 +124,12 @@ int ft_file::get_fd() const
     return (this->_fd);
 }
 
-int ft_file::get_error_code() const noexcept
+int ft_file::get_error() const noexcept
 {
 	return (this->_error_code);
 }
 
-const char *ft_file::get_error_message() const noexcept
+const char *ft_file::get_error_str() const noexcept
 {
 	return (ft_strerror(_error_code));
 }

--- a/CPP_class/file.hpp
+++ b/CPP_class/file.hpp
@@ -31,8 +31,8 @@ class ft_file
     	ft_file& operator=(ft_file&& other) noexcept;
 
     	int			get_fd() const;
-	    int			get_error_code() const noexcept;
-    	const char	*get_error_message() const noexcept;
+	    int			get_error() const noexcept;
+    	const char	*get_error_str() const noexcept;
 
 	    int			open(const char* filename, int flags, mode_t mode) noexcept;
 		int			open(const char* filename, int flags) noexcept;

--- a/CPP_class/string_class.hpp
+++ b/CPP_class/string_class.hpp
@@ -44,8 +44,8 @@ class ft_string
         char*       print() noexcept;
         size_t      size() const noexcept;
         bool        empty() const noexcept;
-        int         getError() const noexcept;
-        const char	*errorStr() const noexcept;
+        int         get_error() const noexcept;
+        const char	*get_error_str() const noexcept;
         void        move(ft_string& other) noexcept;
         void        erase(std::size_t index, std::size_t count) noexcept;
 

--- a/CPP_class/string_methods.cpp
+++ b/CPP_class/string_methods.cpp
@@ -123,12 +123,12 @@ bool ft_string::empty() const noexcept
     return (this->_length == 0);
 }
 
-int ft_string::getError() const noexcept
+int ft_string::get_error() const noexcept
 {
     return (this->_errorCode);
 }
 
-const char* ft_string::errorStr() const noexcept
+const char* ft_string::get_error_str() const noexcept
 {
     return (ft_strerror(this->_errorCode));
 }

--- a/GetNextLine/read_file.cpp
+++ b/GetNextLine/read_file.cpp
@@ -77,7 +77,7 @@ char **ft_open_and_read_file(const char *file_name)
 {
     ft_file file(file_name, O_RDONLY);
 
-    if (file.get_error_code())
+    if (file.get_error())
         return (ft_nullptr);
     return (ft_read_file_lines(file));
 }

--- a/Networking/networking.cpp
+++ b/Networking/networking.cpp
@@ -23,12 +23,12 @@ SocketConfig::SocketConfig()
       multicast_group(""),
       multicast_interface("")
 {
-    if (!_error && ip.getError())
-        _error = ip.getError();
-    if (!_error && multicast_group.getError())
-        _error = multicast_group.getError();
-    if (!_error && multicast_interface.getError())
-        _error = multicast_interface.getError();
+    if (!_error && ip.get_error())
+        _error = ip.get_error();
+    if (!_error && multicast_group.get_error())
+        _error = multicast_group.get_error();
+    if (!_error && multicast_interface.get_error())
+        _error = multicast_interface.get_error();
     return ;
 }
 
@@ -47,12 +47,12 @@ SocketConfig::SocketConfig(const SocketConfig& other) noexcept
       multicast_group(other.multicast_group),
       multicast_interface(other.multicast_interface)
 {
-	if (!_error && ip.getError())
-        _error = ip.getError();
-	if (!_error && multicast_group.getError())
-        _error = multicast_group.getError();
-	if (!_error && multicast_interface.getError())
-        _error = multicast_interface.getError();
+	if (!_error && ip.get_error())
+        _error = ip.get_error();
+	if (!_error && multicast_group.get_error())
+        _error = multicast_group.get_error();
+	if (!_error && multicast_interface.get_error())
+        _error = multicast_interface.get_error();
 	return ;
 }
 
@@ -74,12 +74,12 @@ SocketConfig& SocketConfig::operator=(const SocketConfig& other) noexcept
         multicast_group = other.multicast_group;
         multicast_interface = other.multicast_interface;
     }
-    if (!_error && ip.getError())
-        _error = ip.getError();
-    if (!_error && multicast_group.getError())
-        _error = multicast_group.getError();
-    if (!_error && multicast_interface.getError())
-        _error = multicast_interface.getError();
+    if (!_error && ip.get_error())
+        _error = ip.get_error();
+    if (!_error && multicast_group.get_error())
+        _error = multicast_group.get_error();
+    if (!_error && multicast_interface.get_error())
+        _error = multicast_interface.get_error();
     return (*this);
 }
 
@@ -110,12 +110,12 @@ SocketConfig::SocketConfig(SocketConfig&& other) noexcept
     other.send_timeout = 0;
     other.multicast_group.clear();
     other.multicast_interface.clear();
-	if (!_error && ip.getError())
-        _error = ip.getError();
-	if (!_error && multicast_group.getError())
-        _error = multicast_group.getError();
-	if (!_error && multicast_interface.getError())
-        _error = multicast_interface.getError();
+	if (!_error && ip.get_error())
+        _error = ip.get_error();
+	if (!_error && multicast_group.get_error())
+        _error = multicast_group.get_error();
+	if (!_error && multicast_interface.get_error())
+        _error = multicast_interface.get_error();
 	return ;
 }
 
@@ -149,12 +149,12 @@ SocketConfig& SocketConfig::operator=(SocketConfig&& other) noexcept
         other.multicast_group.clear();
         other.multicast_interface.clear();
     }
-	if (!_error && ip.getError())
-        _error = ip.getError();
-    if (!_error && multicast_group.getError())
-        _error = multicast_group.getError();
-    if (!_error && multicast_interface.getError())
-        _error = multicast_interface.getError();
+	if (!_error && ip.get_error())
+        _error = ip.get_error();
+    if (!_error && multicast_group.get_error())
+        _error = multicast_group.get_error();
+    if (!_error && multicast_interface.get_error())
+        _error = multicast_interface.get_error();
     return (*this);
 }
 
@@ -163,12 +163,12 @@ SocketConfig::~SocketConfig()
 	return ;
 }
 
-int SocketConfig::getError()
+int SocketConfig::get_error()
 {
 	return (_error);
 }
 
-const char *SocketConfig::getStrError()
+const char *SocketConfig::get_error_str()
 {
 	return (ft_strerror(_error));
 }

--- a/Networking/networking.hpp
+++ b/Networking/networking.hpp
@@ -50,8 +50,8 @@ class SocketConfig
     	SocketConfig& operator=(const SocketConfig& other) noexcept;
     	SocketConfig& operator=(SocketConfig&& other) noexcept;
 
-		int getError();
-		const char *getStrError();
+		int get_error();
+		const char *get_error_str();
 };
 
 #endif

--- a/Networking/socket_class.cpp
+++ b/Networking/socket_class.cpp
@@ -120,7 +120,7 @@ int ft_socket::accept_connection()
     }
     ft_socket new_socket(new_fd, client_addr);
     this->_connected.push_back(std::move(new_socket));
-	if (this->_connected.getError())
+	if (this->_connected.get_error())
 	{
 		ft_errno = VECTOR_ALLOC_FAIL;
 		this->_error = ft_errno;
@@ -298,7 +298,7 @@ int ft_socket::get_error() const
     return (this->_error);
 }
 
-const char* ft_socket::get_error_message() const
+const char* ft_socket::get_error_str() const
 {
     return (ft_strerror(this->_error));
 }

--- a/Networking/socket_class.hpp
+++ b/Networking/socket_class.hpp
@@ -62,7 +62,7 @@ class ft_socket
     	ssize_t		receive_data(void *buffer, size_t size, int flags = 0);
     	bool		close_socket();
     	int 		get_error() const;
-    	const char	*get_error_message() const;
+    	const char	*get_error_str() const;
 		ssize_t 	broadcast_data(const void *data, size_t size, int flags);
 		ssize_t 	broadcast_data(const void *data, size_t size, int flags, int exception);
 		ssize_t 	send_data(const void *data, size_t size, int flags, int fd);

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ library:
 
 Error handling is built into these classes.  Each object stores its last
 failure code and exposes accessor methods so callers can inspect what went
-wrong.  For example `ft_file` provides `get_error_code()` and
-`get_error_message()` while `ft_string` offers `getError()` and `errorStr()`.
+wrong.  For example `ft_file` provides `get_error()` and
+`get_error_str()` while `ft_string` offers `get_error()` and `get_error_str()`.
 `DataBuffer` maintains an internal flag queried with `good()` or `bad()`.  When
 an operation fails these methods also update `ft_errno`, ensuring a consistent
 error reporting mechanism across the library.
@@ -231,8 +231,8 @@ helper classes:
   system calls.
 
 Both classes keep track of errors internally.  Methods like
-`SocketConfig::getError()` and `ft_socket::get_error()` return the last
-error code encountered while `get_error_message()` converts it to a
+`SocketConfig::get_error()` and `ft_socket::get_error()` return the last
+error code encountered while `get_error_str()` converts it to a
 human-readable string.  Whenever a system call fails these classes also set
 `ft_errno`, allowing calling code to react uniformly across platforms.
 
@@ -254,8 +254,8 @@ included without separate compilation steps.
 
 Every container stores an error flag that mirrors the global `ft_errno`.  When a
 memory allocation fails or an index is out of range the object records the
-appropriate code from `errno.hpp`.  Functions such as `ft_vector::getError()`,
-`ft_map::getError()` and the `hasError`/`errorMessage` helpers on the smart
+appropriate code from `errno.hpp`.  Functions such as `ft_vector::get_error()`,
+`ft_map::get_error()` and the `hasError`/`get_error_str()` helpers on the smart
 pointers allow applications to inspect these failures without resorting to
 exceptions.  A default value is returned when an operation cannot be completed,
 leaving the object in a valid but errored state.

--- a/Template/map.hpp
+++ b/Template/map.hpp
@@ -36,7 +36,7 @@ public:
     void        clear();
     size_t      getSize() const;
     size_t      getCapacity() const;
-    int         getError() const;
+    int         get_error() const;
 
     Pair<Key, MappedType>* end();
     MappedType &at(const Key& key);
@@ -287,7 +287,7 @@ size_t ft_map<Key, MappedType>::getCapacity() const
 }
 
 template <typename Key, typename MappedType>
-int ft_map<Key, MappedType>::getError() const
+int ft_map<Key, MappedType>::get_error() const
 {
     return (this->_error);
 }

--- a/Template/shared_ptr.hpp
+++ b/Template/shared_ptr.hpp
@@ -81,8 +81,8 @@ class ft_sharedptr
         int use_count() const;
         bool hasError() const;
         void set_error(int error) const;
-        int getErrorCode() const;
-        const char* errorMessage() const;
+        int get_error() const;
+        const char* get_error_str() const;
         ManagedType* get();
         const ManagedType* get() const;
         bool unique() const;
@@ -436,13 +436,13 @@ bool ft_sharedptr<ManagedType>::hasError() const
 }
 
 template <typename ManagedType>
-int ft_sharedptr<ManagedType>::getErrorCode() const
+int ft_sharedptr<ManagedType>::get_error() const
 {
     return (_errorCode);
 }
 
 template <typename ManagedType>
-const char* ft_sharedptr<ManagedType>::errorMessage() const
+const char* ft_sharedptr<ManagedType>::get_error_str() const
 {
     return (ft_strerror(_errorCode));
 }

--- a/Template/unique_ptr.hpp
+++ b/Template/unique_ptr.hpp
@@ -48,8 +48,8 @@ class ft_uniqueptr
         ManagedType* release_ptr();
         void reset(ManagedType* pointer = ft_nullptr, size_t size = 1, bool arrayType = false);
         bool hasError() const;
-        int getErrorCode() const;
-        const char* errorMessage() const;
+        int get_error() const;
+        const char* get_error_str() const;
         explicit operator bool() const noexcept;
         void swap(ft_uniqueptr& other);
         void set_error(int error) const;
@@ -361,13 +361,13 @@ bool ft_uniqueptr<ManagedType>::hasError() const
 }
 
 template <typename ManagedType>
-int ft_uniqueptr<ManagedType>::getErrorCode() const
+int ft_uniqueptr<ManagedType>::get_error() const
 {
     return (_errorCode);
 }
 
 template <typename ManagedType>
-const char* ft_uniqueptr<ManagedType>::errorMessage() const
+const char* ft_uniqueptr<ManagedType>::get_error_str() const
 {
     return (ft_strerror(_errorCode));
 }

--- a/Template/unordened_map.hpp
+++ b/Template/unordened_map.hpp
@@ -82,7 +82,7 @@ public:
     void           clear();
     size_t         getSize() const;
     size_t         getCapacity() const;
-    int            getError() const;
+    int            get_error() const;
     iterator       begin();
     iterator       end();
     const_iterator begin() const;
@@ -630,7 +630,7 @@ size_t ft_unord_map<Key, MappedType>::getCapacity() const
 }
 
 template <typename Key, typename MappedType>
-int ft_unord_map<Key, MappedType>::getError() const
+int ft_unord_map<Key, MappedType>::get_error() const
 {
     return (_error);
 }

--- a/Template/vector.hpp
+++ b/Template/vector.hpp
@@ -38,7 +38,7 @@ class ft_vector
 
     	size_t size() const;
     	size_t capacity() const;
-    	int getError() const;
+    	int get_error() const;
 
     	void push_back(const ElementType &value);
     	void push_back(ElementType &&value);
@@ -146,7 +146,7 @@ void ft_vector<ElementType>::setError(int errorCode)
 }
 
 template <typename ElementType>
-int ft_vector<ElementType>::getError() const
+int ft_vector<ElementType>::get_error() const
 {
     return (this->_errorCode);
 }

--- a/file/file_check_directory.cpp
+++ b/file/file_check_directory.cpp
@@ -56,7 +56,7 @@ static ft_string normalize_path(ft_string path)
 int dir_exists(const char *rel_path)
 {
     ft_string path = normalize_path(rel_path);
-    if (path.getError())
+    if (path.get_error())
     {
         ft_errno = CHECK_DIR_FAIL;
         return (-1);


### PR DESCRIPTION
## Summary
- rename error accessors across classes
- update README

## Testing
- `make -C Test`

------
https://chatgpt.com/codex/tasks/task_e_6866c0257410833198ab22224641d75c