### PR TITLE
Add error case tests for networking

### DIFF
--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -34,6 +34,8 @@ int test_html_find_by_tag(void);
 int test_html_write_to_string(void);
 int test_html_find_by_attr(void);
 int test_network_send_receive(void);
+int test_network_invalid_ip(void);
+int test_network_send_uninitialized(void);
 
 int main(void)
 {
@@ -53,7 +55,9 @@ int main(void)
         { test_html_find_by_tag, "html find by tag" },
         { test_html_write_to_string, "html write to string" },
         { test_html_find_by_attr, "html find by attr" },
-        { test_network_send_receive, "network send/receive" }
+        { test_network_send_receive, "network send/receive" },
+        { test_network_invalid_ip, "network invalid ip" },
+        { test_network_send_uninitialized, "network send uninitialized" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
     int index = 0;

--- a/Test/networking_tests.cpp
+++ b/Test/networking_tests.cpp
@@ -36,3 +36,21 @@ int test_network_send_receive(void)
     return ft_strcmp(buf, msg) == 0;
 }
 
+int test_network_invalid_ip(void)
+{
+    SocketConfig conf;
+    conf.type = SocketType::SERVER;
+    conf.port = 54324;
+    conf.ip = "256.0.0.1";
+    ft_socket server(conf);
+    return (server.get_error() == SOCKET_INVALID_CONFIGURATION);
+}
+
+int test_network_send_uninitialized(void)
+{
+    ft_socket sock;
+    const char *msg = "fail";
+    ssize_t r = sock.send_all(msg, ft_strlen(msg), 0);
+    return (r < 0 && sock.get_error() == SOCKET_INVALID_CONFIGURATION);
+}
+


### PR DESCRIPTION
## Summary
- expand networking tests with invalid IP and uninitialized send cases
- list new tests in the main test runner

## Testing
- `make`
- `make -C Test`
- `./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_686abead1d34833190935af267dc4bff