### PR TITLE
Add CPP_class unit tests

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,7 +1,7 @@
 TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
-SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp
+SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/cpp_class_tests.cpp
+++ b/Test/cpp_class_tests.cpp
@@ -1,0 +1,56 @@
+#include "../CPP_class/string_class.hpp"
+#include "../CPP_class/data_buffer.hpp"
+#include "../CPP_class/file.hpp"
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+#include <string>
+
+int test_ft_string_append(void)
+{
+    ft_string s;
+    s.append('h');
+    s.append('i');
+    return (s.size() == 2 && std::strcmp(s.c_str(), "hi") == 0);
+}
+
+int test_ft_string_concat(void)
+{
+    ft_string a("Hello");
+    ft_string b("World");
+    ft_string c = a + " " + b;
+    return (c == "Hello World");
+}
+
+int test_data_buffer_io(void)
+{
+    DataBuffer buf;
+    buf << 42 << std::string("abc");
+    int i = 0;
+    std::string s;
+    buf >> i >> s;
+    return (i == 42 && s == "abc" && buf.good());
+}
+
+int test_ft_file_write_read(void)
+{
+    const char *fname = "tmp_cpp_file.txt";
+    {
+        ft_file file(fname, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (file.get_fd() < 0)
+            return 0;
+        if (file.write("hello") <= 0)
+            return 0;
+    }
+    {
+        ft_file file(fname, O_RDONLY);
+        if (file.get_fd() < 0)
+            return 0;
+        char buf[6] = {0};
+        if (file.read(buf, 5) != 5)
+            return 0;
+        file.close();
+        ::unlink(fname);
+        return (std::strcmp(buf, "hello") == 0);
+    }
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -78,6 +78,10 @@ int test_abs_zero(void);
 int test_abs_positive(void);
 int test_atol_basic(void);
 int test_atol_whitespace(void);
+int test_ft_string_append(void);
+int test_ft_string_concat(void);
+int test_data_buffer_io(void);
+int test_ft_file_write_read(void);
 
 int main(void)
 {
@@ -141,7 +145,11 @@ int main(void)
         { test_isalnum_true, "isalnum true" },
         { test_isalnum_false, "isalnum false" },
         { test_isspace_true, "isspace true" },
-        { test_isspace_false, "isspace false" }
+        { test_isspace_false, "isspace false" },
+        { test_ft_string_append, "ft_string append" },
+        { test_ft_string_concat, "ft_string concat" },
+        { test_data_buffer_io, "DataBuffer io" },
+        { test_ft_file_write_read, "ft_file write/read" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
     int index = 0;


### PR DESCRIPTION
## Summary
- extend Test/Makefile source list with `cpp_class_tests.cpp`
- declare CPP_class test prototypes in `main.cpp`
- register new tests in the test array
- add new `cpp_class_tests.cpp` implementing tests for `ft_string`, `DataBuffer`, and `ft_file`

## Testing
- `make -C Test`
- `./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_686ac666c4f8833197bf3ad5fe8722c7