### PR TITLE
Add comprehensive printf tests

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,7 +1,7 @@
 TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
-SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp
+SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -98,6 +98,11 @@ int test_ft_unique_ptr_basic(void);
 int test_ft_unique_ptr_array(void);
 int test_ft_unique_ptr_release(void);
 int test_ft_unique_ptr_swap(void);
+int test_pf_printf_basic(void);
+int test_pf_printf_misc(void);
+int test_pf_printf_bool(void);
+int test_pf_printf_nullptr(void);
+int test_pf_printf_modifiers(void);
 
 int main(void)
 {
@@ -181,7 +186,12 @@ int main(void)
         { test_ft_unique_ptr_basic, "ft_uniqueptr basic" },
         { test_ft_unique_ptr_array, "ft_uniqueptr array" },
         { test_ft_unique_ptr_release, "ft_uniqueptr release" },
-        { test_ft_unique_ptr_swap, "ft_uniqueptr swap" }
+        { test_ft_unique_ptr_swap, "ft_uniqueptr swap" },
+        { test_pf_printf_basic, "pf_printf basic" },
+        { test_pf_printf_misc, "pf_printf misc" },
+        { test_pf_printf_bool, "pf_printf bool" },
+        { test_pf_printf_nullptr, "pf_printf nullptr" },
+        { test_pf_printf_modifiers, "pf_printf modifiers" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
     int index = 0;

--- a/Test/printf_tests.cpp
+++ b/Test/printf_tests.cpp
@@ -1,0 +1,96 @@
+#include "../Printf/printf.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <fcntl.h>
+#include <unistd.h>
+
+int test_pf_printf_basic(void)
+{
+    const char *fname = "tmp_pf_printf_basic.txt";
+    int fd = ::open(fname, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0)
+        return 0;
+    pf_printf_fd(fd, "Hello %s %d!", "world", 42);
+    ::lseek(fd, 0, SEEK_SET);
+    char buf[64];
+    ssize_t r = ::read(fd, buf, sizeof(buf) - 1);
+    ::close(fd);
+    ::unlink(fname);
+    if (r < 0)
+        return 0;
+    buf[r] = '\0';
+    return (ft_strcmp(buf, "Hello world 42!") == 0);
+}
+
+int test_pf_printf_misc(void)
+{
+    const char *fname = "tmp_pf_printf_misc.txt";
+    int fd = ::open(fname, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0)
+        return 0;
+    pf_printf_fd(fd, "%c %X %b %%", 'A', 0x2A, 0);
+    ::lseek(fd, 0, SEEK_SET);
+    char buf[64];
+    ssize_t r = ::read(fd, buf, sizeof(buf) - 1);
+    ::close(fd);
+    ::unlink(fname);
+    if (r < 0)
+        return 0;
+    buf[r] = '\0';
+    return (ft_strcmp(buf, "A 2A false %") == 0);
+}
+int test_pf_printf_bool(void)
+{
+    const char *fname = "tmp_pf_printf_bool.txt";
+    int fd = ::open(fname, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0)
+        return 0;
+    pf_printf_fd(fd, "%b %b", 1, 0);
+    ::lseek(fd, 0, SEEK_SET);
+    char buf[64];
+    ssize_t r = ::read(fd, buf, sizeof(buf) - 1);
+    ::close(fd);
+    ::unlink(fname);
+    if (r < 0)
+        return 0;
+    buf[r] = '\0';
+    return (ft_strcmp(buf, "true false") == 0);
+}
+
+int test_pf_printf_nullptr(void)
+{
+    const char *fname = "tmp_pf_printf_nullptr.txt";
+    int fd = ::open(fname, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0)
+        return 0;
+    pf_printf_fd(fd, "%p %s", static_cast<void*>(ft_nullptr), static_cast<char*>(ft_nullptr));
+    ::lseek(fd, 0, SEEK_SET);
+    char buf[64];
+    ssize_t r = ::read(fd, buf, sizeof(buf) - 1);
+    ::close(fd);
+    ::unlink(fname);
+    if (r < 0)
+        return 0;
+    buf[r] = '\0';
+    return (ft_strcmp(buf, "0x0 (null)") == 0);
+}
+
+int test_pf_printf_modifiers(void)
+{
+    const char *fname = "tmp_pf_printf_modifiers.txt";
+    int fd = ::open(fname, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0)
+        return 0;
+    long lval = 2147483648L;
+    size_t zval = static_cast<size_t>(0x1FFFFFFFFULL);
+    pf_printf_fd(fd, "%ld %lu %lx %zu %zx", lval, lval, lval, zval, zval);
+    ::lseek(fd, 0, SEEK_SET);
+    char buf[128];
+    ssize_t r = ::read(fd, buf, sizeof(buf) - 1);
+    ::close(fd);
+    ::unlink(fname);
+    if (r < 0)
+        return 0;
+    buf[r] = '\0';
+    return (ft_strcmp(buf, "2147483648 2147483648 80000000 8589934591 1ffffffff") == 0);
+}


### PR DESCRIPTION
## Summary
- expand printf_tests.cpp with checks for bool output, nullptr handling, and length modifiers
- declare new test functions in main.cpp and run them in the test suite

## Testing
- `make` in `Test`
- `./libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_686ad552cc4883318851fbe9a9d947e7