### PR TITLE
Add 3D map backend module

### DIFF
--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -38,5 +38,6 @@
 #include "Windows/windows_file.hpp"
 #include "encryption/BasicEncryption.hpp"
 #include "file/open_dir.hpp"
+#include "Game/map3d.hpp"
 
 #endif // FULL_LIBFT_HPP

--- a/Game/Makefile
+++ b/Game/Makefile
@@ -1,0 +1,70 @@
+TARGET := Game.a
+DEBUG_TARGET := Game_debug.a
+
+SRCS := map3d.cpp
+
+HEADERS := map3d.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
+clean:
+	-$(RM) $(CLEAN_FILES)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/Game/map3d.cpp
+++ b/Game/map3d.cpp
@@ -1,0 +1,100 @@
+#include "map3d.hpp"
+
+ft_map3d::ft_map3d(size_t width, size_t height, size_t depth, int value)
+    : _data(ft_nullptr), _width(0), _height(0), _depth(0)
+{
+    this->allocate(width, height, depth, value);
+    return ;
+}
+
+ft_map3d::~ft_map3d()
+{
+    this->deallocate();
+    return ;
+}
+
+void ft_map3d::resize(size_t width, size_t height, size_t depth, int value)
+{
+    this->deallocate();
+    this->allocate(width, height, depth, value);
+    return ;
+}
+
+size_t ft_map3d::index(size_t x, size_t y, size_t z) const
+{
+    return (x + y * this->_width + z * this->_width * this->_height);
+}
+
+int ft_map3d::get(size_t x, size_t y, size_t z) const
+{
+    return (this->_data[z][y][x]);
+}
+
+void ft_map3d::set(size_t x, size_t y, size_t z, int value)
+{
+    this->_data[z][y][x] = value;
+    return ;
+}
+
+size_t ft_map3d::get_width() const
+{
+    return (this->_width);
+}
+
+size_t ft_map3d::get_height() const
+{
+    return (this->_height);
+}
+
+size_t ft_map3d::get_depth() const
+{
+    return (this->_depth);
+}
+
+void ft_map3d::allocate(size_t width, size_t height, size_t depth, int value)
+{
+    this->_width = width;
+    this->_height = height;
+    this->_depth = depth;
+    if (width == 0 || height == 0 || depth == 0)
+    {
+        this->_data = ft_nullptr;
+        return ;
+    }
+    this->_data = static_cast<int***>(cma_malloc(sizeof(int**) * depth));
+    if (!this->_data)
+        return ;
+    for (size_t z = 0; z < depth; z++)
+    {
+        this->_data[z] = static_cast<int**>(cma_malloc(sizeof(int*) * height));
+        if (!this->_data[z])
+            return ;
+        for (size_t y = 0; y < height; y++)
+        {
+            this->_data[z][y] = static_cast<int*>(cma_malloc(sizeof(int) * width));
+            if (!this->_data[z][y])
+                return ;
+            for (size_t x = 0; x < width; x++)
+                this->_data[z][y][x] = value;
+        }
+    }
+    return ;
+}
+
+void ft_map3d::deallocate()
+{
+    if (!this->_data)
+        return ;
+    for (size_t z = 0; z < this->_depth; z++)
+    {
+        for (size_t y = 0; y < this->_height; y++)
+            cma_free(this->_data[z][y]);
+        cma_free(this->_data[z]);
+    }
+    cma_free(this->_data);
+    this->_data = ft_nullptr;
+    this->_width = 0;
+    this->_height = 0;
+    this->_depth = 0;
+    return ;
+}

--- a/Game/map3d.hpp
+++ b/Game/map3d.hpp
@@ -1,0 +1,35 @@
+#ifndef MAP3D_HPP
+# define MAP3D_HPP
+
+#include <cstddef>
+#include "../CMA/CMA.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+class ft_map3d
+{
+    private:
+        int     ***_data;
+        size_t  _width;
+        size_t  _height;
+        size_t  _depth;
+
+        void    allocate(size_t width, size_t height, size_t depth, int value);
+        void    deallocate();
+        size_t  index(size_t x, size_t y, size_t z) const;
+
+    public:
+        ft_map3d(size_t width = 0, size_t height = 0, size_t depth = 0, int value = 0);
+        ~ft_map3d();
+
+        ft_map3d(const ft_map3d&) = delete;
+        ft_map3d &operator=(const ft_map3d&) = delete;
+
+        void    resize(size_t width, size_t height, size_t depth, int value = 0);
+        int     get(size_t x, size_t y, size_t z) const;
+        void    set(size_t x, size_t y, size_t z, int value);
+        size_t  get_width() const;
+        size_t  get_height() const;
+        size_t  get_depth() const;
+};
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ SUBDIRS += encryption \
             RNG \
             JSon \
             file \
-            HTML
+            HTML \
+            Game
 
 LIB_BASES := \
   CMA/CustomMemoryAllocator \
@@ -56,7 +57,8 @@ LIB_BASES += encryption/encryption \
   RNG/RNG \
   JSon/JSon \
   file/file \
-  HTML/HTMLParser
+  HTML/HTMLParser \
+  Game/Game
 
 ifeq ($(OS),Windows_NT)
 OS_EXTRACT = $(call EXTRACT,Windows/Windows.a)
@@ -107,6 +109,7 @@ $(TARGET): $(LIBS)
 	$(call EXTRACT,JSon/JSon.a)
 	$(call EXTRACT,file/file.a)
 	$(call EXTRACT,HTML/HTMLParser.a)
+	$(call EXTRACT,Game/Game.a)
 	$(AR) $(ARFLAGS) $@ temp_objs/*.o
 	$(RMDIR) temp_objs
 
@@ -129,6 +132,7 @@ $(DEBUG_TARGET): $(DEBUG_LIBS)
 	$(call EXTRACT,JSon/JSon_debug.a)
 	$(call EXTRACT,file/file_debug.a)
 	$(call EXTRACT,HTML/HTMLParser_debug.a)
+	$(call EXTRACT,Game/Game_debug.a)
 	$(AR) $(ARFLAGS) $@ temp_objs/*.o
 	$(RMDIR) temp_objs
 
@@ -154,6 +158,7 @@ clean:
 	$(MAKE) -C JSon clean
 	$(MAKE) -C file clean
 	$(MAKE) -C HTML clean
+	$(MAKE) -C Game clean
 	$(RM) $(TARGET) $(DEBUG_TARGET)
 
 fclean: clean
@@ -172,6 +177,7 @@ fclean: clean
 	$(MAKE) -C JSon fclean
 	$(MAKE) -C file fclean
 	$(MAKE) -C HTML fclean
+	$(MAKE) -C Game fclean
 	$(RM) $(TARGET) $(DEBUG_TARGET)
 	
 .PHONY: all debug both re clean fclean


### PR DESCRIPTION
## Summary
- implement a `Game` module for basic game backend usage
- create `ft_map3d` class handling a simple 3D integer map
- include new module in the main library build system
- refactor `ft_map3d` to allocate and free a dynamic 3D array

## Testing
- `make clean`
- `make`
- `make -C Game`


------
https://chatgpt.com/codex/tasks/task_e_686edddfb0308331b0545dfcad05d5c1