### PR TITLE
Remove unused item stat macros

### DIFF
--- a/Game/Makefile
+++ b/Game/Makefile
@@ -1,9 +1,9 @@
 TARGET := Game.a
 DEBUG_TARGET := Game_debug.a
 
-SRCS := map3d.cpp character.cpp
+SRCS := map3d.cpp character.cpp item.cpp
 
-HEADERS := map3d.hpp character.hpp
+HEADERS := map3d.hpp character.hpp item.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Game/item.cpp
+++ b/Game/item.cpp
@@ -1,0 +1,67 @@
+#include "item.hpp"
+
+ft_item::ft_item() noexcept
+    : _hit_points(0), _armor(0), _might(0), _agility(0),
+      _endurance(0), _reason(0), _insigh(0), _presence(0),
+      _coins(0),
+      _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
+      _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
+      _physical_res{0, 0},
+      _ability_1{0, 0, 0, 0, 0, 0}, _ability_2{0, 0, 0, 0, 0, 0}
+{
+    return ;
+}
+
+int ft_item::get_hit_points() const noexcept { return _hit_points; }
+void ft_item::set_hit_points(int hp) noexcept { _hit_points = hp; }
+
+int ft_item::get_armor() const noexcept { return _armor; }
+void ft_item::set_armor(int armor) noexcept { _armor = armor; }
+
+int ft_item::get_might() const noexcept { return _might; }
+void ft_item::set_might(int might) noexcept { _might = might; }
+
+int ft_item::get_agility() const noexcept { return _agility; }
+void ft_item::set_agility(int agility) noexcept { _agility = agility; }
+
+int ft_item::get_endurance() const noexcept { return _endurance; }
+void ft_item::set_endurance(int endurance) noexcept { _endurance = endurance; }
+
+int ft_item::get_reason() const noexcept { return _reason; }
+void ft_item::set_reason(int reason) noexcept { _reason = reason; }
+
+int ft_item::get_insigh() const noexcept { return _insigh; }
+void ft_item::set_insigh(int insigh) noexcept { _insigh = insigh; }
+
+int ft_item::get_presence() const noexcept { return _presence; }
+void ft_item::set_presence(int presence) noexcept { _presence = presence; }
+
+int ft_item::get_coins() const noexcept { return _coins; }
+void ft_item::set_coins(int coins) noexcept { _coins = coins; }
+
+ft_resistance ft_item::get_fire_res() const noexcept { return _fire_res; }
+void ft_item::set_fire_res(int percent, int flat) noexcept { _fire_res = {percent, flat}; }
+
+ft_resistance ft_item::get_frost_res() const noexcept { return _frost_res; }
+void ft_item::set_frost_res(int percent, int flat) noexcept { _frost_res = {percent, flat}; }
+
+ft_resistance ft_item::get_lightning_res() const noexcept { return _lightning_res; }
+void ft_item::set_lightning_res(int percent, int flat) noexcept { _lightning_res = {percent, flat}; }
+
+ft_resistance ft_item::get_air_res() const noexcept { return _air_res; }
+void ft_item::set_air_res(int percent, int flat) noexcept { _air_res = {percent, flat}; }
+
+ft_resistance ft_item::get_earth_res() const noexcept { return _earth_res; }
+void ft_item::set_earth_res(int percent, int flat) noexcept { _earth_res = {percent, flat}; }
+
+ft_resistance ft_item::get_chaos_res() const noexcept { return _chaos_res; }
+void ft_item::set_chaos_res(int percent, int flat) noexcept { _chaos_res = {percent, flat}; }
+
+ft_resistance ft_item::get_physical_res() const noexcept { return _physical_res; }
+void ft_item::set_physical_res(int percent, int flat) noexcept { _physical_res = {percent, flat}; }
+
+ft_item_ability ft_item::get_ability_1() const noexcept { return _ability_1; }
+void ft_item::set_ability_1(const ft_item_ability &ability) noexcept { _ability_1 = ability; }
+
+ft_item_ability ft_item::get_ability_2() const noexcept { return _ability_2; }
+void ft_item::set_ability_2(const ft_item_ability &ability) noexcept { _ability_2 = ability; }

--- a/Game/item.hpp
+++ b/Game/item.hpp
@@ -1,0 +1,106 @@
+#ifndef ITEM_HPP
+# define ITEM_HPP
+
+#include <cstdint>
+#include "character.hpp"
+
+// Stat identifiers (8-bit)
+# define FT_STAT_MIGHT             0x01
+# define FT_STAT_AGILITY           0x02
+# define FT_STAT_ENDURANCE         0x03
+# define FT_STAT_REASON            0x04
+# define FT_STAT_INSIGH            0x05
+# define FT_STAT_PRESENCE          0x06
+
+struct ft_item_ability
+{
+    uint8_t    stat_id;
+    int        main_modifier;
+    int        bonus_modifier;
+    int        duration;
+    int        duration_modifier;
+    int        stat_modifier;
+};
+
+class ft_item
+{
+    private:
+        int _hit_points;
+        int _armor;
+        int _might;
+        int _agility;
+        int _endurance;
+        int _reason;
+        int _insigh;
+        int _presence;
+        int _coins;
+        ft_resistance _fire_res;
+        ft_resistance _frost_res;
+        ft_resistance _lightning_res;
+        ft_resistance _air_res;
+        ft_resistance _earth_res;
+        ft_resistance _chaos_res;
+        ft_resistance _physical_res;
+        ft_item_ability _ability_1;
+        ft_item_ability _ability_2;
+
+    public:
+        ft_item() noexcept;
+        virtual ~ft_item() = default;
+
+        int get_hit_points() const noexcept;
+        void set_hit_points(int hp) noexcept;
+
+        int get_armor() const noexcept;
+        void set_armor(int armor) noexcept;
+
+        int get_might() const noexcept;
+        void set_might(int might) noexcept;
+
+        int get_agility() const noexcept;
+        void set_agility(int agility) noexcept;
+
+        int get_endurance() const noexcept;
+        void set_endurance(int endurance) noexcept;
+
+        int get_reason() const noexcept;
+        void set_reason(int reason) noexcept;
+
+        int get_insigh() const noexcept;
+        void set_insigh(int insigh) noexcept;
+
+        int get_presence() const noexcept;
+        void set_presence(int presence) noexcept;
+
+        int get_coins() const noexcept;
+        void set_coins(int coins) noexcept;
+
+        ft_resistance get_fire_res() const noexcept;
+        void set_fire_res(int percent, int flat) noexcept;
+
+        ft_resistance get_frost_res() const noexcept;
+        void set_frost_res(int percent, int flat) noexcept;
+
+        ft_resistance get_lightning_res() const noexcept;
+        void set_lightning_res(int percent, int flat) noexcept;
+
+        ft_resistance get_air_res() const noexcept;
+        void set_air_res(int percent, int flat) noexcept;
+
+        ft_resistance get_earth_res() const noexcept;
+        void set_earth_res(int percent, int flat) noexcept;
+
+        ft_resistance get_chaos_res() const noexcept;
+        void set_chaos_res(int percent, int flat) noexcept;
+
+        ft_resistance get_physical_res() const noexcept;
+        void set_physical_res(int percent, int flat) noexcept;
+
+        ft_item_ability get_ability_1() const noexcept;
+        void set_ability_1(const ft_item_ability &ability) noexcept;
+
+        ft_item_ability get_ability_2() const noexcept;
+        void set_ability_2(const ft_item_ability &ability) noexcept;
+};
+
+#endif // ITEM_HPP


### PR DESCRIPTION
## Summary
- trim macro identifiers for item stats to the six required values

## Testing
- `make -C Game`
- `make -C Game debug`


------
https://chatgpt.com/codex/tasks/task_e_68700f3136e08331b06e2379853dd95e