### PR TITLE
Add valor currency to game characters

### DIFF
--- a/Game/character.cpp
+++ b/Game/character.cpp
@@ -3,7 +3,7 @@
 ft_character::ft_character() noexcept
     : _hit_points(0), _armor(0), _might(0), _agility(0),
       _endurance(0), _reason(0), _insigh(0), _presence(0),
-      _coins(0),
+      _coins(0), _valor(0),
       _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
       _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
       _physical_res{0, 0}
@@ -107,6 +107,17 @@ int ft_character::get_coins() const noexcept
 void ft_character::set_coins(int coins) noexcept
 {
     _coins = coins;
+    return ;
+}
+
+int ft_character::get_valor() const noexcept
+{
+    return (_valor);
+}
+
+void ft_character::set_valor(int valor) noexcept
+{
+    _valor = valor;
     return ;
 }
 

--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -19,6 +19,7 @@ class ft_character
         int _insigh;
         int _presence;
         int _coins;
+        int _valor;
         ft_resistance _fire_res;
         ft_resistance _frost_res;
         ft_resistance _lightning_res;
@@ -57,6 +58,9 @@ class ft_character
 
         int get_coins() const noexcept;
         void set_coins(int coins) noexcept;
+
+        int get_valor() const noexcept;
+        void set_valor(int valor) noexcept;
 
         ft_resistance get_fire_res() const noexcept;
         void set_fire_res(int percent, int flat) noexcept;


### PR DESCRIPTION
## Summary
- extend `ft_character` with valor points currency
- implement `get_valor` and `set_valor`

## Testing
- `make -C Game`
- `make -C Test`
- `./Test/libft_tests`


------
https://chatgpt.com/codex/tasks/task_e_6870e9a58a988331b1bfc4be8a9a4149