### PR TITLE
Fix style by normalizing indentation

### DIFF
--- a/CPP_class/file.cpp
+++ b/CPP_class/file.cpp
@@ -9,44 +9,44 @@
 
 ft_file::ft_file() noexcept
 {
-	this->_fd = -1;
-	this->_error_code = 0;
-	return ;
+    this->_fd = -1;
+    this->_error_code = 0;
+    return ;
 }
 
 ft_file::ft_file(const char* filename, int flags, mode_t mode) noexcept 
     : _fd(-1), _error_code(0)
 {
-	if (DEBUG == 1)
-		pf_printf("Opening %s\n", filename);
+    if (DEBUG == 1)
+        pf_printf("Opening %s\n", filename);
     this->_fd = ::open(filename, flags, mode);
-	if (_fd < 0)
-		this->set_error(errno + ERRNO_OFFSET);
-	return ;
+    if (this->_fd < 0)
+        this->set_error(errno + ERRNO_OFFSET);
+    return ;
 }
 
 ft_file::ft_file(const char* filename, int flags) noexcept 
     : _fd(-1), _error_code(0)
 {
     this->_fd = ::open(filename, flags);
-	if (this->_fd < 0)
-		this->set_error(errno + ERRNO_OFFSET);
-	return ;
+    if (this->_fd < 0)
+        this->set_error(errno + ERRNO_OFFSET);
+    return ;
 }
 
 ft_file::ft_file(int fd) noexcept : _fd(fd), _error_code(0)
 {
-	return ;
+    return ;
 }
 
 ft_file::~ft_file() noexcept
 {
     if (this->_fd >= 0)
-	{
+    {
         if (::close(this->_fd) == -1)
-			ft_errno = errno + ERRNO_OFFSET;
+            ft_errno = errno + ERRNO_OFFSET;
     }
-	return ;
+    return ;
 }
 
 ft_file::ft_file(ft_file&& other) noexcept 
@@ -54,16 +54,16 @@ ft_file::ft_file(ft_file&& other) noexcept
 {
     other._fd = -1;
     other._error_code = 0;
-	return ;
+    return ;
 }
 
 ft_file& ft_file::operator=(ft_file&& other) noexcept
 {
     if (this != &other)
-	{
+    {
         if (this->_fd >= 0)
-		{
-            if (::close(_fd) == -1 && this->_error_code == 0)
+        {
+            if (::close(this->_fd) == -1 && this->_error_code == 0)
                 this->_error_code = errno;
         }
         this->_fd = other._fd;
@@ -74,49 +74,49 @@ ft_file& ft_file::operator=(ft_file&& other) noexcept
     return (*this);
 }
 
-void	ft_file::close() noexcept
+void    ft_file::close() noexcept
 {
-	if (this->_fd >= 0)
-	{
-		::close(this->_fd);
-		this->_fd = -1;
-	}
-	return ;
+    if (this->_fd >= 0)
+    {
+        ::close(this->_fd);
+        this->_fd = -1;
+    }
+    return ;
 }
 
-int	ft_file::open(const char* filename, int flags, mode_t mode) noexcept
+int ft_file::open(const char* filename, int flags, mode_t mode) noexcept
 {
-	if (DEBUG == 1)
-		pf_printf("Opening %s\n", filename);
-	if (this->_fd != -1)
-		this->close();
-	_fd = ::open(filename, flags, mode);
-	if (this->_fd < 0)
-	{
-		this->set_error(errno + ERRNO_OFFSET);
-		return (1);
-	}
-	return (0);
+    if (DEBUG == 1)
+        pf_printf("Opening %s\n", filename);
+    if (this->_fd != -1)
+        this->close();
+    this->_fd = ::open(filename, flags, mode);
+    if (this->_fd < 0)
+    {
+        this->set_error(errno + ERRNO_OFFSET);
+        return (1);
+    }
+    return (0);
 }
 
-int	ft_file::open(const char* filename, int flags) noexcept
+int ft_file::open(const char* filename, int flags) noexcept
 {
-	if (this->_fd != -1)
-		this->close();
-	_fd = ::open(filename, flags);
-	if (this->_fd < 0)
-	{
-		this->set_error(errno + ERRNO_OFFSET);
-		return (1);
-	}
-	return (0);
+    if (this->_fd != -1)
+        this->close();
+    this->_fd = ::open(filename, flags);
+    if (this->_fd < 0)
+    {
+        this->set_error(errno + ERRNO_OFFSET);
+        return (1);
+    }
+    return (0);
 }
 
-void	ft_file::set_error(int error_code)
+void    ft_file::set_error(int error_code)
 {
-	ft_errno = error_code;
-	this->_error_code = error_code;
-	return ;
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
 }
 
 int ft_file::get_fd() const
@@ -126,30 +126,30 @@ int ft_file::get_fd() const
 
 int ft_file::get_error() const noexcept
 {
-	return (this->_error_code);
+    return (this->_error_code);
 }
 
 const char *ft_file::get_error_str() const noexcept
 {
-	return (ft_strerror(_error_code));
+    return (ft_strerror(this->_error_code));
 }
 
-ssize_t	ft_file::read(char *buffer, int count) noexcept
+ssize_t ft_file::read(char *buffer, int count) noexcept
 {
-	if (buffer == NULL || count <= 0)
-	{
-		this->set_error(FT_EINVAL);
-		return (-1);
-	}
-	if (this->_fd < 0)
-	{
-		this->set_error(FILE_INVALID_FD);
-		return (-1);
-	}
-	ssize_t bytes_read = ::read(this->_fd, buffer, count);
-	if (bytes_read == -1)
-		this->set_error(errno + ERRNO_OFFSET);
-	return (bytes_read);
+    if (buffer == NULL || count <= 0)
+    {
+        this->set_error(FT_EINVAL);
+        return (-1);
+    }
+    if (this->_fd < 0)
+    {
+        this->set_error(FILE_INVALID_FD);
+        return (-1);
+    }
+    ssize_t bytes_read = ::read(this->_fd, buffer, count);
+    if (bytes_read == -1)
+        this->set_error(errno + ERRNO_OFFSET);
+    return (bytes_read);
 }
 
 ssize_t ft_file::write(const char *string) noexcept
@@ -180,17 +180,17 @@ int ft_file::seek(off_t offset, int whence) noexcept
     return (0);
 }
 
-int	ft_file::printf(const char *format, ...)
+int ft_file::printf(const char *format, ...)
 {
     va_list args;
 
-	if (!format)
+    if (!format)
         return (0);
-	if (this->_fd == -1)
-	{
-		this->set_error(FILE_INVALID_FD);
-		return (0);
-	}
+    if (this->_fd == -1)
+    {
+        this->set_error(FILE_INVALID_FD);
+        return (0);
+    }
     va_start(args, format);
     int printed_chars = pf_printf_fd_v(this->_fd, format, args);
     va_end(args);
@@ -199,5 +199,5 @@ int	ft_file::printf(const char *format, ...)
 
 ft_file::operator int() const
 {
-	return (this->_fd);
+    return (this->_fd);
 }

--- a/CPP_class/string_constructors.cpp
+++ b/CPP_class/string_constructors.cpp
@@ -104,11 +104,11 @@ ft_string& ft_string::operator=(ft_string&& other) noexcept
 {
     if (this != &other)
     {
-        delete[] _data;
-        _data = other._data;
-        _length = other._length;
-        _capacity = other._capacity;
-        _errorCode = other._errorCode;
+        delete[] this->_data;
+        this->_data = other._data;
+        this->_length = other._length;
+        this->_capacity = other._capacity;
+        this->_errorCode = other._errorCode;
         other._data = nullptr;
         other._length = 0;
         other._capacity = 0;

--- a/CPP_class/string_methods.cpp
+++ b/CPP_class/string_methods.cpp
@@ -56,7 +56,7 @@ void ft_string::append(const ft_string& string) noexcept
     ft_memcpy(this->_data + this->_length, string._data, string._length);
     this->_length = new_length;
     this->_data[this->_length] = '\0';
-	return ;
+    return ;
 }
 
 void ft_string::append(const char *string) noexcept
@@ -144,43 +144,43 @@ void ft_string::move(ft_string& other) noexcept
 {
     if (this != &other)
     {
-        cma_free(_data);
-        _data = other._data;
-        _length = other._length;
-        _capacity = other._capacity;
-        _errorCode = other._errorCode;
+        cma_free(this->_data);
+        this->_data = other._data;
+        this->_length = other._length;
+        this->_capacity = other._capacity;
+        this->_errorCode = other._errorCode;
         other._data = nullptr;
         other._length = 0;
         other._capacity = 0;
         other._errorCode = 0;
     }
-	return ;
+    return ;
 }
 
 ft_string& ft_string::operator+=(const ft_string& other) noexcept
 {
-	size_t index = 0;
+    size_t index = 0;
 
     while (index < other._length)
-	{
+    {
         this->append(other._data[index]);
-		if (_errorCode)
-			return (*this);
-		index++;
-	}
+        if (this->_errorCode)
+            return (*this);
+        index++;
+    }
     return (*this);
 }
 
 ft_string& ft_string::operator+=(const char* cstr) noexcept
 {
     if (cstr)
-	{
+    {
         size_t i = 0;
         while (cstr[i] != '\0')
-		{
+        {
             this->append(cstr[i]);
-			if (_errorCode)
-				return (*this);
+            if (this->_errorCode)
+                return (*this);
             ++i;
         }
     }
@@ -205,7 +205,7 @@ void ft_string::erase(std::size_t index, std::size_t count) noexcept
     if (count > 0)
     {
         ft_memmove(this->_data + index, this->_data + index + count,
-				this->_length - index - count);
+                this->_length - index - count);
         this->_length -= count;
         this->_data[this->_length] = '\0';
     }

--- a/Game/character.cpp
+++ b/Game/character.cpp
@@ -13,219 +13,219 @@ ft_character::ft_character() noexcept
 
 int ft_character::get_hit_points() const noexcept
 {
-    return (_hit_points);
+    return (this->_hit_points);
 }
 
 void ft_character::set_hit_points(int hp) noexcept
 {
-    _hit_points = hp;
+    this->_hit_points = hp;
     return ;
 }
 
 int ft_character::get_armor() const noexcept
 {
-    return (_armor);
+    return (this->_armor);
 }
 
 void ft_character::set_armor(int armor) noexcept
 {
-    _armor = armor;
+    this->_armor = armor;
     return ;
 }
 
 int ft_character::get_might() const noexcept
 {
-    return (_might);
+    return (this->_might);
 }
 
 void ft_character::set_might(int might) noexcept
 {
-    _might = might;
+    this->_might = might;
     return ;
 }
 
 int ft_character::get_agility() const noexcept
 {
-    return (_agility);
+    return (this->_agility);
 }
 
 void ft_character::set_agility(int agility) noexcept
 {
-    _agility = agility;
+    this->_agility = agility;
     return ;
 }
 
 int ft_character::get_endurance() const noexcept
 {
-    return (_endurance);
+    return (this->_endurance);
 }
 
 void ft_character::set_endurance(int endurance) noexcept
 {
-    _endurance = endurance;
+    this->_endurance = endurance;
     return ;
 }
 
 int ft_character::get_reason() const noexcept
 {
-    return (_reason);
+    return (this->_reason);
 }
 
 void ft_character::set_reason(int reason) noexcept
 {
-    _reason = reason;
+    this->_reason = reason;
     return ;
 }
 
 int ft_character::get_insigh() const noexcept
 {
-    return (_insigh);
+    return (this->_insigh);
 }
 
 void ft_character::set_insigh(int insigh) noexcept
 {
-    _insigh = insigh;
+    this->_insigh = insigh;
     return ;
 }
 
 int ft_character::get_presence() const noexcept
 {
-    return (_presence);
+    return (this->_presence);
 }
 
 void ft_character::set_presence(int presence) noexcept
 {
-    _presence = presence;
+    this->_presence = presence;
     return ;
 }
 
 int ft_character::get_coins() const noexcept
 {
-    return (_coins);
+    return (this->_coins);
 }
 
 void ft_character::set_coins(int coins) noexcept
 {
-    _coins = coins;
+    this->_coins = coins;
     return ;
 }
 
 int ft_character::get_x() const noexcept
 {
-    return (_x);
+    return (this->_x);
 }
 
 void ft_character::set_x(int x) noexcept
 {
-    _x = x;
+    this->_x = x;
     return ;
 }
 
 int ft_character::get_y() const noexcept
 {
-    return (_y);
+    return (this->_y);
 }
 
 void ft_character::set_y(int y) noexcept
 {
-    _y = y;
+    this->_y = y;
     return ;
 }
 
 int ft_character::get_z() const noexcept
 {
-    return (_z);
+    return (this->_z);
 }
 
 void ft_character::set_z(int z) noexcept
 {
-    _z = z;
+    this->_z = z;
     return ;
 }
 
 ft_resistance ft_character::get_fire_res() const noexcept
 {
-    return (_fire_res);
+    return (this->_fire_res);
 }
 
 void ft_character::set_fire_res(int percent, int flat) noexcept
 {
-    _fire_res = {percent, flat};
+    this->_fire_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_character::get_frost_res() const noexcept
 {
-    return (_frost_res);
+    return (this->_frost_res);
 }
 
 void ft_character::set_frost_res(int percent, int flat) noexcept
 {
-    _frost_res = {percent, flat};
+    this->_frost_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_character::get_lightning_res() const noexcept
 {
-    return (_lightning_res);
+    return (this->_lightning_res);
 }
 
 void ft_character::set_lightning_res(int percent, int flat) noexcept
 {
-    _lightning_res = {percent, flat};
+    this->_lightning_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_character::get_air_res() const noexcept
 {
-    return (_air_res);
+    return (this->_air_res);
 }
 
 void ft_character::set_air_res(int percent, int flat) noexcept
 {
-    _air_res = {percent, flat};
+    this->_air_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_character::get_earth_res() const noexcept
 {
-    return (_earth_res);
+    return (this->_earth_res);
 }
 
 void ft_character::set_earth_res(int percent, int flat) noexcept
 {
-    _earth_res = {percent, flat};
+    this->_earth_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_character::get_chaos_res() const noexcept
 {
-    return (_chaos_res);
+    return (this->_chaos_res);
 }
 
 void ft_character::set_chaos_res(int percent, int flat) noexcept
 {
-    _chaos_res = {percent, flat};
+    this->_chaos_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_character::get_physical_res() const noexcept
 {
-    return (_physical_res);
+    return (this->_physical_res);
 }
 
 void ft_character::set_physical_res(int percent, int flat) noexcept
 {
-    _physical_res = {percent, flat};
+    this->_physical_res = {percent, flat};
     return ;
 }
 
 ft_map<int, ft_quest> &ft_character::get_quests() noexcept
 {
-    return (_quests);
+    return (this->_quests);
 }
 
 const ft_map<int, ft_quest> &ft_character::get_quests() const noexcept
 {
-    return (_quests);
+    return (this->_quests);
 }

--- a/Game/item.cpp
+++ b/Game/item.cpp
@@ -14,330 +14,330 @@ ft_item::ft_item() noexcept
 
 int ft_item::get_hit_points() const noexcept
 {
-    return (_hit_points);
+    return (this->_hit_points);
 }
 
 void ft_item::set_hit_points(int hp) noexcept
 {
-    _hit_points = hp;
+    this->_hit_points = hp;
     return ;
 }
 
 int ft_item::get_armor() const noexcept
 {
-    return (_armor);
+    return (this->_armor);
 }
 
 void ft_item::set_armor(int armor) noexcept
 {
-    _armor = armor;
+    this->_armor = armor;
     return ;
 }
 
 int ft_item::get_might() const noexcept
 {
-    return (_might);
+    return (this->_might);
 }
 
 void ft_item::set_might(int might) noexcept
 {
-    _might = might;
+    this->_might = might;
     return ;
 }
 
 int ft_item::get_agility() const noexcept
 {
-    return (_agility);
+    return (this->_agility);
 }
 
 void ft_item::set_agility(int agility) noexcept
 {
-    _agility = agility;
+    this->_agility = agility;
     return ;
 }
 
 int ft_item::get_endurance() const noexcept
 {
-    return (_endurance);
+    return (this->_endurance);
 }
 
 void ft_item::set_endurance(int endurance) noexcept
 {
-    _endurance = endurance;
+    this->_endurance = endurance;
     return ;
 }
 
 int ft_item::get_reason() const noexcept
 {
-    return (_reason);
+    return (this->_reason);
 }
 
 void ft_item::set_reason(int reason) noexcept
 {
-    _reason = reason;
+    this->_reason = reason;
     return ;
 }
 
 int ft_item::get_insigh() const noexcept
 {
-    return (_insigh);
+    return (this->_insigh);
 }
 
 void ft_item::set_insigh(int insigh) noexcept
 {
-    _insigh = insigh;
+    this->_insigh = insigh;
     return ;
 }
 
 int ft_item::get_presence() const noexcept
 {
-    return (_presence);
+    return (this->_presence);
 }
 
 void ft_item::set_presence(int presence) noexcept
 {
-    _presence = presence;
+    this->_presence = presence;
     return ;
 }
 
 int ft_item::get_coins() const noexcept
 {
-    return (_coins);
+    return (this->_coins);
 }
 
 void ft_item::set_coins(int coins) noexcept
 {
-    _coins = coins;
+    this->_coins = coins;
     return ;
 }
 
 ft_resistance ft_item::get_fire_res() const noexcept
 {
-    return (_fire_res);
+    return (this->_fire_res);
 }
 
 void ft_item::set_fire_res(int percent, int flat) noexcept
 {
-    _fire_res = {percent, flat};
+    this->_fire_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_item::get_frost_res() const noexcept
 {
-    return (_frost_res);
+    return (this->_frost_res);
 }
 
 void ft_item::set_frost_res(int percent, int flat) noexcept
 {
-    _frost_res = {percent, flat};
+    this->_frost_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_item::get_lightning_res() const noexcept
 {
-    return (_lightning_res);
+    return (this->_lightning_res);
 }
 
 void ft_item::set_lightning_res(int percent, int flat) noexcept
 {
-    _lightning_res = {percent, flat};
+    this->_lightning_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_item::get_air_res() const noexcept
 {
-    return (_air_res);
+    return (this->_air_res);
 }
 
 void ft_item::set_air_res(int percent, int flat) noexcept
 {
-    _air_res = {percent, flat};
+    this->_air_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_item::get_earth_res() const noexcept
 {
-    return (_earth_res);
+    return (this->_earth_res);
 }
 
 void ft_item::set_earth_res(int percent, int flat) noexcept
 {
-    _earth_res = {percent, flat};
+    this->_earth_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_item::get_chaos_res() const noexcept
 {
-    return (_chaos_res);
+    return (this->_chaos_res);
 }
 
 void ft_item::set_chaos_res(int percent, int flat) noexcept
 {
-    _chaos_res = {percent, flat};
+    this->_chaos_res = {percent, flat};
     return ;
 }
 
 ft_resistance ft_item::get_physical_res() const noexcept
 {
-    return (_physical_res);
+    return (this->_physical_res);
 }
 
 void ft_item::set_physical_res(int percent, int flat) noexcept
 {
-    _physical_res = {percent, flat};
+    this->_physical_res = {percent, flat};
     return ;
 }
 
 ft_item_ability ft_item::get_ability_1() const noexcept
 {
-    return (_ability_1);
+    return (this->_ability_1);
 }
 
 void ft_item::set_ability_1(const ft_item_ability &ability) noexcept
 {
-    _ability_1 = ability;
+    this->_ability_1 = ability;
     return ;
 }
 
 ft_item_ability ft_item::get_ability_2() const noexcept
 {
-    return (_ability_2);
+    return (this->_ability_2);
 }
 
 void ft_item::set_ability_2(const ft_item_ability &ability) noexcept
 {
-    _ability_2 = ability;
+    this->_ability_2 = ability;
     return ;
 }
 
 uint8_t ft_item::get_ability_1_stat_id() const noexcept
 {
-    return (_ability_1.stat_id);
+    return (this->_ability_1.stat_id);
 }
 
 void ft_item::set_ability_1_stat_id(uint8_t id) noexcept
 {
-    _ability_1.stat_id = id;
+    this->_ability_1.stat_id = id;
     return ;
 }
 
 int ft_item::get_ability_1_main_modifier() const noexcept
 {
-    return (_ability_1.main_modifier);
+    return (this->_ability_1.main_modifier);
 }
 
 void ft_item::set_ability_1_main_modifier(int mod) noexcept
 {
-    _ability_1.main_modifier = mod;
+    this->_ability_1.main_modifier = mod;
     return ;
 }
 
 int ft_item::get_ability_1_bonus_modifier() const noexcept
 {
-    return (_ability_1.bonus_modifier);
+    return (this->_ability_1.bonus_modifier);
 }
 
 void ft_item::set_ability_1_bonus_modifier(int mod) noexcept
 {
-    _ability_1.bonus_modifier = mod;
+    this->_ability_1.bonus_modifier = mod;
     return ;
 }
 
 int ft_item::get_ability_1_duration() const noexcept
 {
-    return (_ability_1.duration);
+    return (this->_ability_1.duration);
 }
 
 void ft_item::set_ability_1_duration(int duration) noexcept
 {
-    _ability_1.duration = duration;
+    this->_ability_1.duration = duration;
     return ;
 }
 
 int ft_item::get_ability_1_duration_modifier() const noexcept
 {
-    return (_ability_1.duration_modifier);
+    return (this->_ability_1.duration_modifier);
 }
 
 void ft_item::set_ability_1_duration_modifier(int mod) noexcept
 {
-    _ability_1.duration_modifier = mod;
+    this->_ability_1.duration_modifier = mod;
     return ;
 }
 
 int ft_item::get_ability_1_stat_modifier() const noexcept
 {
-    return (_ability_1.stat_modifier);
+    return (this->_ability_1.stat_modifier);
 }
 
 void ft_item::set_ability_1_stat_modifier(int mod) noexcept
 {
-    _ability_1.stat_modifier = mod;
+    this->_ability_1.stat_modifier = mod;
     return ;
 }
 
 uint8_t ft_item::get_ability_2_stat_id() const noexcept
 {
-    return (_ability_2.stat_id);
+    return (this->_ability_2.stat_id);
 }
 
 void ft_item::set_ability_2_stat_id(uint8_t id) noexcept
 {
-    _ability_2.stat_id = id;
+    this->_ability_2.stat_id = id;
     return ;
 }
 
 int ft_item::get_ability_2_main_modifier() const noexcept
 {
-    return (_ability_2.main_modifier);
+    return (this->_ability_2.main_modifier);
 }
 
 void ft_item::set_ability_2_main_modifier(int mod) noexcept
 {
-    _ability_2.main_modifier = mod;
+    this->_ability_2.main_modifier = mod;
     return ;
 }
 
 int ft_item::get_ability_2_bonus_modifier() const noexcept
 {
-    return (_ability_2.bonus_modifier);
+    return (this->_ability_2.bonus_modifier);
 }
 
 void ft_item::set_ability_2_bonus_modifier(int mod) noexcept
 {
-    _ability_2.bonus_modifier = mod;
+    this->_ability_2.bonus_modifier = mod;
     return ;
 }
 
 int ft_item::get_ability_2_duration() const noexcept
 {
-    return (_ability_2.duration);
+    return (this->_ability_2.duration);
 }
 
 void ft_item::set_ability_2_duration(int duration) noexcept
 {
-    _ability_2.duration = duration;
+    this->_ability_2.duration = duration;
     return ;
 }
 
 int ft_item::get_ability_2_duration_modifier() const noexcept
 {
-    return (_ability_2.duration_modifier);
+    return (this->_ability_2.duration_modifier);
 }
 
 void ft_item::set_ability_2_duration_modifier(int mod) noexcept
 {
-    _ability_2.duration_modifier = mod;
+    this->_ability_2.duration_modifier = mod;
     return ;
 }
 
 int ft_item::get_ability_2_stat_modifier() const noexcept
 {
-    return (_ability_2.stat_modifier);
+    return (this->_ability_2.stat_modifier);
 }
 
 void ft_item::set_ability_2_stat_modifier(int mod) noexcept
 {
-    _ability_2.stat_modifier = mod;
+    this->_ability_2.stat_modifier = mod;
     return ;
 }

--- a/Game/quest.cpp
+++ b/Game/quest.cpp
@@ -8,33 +8,33 @@ ft_quest::ft_quest() noexcept
 
 int ft_quest::get_id() const noexcept
 {
-    return (_id);
+    return (this->_id);
 }
 
 void ft_quest::set_id(int id) noexcept
 {
-    _id = id;
+    this->_id = id;
     return ;
 }
 
 int ft_quest::get_phases() const noexcept
 {
-    return (_phases);
+    return (this->_phases);
 }
 
 void ft_quest::set_phases(int phases) noexcept
 {
-    _phases = phases;
+    this->_phases = phases;
     return ;
 }
 
 int ft_quest::get_current_phase() const noexcept
 {
-    return (_current_phase);
+    return (this->_current_phase);
 }
 
 void ft_quest::set_current_phase(int phase) noexcept
 {
-    _current_phase = phase;
+    this->_current_phase = phase;
     return ;
 }


### PR DESCRIPTION
## Summary
- convert tabs to spaces in `file.cpp` and `string_methods.cpp`
- realign statement indentation to multiples of four spaces

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68790adeaab88331a15e530a49999fd7