### PR TITLE
Add reputation class

### DIFF
--- a/Game/Makefile
+++ b/Game/Makefile
@@ -1,9 +1,9 @@
 TARGET := Game.a
 DEBUG_TARGET := Game_debug.a
 
-SRCS := map3d.cpp character.cpp item.cpp quest.cpp
+SRCS := map3d.cpp character.cpp item.cpp quest.cpp reputation.cpp
 
-HEADERS := map3d.hpp character.hpp item.hpp quest.hpp
+HEADERS := map3d.hpp character.hpp item.hpp quest.hpp reputation.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Game/character.cpp
+++ b/Game/character.cpp
@@ -6,8 +6,12 @@ ft_character::ft_character() noexcept
       _coins(0), _x(0), _y(0), _z(0),
       _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
       _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
-      _physical_res{0, 0}, _quests()
+      _physical_res{0, 0}, _quests(), _reputation(), _error(ER_SUCCESS)
 {
+    if (this->_quests.get_error() != ER_SUCCESS)
+        this->set_error(this->_quests.get_error());
+    else if (this->_reputation.get_error() != ER_SUCCESS)
+        this->set_error(this->_reputation.get_error());
     return ;
 }
 
@@ -228,4 +232,26 @@ ft_map<int, ft_quest> &ft_character::get_quests() noexcept
 const ft_map<int, ft_quest> &ft_character::get_quests() const noexcept
 {
     return (this->_quests);
+}
+
+ft_reputation &ft_character::get_reputation() noexcept
+{
+    return (this->_reputation);
+}
+
+const ft_reputation &ft_character::get_reputation() const noexcept
+{
+    return (this->_reputation);
+}
+
+int ft_character::get_error() const noexcept
+{
+    return (this->_error);
+}
+
+void ft_character::set_error(int err) const noexcept
+{
+    ft_errno = err;
+    this->_error = err;
+    return ;
 }

--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -3,6 +3,8 @@
 
 #include "../Template/map.hpp"
 #include "quest.hpp"
+#include "reputation.hpp"
+#include "../Errno/errno.hpp"
 
 struct ft_resistance
 {
@@ -33,6 +35,10 @@ class ft_character
         ft_resistance _chaos_res;
         ft_resistance _physical_res;
         ft_map<int, ft_quest> _quests;
+        ft_reputation         _reputation;
+        mutable int           _error;
+
+        void    set_error(int err) const noexcept;
 
     public:
         ft_character() noexcept;
@@ -100,6 +106,11 @@ class ft_character
 
         ft_map<int, ft_quest>       &get_quests() noexcept;
         const ft_map<int, ft_quest> &get_quests() const noexcept;
+
+        ft_reputation       &get_reputation() noexcept;
+        const ft_reputation &get_reputation() const noexcept;
+
+        int get_error() const noexcept;
 };
 
 #endif

--- a/Game/reputation.cpp
+++ b/Game/reputation.cpp
@@ -1,0 +1,138 @@
+#include "reputation.hpp"
+
+ft_reputation::ft_reputation() noexcept
+    : _milestones(), _reps(), _total_rep(0),
+      _current_rep(0), _error(ER_SUCCESS)
+{
+    if (this->_milestones.get_error() != ER_SUCCESS)
+        this->set_error(this->_milestones.get_error());
+    else if (this->_reps.get_error() != ER_SUCCESS)
+        this->set_error(this->_reps.get_error());
+    return ;
+}
+
+ft_reputation::ft_reputation(const ft_map<int, int> &milestones, int total) noexcept
+    : _milestones(milestones), _reps(), _total_rep(total),
+      _current_rep(0), _error(ER_SUCCESS)
+{
+    if (this->_milestones.get_error() != ER_SUCCESS)
+        this->set_error(this->_milestones.get_error());
+    else if (this->_reps.get_error() != ER_SUCCESS)
+        this->set_error(this->_reps.get_error());
+    return ;
+}
+
+int ft_reputation::get_total_rep() const noexcept
+{
+    return (this->_total_rep);
+}
+
+void ft_reputation::set_total_rep(int rep) noexcept
+{
+    this->_total_rep = rep;
+    return ;
+}
+
+void ft_reputation::add_total_rep(int rep) noexcept
+{
+    this->_total_rep += rep;
+    return ;
+}
+
+int ft_reputation::get_current_rep() const noexcept
+{
+    return (this->_current_rep);
+}
+
+void ft_reputation::set_current_rep(int rep) noexcept
+{
+    this->_current_rep = rep;
+    return ;
+}
+
+void ft_reputation::add_current_rep(int rep) noexcept
+{
+    this->_current_rep += rep;
+    this->_total_rep += rep;
+    return ;
+}
+
+ft_map<int, int> &ft_reputation::get_milestones() noexcept
+{
+    return (this->_milestones);
+}
+
+const ft_map<int, int> &ft_reputation::get_milestones() const noexcept
+{
+    return (this->_milestones);
+}
+
+void ft_reputation::set_milestones(const ft_map<int, int> &milestones) noexcept
+{
+    this->_milestones = milestones;
+    return ;
+}
+
+int ft_reputation::get_milestone(int id) const noexcept
+{
+    const Pair<int, int> *entry = this->_milestones.find(id);
+    if (!entry)
+        return (0);
+    return (entry->value);
+}
+
+void ft_reputation::set_milestone(int id, int value) noexcept
+{
+    Pair<int, int> *entry = this->_milestones.find(id);
+    if (!entry)
+        this->_milestones.insert(id, value);
+    else
+        entry->value = value;
+    return ;
+}
+
+ft_map<int, int> &ft_reputation::get_reps() noexcept
+{
+    return (this->_reps);
+}
+
+const ft_map<int, int> &ft_reputation::get_reps() const noexcept
+{
+    return (this->_reps);
+}
+
+void ft_reputation::set_reps(const ft_map<int, int> &reps) noexcept
+{
+    this->_reps = reps;
+    return ;
+}
+
+int ft_reputation::get_rep(int id) const noexcept
+{
+    const Pair<int, int> *entry = this->_reps.find(id);
+    if (!entry)
+        return (0);
+    return (entry->value);
+}
+
+void ft_reputation::set_rep(int id, int value) noexcept
+{
+    Pair<int, int> *entry = this->_reps.find(id);
+    if (!entry)
+        this->_reps.insert(id, value);
+    else
+        entry->value = value;
+    return ;
+}
+
+int ft_reputation::get_error() const noexcept
+{
+    return (this->_error);
+}
+
+void ft_reputation::set_error(int err) const noexcept
+{
+    ft_errno = err;
+    this->_error = err;
+    return ;
+}

--- a/Game/reputation.hpp
+++ b/Game/reputation.hpp
@@ -1,0 +1,46 @@
+#ifndef REPUTATION_HPP
+# define REPUTATION_HPP
+
+#include "../Template/map.hpp"
+#include "../Errno/errno.hpp"
+
+class ft_reputation
+{
+    private:
+        ft_map<int, int> _milestones;
+        ft_map<int, int> _reps;
+        int             _total_rep;
+        int             _current_rep;
+        mutable int     _error;
+
+        void    set_error(int err) const noexcept;
+
+    public:
+        ft_reputation() noexcept;
+        ft_reputation(const ft_map<int, int> &milestones, int total = 0) noexcept;
+        virtual ~ft_reputation() = default;
+
+        int get_total_rep() const noexcept;
+        void set_total_rep(int rep) noexcept;
+        void add_total_rep(int rep) noexcept;
+
+        int get_current_rep() const noexcept;
+        void set_current_rep(int rep) noexcept;
+        void add_current_rep(int rep) noexcept;
+
+        ft_map<int, int>       &get_milestones() noexcept;
+        const ft_map<int, int> &get_milestones() const noexcept;
+        void set_milestones(const ft_map<int, int> &milestones) noexcept;
+        int get_milestone(int id) const noexcept;
+        void set_milestone(int id, int value) noexcept;
+
+        ft_map<int, int>       &get_reps() noexcept;
+        const ft_map<int, int> &get_reps() const noexcept;
+        void set_reps(const ft_map<int, int> &reps) noexcept;
+        int get_rep(int id) const noexcept;
+        void set_rep(int id, int value) noexcept;
+
+        int get_error() const noexcept;
+};
+
+#endif // REPUTATION_HPP


### PR DESCRIPTION
## Summary
- introduce `ft_reputation` class in the Game module
- track custom reputation milestones and totals
- hook new source into Game build system
- extend reputation to hold current rep and error state
- add reputation member to characters with error handling

## Testing
- `make -C Game`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_687911502628833182806004628da18f