### PR TITLE
Add cma_checked_free and tests

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -5,6 +5,7 @@
 
 void	*cma_malloc(std::size_t size) __attribute__ ((warn_unused_result, hot));
 void	cma_free(void* ptr) __attribute__ ((hot));
+int     cma_checked_free(void* ptr) __attribute__ ((warn_unused_result, hot));
 char	*cma_strdup(const char *string) __attribute__ ((warn_unused_result));
 void    *cma_memdup(const void *source, size_t size) __attribute__ ((warn_unused_result));
 void	*cma_calloc(std::size_t, std::size_t size) __attribute__ ((warn_unused_result));

--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -6,6 +6,7 @@ SRCS := cma_calloc.cpp \
         cma_memdup.cpp \
         cma_malloc.cpp \
         cma_free.cpp \
+        cma_free_checked.cpp \
         cma_realloc.cpp \
         cma_itoa.cpp \
         cma_itoa_base.cpp \

--- a/CMA/cma_free_checked.cpp
+++ b/CMA/cma_free_checked.cpp
@@ -1,0 +1,46 @@
+#include "CMA.hpp"
+#include "CMA_internal.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include "../Errno/errno.hpp"
+#include "../PThread/mutex.hpp"
+
+int cma_checked_free(void* ptr)
+{
+    if (OFFSWITCH == 1)
+    {
+        ::operator delete(ptr);
+        return (0);
+    }
+    if (!ptr)
+        return (0);
+    g_malloc_mutex.lock(THREAD_ID);
+    Page* page = page_list;
+    Block* found = ft_nullptr;
+    while (page && !found)
+    {
+        Block* block = page->blocks;
+        while (block)
+        {
+            char* data_start = reinterpret_cast<char*>(block) + sizeof(Block);
+            char* data_end = data_start + block->size;
+            if (reinterpret_cast<char*>(ptr) >= data_start &&
+                reinterpret_cast<char*>(ptr) < data_end)
+            {
+                found = block;
+                break;
+            }
+            block = block->next;
+        }
+        page = page->next;
+    }
+    if (!found)
+    {
+        g_malloc_mutex.unlock(THREAD_ID);
+        ft_errno = CMA_INVALID_PTR;
+        return (-1);
+    }
+    found->free = true;
+    merge_block(found);
+    g_malloc_mutex.unlock(THREAD_ID);
+    return (0);
+}

--- a/Errno/errno.hpp
+++ b/Errno/errno.hpp
@@ -8,7 +8,8 @@ extern thread_local int ft_errno;
 enum PTErrorCode
 {
     ER_SUCCESS = 0,
-	CMA_BAD_ALLOC,
+        CMA_BAD_ALLOC,
+    CMA_INVALID_PTR,
     PT_ERR_QUEUE_FULL,
     PT_ERR_MUTEX_NULLPTR,
     PT_ERR_MUTEX_OWNER,

--- a/Errno/strerror.cpp
+++ b/Errno/strerror.cpp
@@ -4,10 +4,12 @@
 
 const char* ft_strerror(int error_code)
 {
-	if (error_code == ER_SUCCESS)
+    if (error_code == ER_SUCCESS)
         return ("Operation successful");
-	if (error_code == CMA_BAD_ALLOC)
-		return ("Bad allocation");
+    if (error_code == CMA_BAD_ALLOC)
+                return ("Bad allocation");
+    else if (error_code == CMA_INVALID_PTR)
+                return ("Invalid CMA pointer");
 	else if (error_code == PT_ERR_QUEUE_FULL)
         return ("Wait queue is full");
 	else if (error_code == PT_ERR_MUTEX_NULLPTR)

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,7 +1,7 @@
 TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
-SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp
+SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/cma_tests.cpp
+++ b/Test/cma_tests.cpp
@@ -1,0 +1,30 @@
+#include "../CMA/CMA.hpp"
+#include "../Errno/errno.hpp"
+
+int test_cma_checked_free_basic(void)
+{
+    ft_errno = 0;
+    void *p = cma_malloc(32);
+    if (!p)
+        return 0;
+    int r = cma_checked_free(p);
+    return (r == 0 && ft_errno == ER_SUCCESS);
+}
+
+int test_cma_checked_free_offset(void)
+{
+    ft_errno = 0;
+    char *p = static_cast<char*>(cma_malloc(32));
+    if (!p)
+        return 0;
+    int r = cma_checked_free(p + 10);
+    return (r == 0 && ft_errno == ER_SUCCESS);
+}
+
+int test_cma_checked_free_invalid(void)
+{
+    int local;
+    ft_errno = 0;
+    int r = cma_checked_free(&local);
+    return (r == -1 && ft_errno == CMA_INVALID_PTR);
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -114,6 +114,9 @@ int test_pf_printf_modifiers(void);
 int test_get_next_line_basic(void);
 int test_get_next_line_empty(void);
 int test_ft_open_and_read_file(void);
+int test_cma_checked_free_basic(void);
+int test_cma_checked_free_offset(void);
+int test_cma_checked_free_invalid(void);
 
 int main(void)
 {
@@ -213,7 +216,10 @@ int main(void)
         { test_pf_printf_modifiers, "pf_printf modifiers" },
         { test_get_next_line_basic, "get_next_line basic" },
         { test_get_next_line_empty, "get_next_line empty" },
-        { test_ft_open_and_read_file, "open_and_read_file" }
+        { test_ft_open_and_read_file, "open_and_read_file" },
+        { test_cma_checked_free_basic, "cma_checked_free basic" },
+        { test_cma_checked_free_offset, "cma_checked_free offset" },
+        { test_cma_checked_free_invalid, "cma_checked_free invalid" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
     int index = 0;


### PR DESCRIPTION
## Summary
- add `cma_checked_free` that validates pointers before freeing
- register new `CMA_INVALID_PTR` error
- expose new message in `ft_strerror`
- build new CMA object and add unit tests

## Testing
- `make -C Test`
- `./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_687934eb04a483319e213332f38c3909