### PR TITLE
Add buff duration adder functions

### DIFF
--- a/Game/Makefile
+++ b/Game/Makefile
@@ -1,9 +1,9 @@
 TARGET := Game.a
 DEBUG_TARGET := Game_debug.a
 
-SRCS := map3d.cpp character.cpp item.cpp quest.cpp reputation.cpp
+SRCS := map3d.cpp character.cpp item.cpp quest.cpp reputation.cpp buff.cpp debuff.cpp
 
-HEADERS := map3d.hpp character.hpp item.hpp quest.hpp reputation.hpp
+HEADERS := map3d.hpp character.hpp item.hpp quest.hpp reputation.hpp buff.hpp debuff.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Game/buff.cpp
+++ b/Game/buff.cpp
@@ -1,0 +1,103 @@
+#include "buff.hpp"
+
+ft_buff::ft_buff() noexcept
+    : _id(0), _duration(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0)
+{
+    return ;
+}
+
+int ft_buff::get_id() const noexcept
+{
+    return (this->_id);
+}
+
+void ft_buff::set_id(int id) noexcept
+{
+    this->_id = id;
+    return ;
+}
+
+int ft_buff::get_duration() const noexcept
+{
+    return (this->_duration);
+}
+
+void ft_buff::set_duration(int duration) noexcept
+{
+    this->_duration = duration;
+    return ;
+}
+
+void ft_buff::add_duration(int duration) noexcept
+{
+    this->_duration += duration;
+    return ;
+}
+
+int ft_buff::get_modifier1() const noexcept
+{
+    return (this->_modifier1);
+}
+
+void ft_buff::set_modifier1(int mod) noexcept
+{
+    this->_modifier1 = mod;
+    return ;
+}
+
+void ft_buff::add_modifier1(int mod) noexcept
+{
+    this->_modifier1 += mod;
+    return ;
+}
+
+int ft_buff::get_modifier2() const noexcept
+{
+    return (this->_modifier2);
+}
+
+void ft_buff::set_modifier2(int mod) noexcept
+{
+    this->_modifier2 = mod;
+    return ;
+}
+
+void ft_buff::add_modifier2(int mod) noexcept
+{
+    this->_modifier2 += mod;
+    return ;
+}
+
+int ft_buff::get_modifier3() const noexcept
+{
+    return (this->_modifier3);
+}
+
+void ft_buff::set_modifier3(int mod) noexcept
+{
+    this->_modifier3 = mod;
+    return ;
+}
+
+void ft_buff::add_modifier3(int mod) noexcept
+{
+    this->_modifier3 += mod;
+    return ;
+}
+
+int ft_buff::get_modifier4() const noexcept
+{
+    return (this->_modifier4);
+}
+
+void ft_buff::set_modifier4(int mod) noexcept
+{
+    this->_modifier4 = mod;
+    return ;
+}
+
+void ft_buff::add_modifier4(int mod) noexcept
+{
+    this->_modifier4 += mod;
+    return ;
+}

--- a/Game/buff.hpp
+++ b/Game/buff.hpp
@@ -1,0 +1,42 @@
+#ifndef BUFF_HPP
+# define BUFF_HPP
+
+class ft_buff
+{
+    private:
+        int _id;
+        int _duration;
+        int _modifier1;
+        int _modifier2;
+        int _modifier3;
+        int _modifier4;
+
+    public:
+        ft_buff() noexcept;
+        virtual ~ft_buff() = default;
+
+        int get_id() const noexcept;
+        void set_id(int id) noexcept;
+
+        int get_duration() const noexcept;
+        void set_duration(int duration) noexcept;
+        void add_duration(int duration) noexcept;
+
+        int get_modifier1() const noexcept;
+        void set_modifier1(int mod) noexcept;
+        void add_modifier1(int mod) noexcept;
+
+        int get_modifier2() const noexcept;
+        void set_modifier2(int mod) noexcept;
+        void add_modifier2(int mod) noexcept;
+
+        int get_modifier3() const noexcept;
+        void set_modifier3(int mod) noexcept;
+        void add_modifier3(int mod) noexcept;
+
+        int get_modifier4() const noexcept;
+        void set_modifier4(int mod) noexcept;
+        void add_modifier4(int mod) noexcept;
+};
+
+#endif // BUFF_HPP

--- a/Game/character.cpp
+++ b/Game/character.cpp
@@ -6,9 +6,14 @@ ft_character::ft_character() noexcept
       _coins(0), _x(0), _y(0), _z(0),
       _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
       _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
-      _physical_res{0, 0}, _quests(), _reputation(), _error(ER_SUCCESS)
+      _physical_res{0, 0}, _buffs(), _debuffs(), _quests(), _reputation(),
+      _error(ER_SUCCESS)
 {
-    if (this->_quests.get_error() != ER_SUCCESS)
+    if (this->_buffs.get_error() != ER_SUCCESS)
+        this->set_error(this->_buffs.get_error());
+    else if (this->_debuffs.get_error() != ER_SUCCESS)
+        this->set_error(this->_debuffs.get_error());
+    else if (this->_quests.get_error() != ER_SUCCESS)
         this->set_error(this->_quests.get_error());
     else if (this->_reputation.get_error() != ER_SUCCESS)
         this->set_error(this->_reputation.get_error());
@@ -222,6 +227,26 @@ void ft_character::set_physical_res(int percent, int flat) noexcept
 {
     this->_physical_res = {percent, flat};
     return ;
+}
+
+ft_map<int, ft_buff> &ft_character::get_buffs() noexcept
+{
+    return (this->_buffs);
+}
+
+const ft_map<int, ft_buff> &ft_character::get_buffs() const noexcept
+{
+    return (this->_buffs);
+}
+
+ft_map<int, ft_debuff> &ft_character::get_debuffs() noexcept
+{
+    return (this->_debuffs);
+}
+
+const ft_map<int, ft_debuff> &ft_character::get_debuffs() const noexcept
+{
+    return (this->_debuffs);
 }
 
 ft_map<int, ft_quest> &ft_character::get_quests() noexcept

--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -4,6 +4,8 @@
 #include "../Template/map.hpp"
 #include "quest.hpp"
 #include "reputation.hpp"
+#include "buff.hpp"
+#include "debuff.hpp"
 #include "../Errno/errno.hpp"
 
 struct ft_resistance
@@ -34,6 +36,8 @@ class ft_character
         ft_resistance _earth_res;
         ft_resistance _chaos_res;
         ft_resistance _physical_res;
+        ft_map<int, ft_buff>  _buffs;
+        ft_map<int, ft_debuff> _debuffs;
         ft_map<int, ft_quest> _quests;
         ft_reputation         _reputation;
         mutable int           _error;
@@ -103,6 +107,12 @@ class ft_character
 
         ft_resistance get_physical_res() const noexcept;
         void set_physical_res(int percent, int flat) noexcept;
+
+        ft_map<int, ft_buff>       &get_buffs() noexcept;
+        const ft_map<int, ft_buff> &get_buffs() const noexcept;
+
+        ft_map<int, ft_debuff>       &get_debuffs() noexcept;
+        const ft_map<int, ft_debuff> &get_debuffs() const noexcept;
 
         ft_map<int, ft_quest>       &get_quests() noexcept;
         const ft_map<int, ft_quest> &get_quests() const noexcept;

--- a/Game/debuff.cpp
+++ b/Game/debuff.cpp
@@ -1,0 +1,103 @@
+#include "debuff.hpp"
+
+ft_debuff::ft_debuff() noexcept
+    : _id(0), _duration(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0)
+{
+    return ;
+}
+
+int ft_debuff::get_id() const noexcept
+{
+    return (this->_id);
+}
+
+void ft_debuff::set_id(int id) noexcept
+{
+    this->_id = id;
+    return ;
+}
+
+int ft_debuff::get_duration() const noexcept
+{
+    return (this->_duration);
+}
+
+void ft_debuff::set_duration(int duration) noexcept
+{
+    this->_duration = duration;
+    return ;
+}
+
+void ft_debuff::add_duration(int duration) noexcept
+{
+    this->_duration += duration;
+    return ;
+}
+
+int ft_debuff::get_modifier1() const noexcept
+{
+    return (this->_modifier1);
+}
+
+void ft_debuff::set_modifier1(int mod) noexcept
+{
+    this->_modifier1 = mod;
+    return ;
+}
+
+void ft_debuff::add_modifier1(int mod) noexcept
+{
+    this->_modifier1 += mod;
+    return ;
+}
+
+int ft_debuff::get_modifier2() const noexcept
+{
+    return (this->_modifier2);
+}
+
+void ft_debuff::set_modifier2(int mod) noexcept
+{
+    this->_modifier2 = mod;
+    return ;
+}
+
+void ft_debuff::add_modifier2(int mod) noexcept
+{
+    this->_modifier2 += mod;
+    return ;
+}
+
+int ft_debuff::get_modifier3() const noexcept
+{
+    return (this->_modifier3);
+}
+
+void ft_debuff::set_modifier3(int mod) noexcept
+{
+    this->_modifier3 = mod;
+    return ;
+}
+
+void ft_debuff::add_modifier3(int mod) noexcept
+{
+    this->_modifier3 += mod;
+    return ;
+}
+
+int ft_debuff::get_modifier4() const noexcept
+{
+    return (this->_modifier4);
+}
+
+void ft_debuff::set_modifier4(int mod) noexcept
+{
+    this->_modifier4 = mod;
+    return ;
+}
+
+void ft_debuff::add_modifier4(int mod) noexcept
+{
+    this->_modifier4 += mod;
+    return ;
+}

--- a/Game/debuff.hpp
+++ b/Game/debuff.hpp
@@ -1,0 +1,42 @@
+#ifndef DEBUFF_HPP
+# define DEBUFF_HPP
+
+class ft_debuff
+{
+    private:
+        int _id;
+        int _duration;
+        int _modifier1;
+        int _modifier2;
+        int _modifier3;
+        int _modifier4;
+
+    public:
+        ft_debuff() noexcept;
+        virtual ~ft_debuff() = default;
+
+        int get_id() const noexcept;
+        void set_id(int id) noexcept;
+
+        int get_duration() const noexcept;
+        void set_duration(int duration) noexcept;
+        void add_duration(int duration) noexcept;
+
+        int get_modifier1() const noexcept;
+        void set_modifier1(int mod) noexcept;
+        void add_modifier1(int mod) noexcept;
+
+        int get_modifier2() const noexcept;
+        void set_modifier2(int mod) noexcept;
+        void add_modifier2(int mod) noexcept;
+
+        int get_modifier3() const noexcept;
+        void set_modifier3(int mod) noexcept;
+        void add_modifier3(int mod) noexcept;
+
+        int get_modifier4() const noexcept;
+        void set_modifier4(int mod) noexcept;
+        void add_modifier4(int mod) noexcept;
+};
+
+#endif // DEBUFF_HPP

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ for the full interface of these templates.
 * **JSon** – simple JSON serialization helpers (`json_create_item`, `json_read_from_file`, etc.).
 * **File** – directory handling wrappers such as `ft_opendir` and `ft_readdir`.
 * **HTML** – minimal HTML node creation and searching utilities.
-* **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_map3d`, `ft_quest`).
+* **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_map3d`, `ft_quest`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration).
 
 The project is a work in progress and not every component is documented here.
 Consult the individual header files for precise behavior and additional


### PR DESCRIPTION
## Summary
- include `add_duration` methods in `ft_buff` and `ft_debuff`
- update headers and implementations with the new methods
- mention duration adders in Game README

## Testing
- `make -B`
- `make -C Test -B -j4`


------
https://chatgpt.com/codex/tasks/task_e_68795f52a07883319f7bfe820aaffebd