### PR TITLE
Interactive test selection using ReadLine

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,7 +1,7 @@
 TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
-SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp
+SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp game_tests.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/game_tests.cpp
+++ b/Test/game_tests.cpp
@@ -1,0 +1,66 @@
+#include "../Game/character.hpp"
+#include "../Game/buff.hpp"
+#include "../Game/debuff.hpp"
+#include "../Game/quest.hpp"
+#include "../Game/reputation.hpp"
+#include "../Game/map3d.hpp"
+#include "../Game/item.hpp"
+
+int test_game_simulation(void)
+{
+    ft_character hero;
+    hero.set_hit_points(50);
+    hero.set_might(10);
+    hero.set_armor(5);
+
+    ft_map3d world(3, 3, 1, 0);
+    world.set(1, 1, 0, 1);
+    hero.set_x(1);
+    hero.set_y(1);
+    hero.set_z(0);
+
+    ft_buff strength;
+    strength.set_id(1);
+    strength.set_modifier1(5);
+    hero.get_buffs().insert(strength.get_id(), strength);
+    hero.set_might(hero.get_might() + strength.get_modifier1());
+    if (hero.get_might() != 15)
+        return 0;
+
+    ft_debuff weakness;
+    weakness.set_id(2);
+    weakness.set_modifier1(-2);
+    hero.get_debuffs().insert(weakness.get_id(), weakness);
+    hero.set_armor(hero.get_armor() + weakness.get_modifier1());
+    if (hero.get_armor() != 3)
+        return 0;
+
+    ft_item sword;
+    sword.set_might(3);
+    hero.set_might(hero.get_might() + sword.get_might());
+    if (hero.get_might() != 18)
+        return 0;
+
+    ft_quest quest;
+    quest.set_id(1);
+    quest.set_phases(2);
+    hero.get_quests().insert(quest.get_id(), quest);
+    Pair<int, ft_quest>* qentry = hero.get_quests().find(1);
+    if (!qentry)
+        return 0;
+    qentry->value.set_current_phase(1);
+    if (qentry->value.get_current_phase() != 1)
+        return 0;
+
+    hero.get_reputation().set_milestone(1, 10);
+    hero.get_reputation().add_current_rep(4);
+    if (hero.get_reputation().get_current_rep() != 4 ||
+        hero.get_reputation().get_total_rep() != 4)
+        return 0;
+
+    if (world.get(hero.get_x(), hero.get_y(), hero.get_z()) != 1)
+        return 0;
+
+    return 1;
+}
+

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -1,5 +1,14 @@
 #include "../Libft/libft.hpp"
 #include "../Printf/printf.hpp"
+#include "../CMA/CMA.hpp"
+#include "../ReadLine/readline.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <sstream>
+#include <string>
+#include <vector>
 
 struct s_test
 {
@@ -117,6 +126,7 @@ int test_ft_open_and_read_file(void);
 int test_cma_checked_free_basic(void);
 int test_cma_checked_free_offset(void);
 int test_cma_checked_free_invalid(void);
+int test_game_simulation(void);
 
 int main(void)
 {
@@ -219,17 +229,54 @@ int main(void)
         { test_ft_open_and_read_file, "open_and_read_file" },
         { test_cma_checked_free_basic, "cma_checked_free basic" },
         { test_cma_checked_free_offset, "cma_checked_free offset" },
-        { test_cma_checked_free_invalid, "cma_checked_free invalid" }
+        { test_cma_checked_free_invalid, "cma_checked_free invalid" },
+        { test_game_simulation, "game simulation" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
-    int index = 0;
-    int passed = 0;
 
-    while (index < total)
+    while (true)
     {
-        run_test(index + 1, &tests[index], &passed);
-        index++;
+        std::printf("Available tests:\n");
+        for (int i = 0; i < total; ++i)
+            std::printf("%2d) %s\n", i + 1, tests[i].description);
+
+        char *line = rl_readline("Select tests to run (or 'all'): ");
+        if (!line)
+            break;
+        std::string input(line);
+        cma_free(line);
+        std::transform(input.begin(), input.end(), input.begin(),
+                       [](unsigned char c){ return std::tolower(c); });
+
+        std::vector<int> to_run;
+        if (input == "all")
+        {
+            for (int i = 0; i < total; ++i)
+                to_run.push_back(i + 1);
+        }
+        else
+        {
+            std::stringstream ss(input);
+            int value;
+            while (ss >> value)
+                if (value >= 1 && value <= total)
+                    to_run.push_back(value);
+        }
+
+        int passed = 0;
+        for (int idx : to_run)
+            run_test(idx, &tests[idx - 1], &passed);
+        std::printf("%d/%zu tests passed\n", passed, to_run.size());
+
+        char *again = rl_readline("Run more tests? (y/n): ");
+        if (!again)
+            break;
+        std::string answer(again);
+        cma_free(again);
+        std::transform(answer.begin(), answer.end(), answer.begin(),
+                       [](unsigned char c){ return std::tolower(c); });
+        if (answer.empty() || answer[0] != 'y')
+            break;
     }
-    pf_printf("%d/%d tests passed\n", passed, total);
     return (0);
 }


### PR DESCRIPTION
## Summary
- add `ReadLine` usage in test runner
- prompt user to select tests to run
- allow repeated runs until user exits
- add a simulation test for the Game library components

## Testing
- `make -C Test`
- `script -q -e -c "printf '100\nn\n' | ./Test/libft_tests" /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68796ad0f6308331a3f8c86bc0a932fa