### PR TITLE
Add simple item class and rename existing

### DIFF
--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -40,5 +40,6 @@
 #include "file/open_dir.hpp"
 #include "Game/map3d.hpp"
 #include "Game/character.hpp"
+#include "Game/item.hpp"
 
 #endif // FULL_LIBFT_HPP

--- a/Game/Makefile
+++ b/Game/Makefile
@@ -1,11 +1,11 @@
 TARGET := Game.a
 DEBUG_TARGET := Game_debug.a
 
-SRCS := map3d.cpp character.cpp item.cpp quest.cpp reputation.cpp buff.cpp debuff.cpp \
-        event.cpp world.cpp
+SRCS := map3d.cpp character.cpp gear.cpp quest.cpp reputation.cpp buff.cpp debuff.cpp \
+        event.cpp world.cpp item.cpp
 
-HEADERS := map3d.hpp character.hpp item.hpp quest.hpp reputation.hpp buff.hpp debuff.hpp \
-           event.hpp world.hpp
+HEADERS := map3d.hpp character.hpp gear.hpp quest.hpp reputation.hpp buff.hpp debuff.hpp \
+           event.hpp world.hpp item.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Game/buff.hpp
+++ b/Game/buff.hpp
@@ -39,4 +39,4 @@ class ft_buff
         void add_modifier4(int mod) noexcept;
 };
 
-#endif // BUFF_HPP
+#endif

--- a/Game/debuff.hpp
+++ b/Game/debuff.hpp
@@ -39,4 +39,4 @@ class ft_debuff
         void add_modifier4(int mod) noexcept;
 };
 
-#endif // DEBUFF_HPP
+#endif

--- a/Game/event.hpp
+++ b/Game/event.hpp
@@ -39,4 +39,4 @@ class ft_event
         void add_modifier4(int mod) noexcept;
 };
 
-#endif // EVENT_HPP
+#endif

--- a/Game/gear.cpp
+++ b/Game/gear.cpp
@@ -1,0 +1,343 @@
+#include "gear.hpp"
+
+ft_gear::ft_gear() noexcept
+    : _hit_points(0), _armor(0), _might(0), _agility(0),
+      _endurance(0), _reason(0), _insigh(0), _presence(0),
+      _coins(0),
+      _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
+      _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
+      _physical_res{0, 0},
+      _ability_1{0, 0, 0, 0, 0, 0}, _ability_2{0, 0, 0, 0, 0, 0}
+{
+    return ;
+}
+
+int ft_gear::get_hit_points() const noexcept
+{
+    return (this->_hit_points);
+}
+
+void ft_gear::set_hit_points(int hp) noexcept
+{
+    this->_hit_points = hp;
+    return ;
+}
+
+int ft_gear::get_armor() const noexcept
+{
+    return (this->_armor);
+}
+
+void ft_gear::set_armor(int armor) noexcept
+{
+    this->_armor = armor;
+    return ;
+}
+
+int ft_gear::get_might() const noexcept
+{
+    return (this->_might);
+}
+
+void ft_gear::set_might(int might) noexcept
+{
+    this->_might = might;
+    return ;
+}
+
+int ft_gear::get_agility() const noexcept
+{
+    return (this->_agility);
+}
+
+void ft_gear::set_agility(int agility) noexcept
+{
+    this->_agility = agility;
+    return ;
+}
+
+int ft_gear::get_endurance() const noexcept
+{
+    return (this->_endurance);
+}
+
+void ft_gear::set_endurance(int endurance) noexcept
+{
+    this->_endurance = endurance;
+    return ;
+}
+
+int ft_gear::get_reason() const noexcept
+{
+    return (this->_reason);
+}
+
+void ft_gear::set_reason(int reason) noexcept
+{
+    this->_reason = reason;
+    return ;
+}
+
+int ft_gear::get_insigh() const noexcept
+{
+    return (this->_insigh);
+}
+
+void ft_gear::set_insigh(int insigh) noexcept
+{
+    this->_insigh = insigh;
+    return ;
+}
+
+int ft_gear::get_presence() const noexcept
+{
+    return (this->_presence);
+}
+
+void ft_gear::set_presence(int presence) noexcept
+{
+    this->_presence = presence;
+    return ;
+}
+
+int ft_gear::get_coins() const noexcept
+{
+    return (this->_coins);
+}
+
+void ft_gear::set_coins(int coins) noexcept
+{
+    this->_coins = coins;
+    return ;
+}
+
+ft_resistance ft_gear::get_fire_res() const noexcept
+{
+    return (this->_fire_res);
+}
+
+void ft_gear::set_fire_res(int percent, int flat) noexcept
+{
+    this->_fire_res = {percent, flat};
+    return ;
+}
+
+ft_resistance ft_gear::get_frost_res() const noexcept
+{
+    return (this->_frost_res);
+}
+
+void ft_gear::set_frost_res(int percent, int flat) noexcept
+{
+    this->_frost_res = {percent, flat};
+    return ;
+}
+
+ft_resistance ft_gear::get_lightning_res() const noexcept
+{
+    return (this->_lightning_res);
+}
+
+void ft_gear::set_lightning_res(int percent, int flat) noexcept
+{
+    this->_lightning_res = {percent, flat};
+    return ;
+}
+
+ft_resistance ft_gear::get_air_res() const noexcept
+{
+    return (this->_air_res);
+}
+
+void ft_gear::set_air_res(int percent, int flat) noexcept
+{
+    this->_air_res = {percent, flat};
+    return ;
+}
+
+ft_resistance ft_gear::get_earth_res() const noexcept
+{
+    return (this->_earth_res);
+}
+
+void ft_gear::set_earth_res(int percent, int flat) noexcept
+{
+    this->_earth_res = {percent, flat};
+    return ;
+}
+
+ft_resistance ft_gear::get_chaos_res() const noexcept
+{
+    return (this->_chaos_res);
+}
+
+void ft_gear::set_chaos_res(int percent, int flat) noexcept
+{
+    this->_chaos_res = {percent, flat};
+    return ;
+}
+
+ft_resistance ft_gear::get_physical_res() const noexcept
+{
+    return (this->_physical_res);
+}
+
+void ft_gear::set_physical_res(int percent, int flat) noexcept
+{
+    this->_physical_res = {percent, flat};
+    return ;
+}
+
+ft_item_ability ft_gear::get_ability_1() const noexcept
+{
+    return (this->_ability_1);
+}
+
+void ft_gear::set_ability_1(const ft_item_ability &ability) noexcept
+{
+    this->_ability_1 = ability;
+    return ;
+}
+
+ft_item_ability ft_gear::get_ability_2() const noexcept
+{
+    return (this->_ability_2);
+}
+
+void ft_gear::set_ability_2(const ft_item_ability &ability) noexcept
+{
+    this->_ability_2 = ability;
+    return ;
+}
+
+uint8_t ft_gear::get_ability_1_stat_id() const noexcept
+{
+    return (this->_ability_1.stat_id);
+}
+
+void ft_gear::set_ability_1_stat_id(uint8_t id) noexcept
+{
+    this->_ability_1.stat_id = id;
+    return ;
+}
+
+int ft_gear::get_ability_1_main_modifier() const noexcept
+{
+    return (this->_ability_1.main_modifier);
+}
+
+void ft_gear::set_ability_1_main_modifier(int mod) noexcept
+{
+    this->_ability_1.main_modifier = mod;
+    return ;
+}
+
+int ft_gear::get_ability_1_bonus_modifier() const noexcept
+{
+    return (this->_ability_1.bonus_modifier);
+}
+
+void ft_gear::set_ability_1_bonus_modifier(int mod) noexcept
+{
+    this->_ability_1.bonus_modifier = mod;
+    return ;
+}
+
+int ft_gear::get_ability_1_duration() const noexcept
+{
+    return (this->_ability_1.duration);
+}
+
+void ft_gear::set_ability_1_duration(int duration) noexcept
+{
+    this->_ability_1.duration = duration;
+    return ;
+}
+
+int ft_gear::get_ability_1_duration_modifier() const noexcept
+{
+    return (this->_ability_1.duration_modifier);
+}
+
+void ft_gear::set_ability_1_duration_modifier(int mod) noexcept
+{
+    this->_ability_1.duration_modifier = mod;
+    return ;
+}
+
+int ft_gear::get_ability_1_stat_modifier() const noexcept
+{
+    return (this->_ability_1.stat_modifier);
+}
+
+void ft_gear::set_ability_1_stat_modifier(int mod) noexcept
+{
+    this->_ability_1.stat_modifier = mod;
+    return ;
+}
+
+uint8_t ft_gear::get_ability_2_stat_id() const noexcept
+{
+    return (this->_ability_2.stat_id);
+}
+
+void ft_gear::set_ability_2_stat_id(uint8_t id) noexcept
+{
+    this->_ability_2.stat_id = id;
+    return ;
+}
+
+int ft_gear::get_ability_2_main_modifier() const noexcept
+{
+    return (this->_ability_2.main_modifier);
+}
+
+void ft_gear::set_ability_2_main_modifier(int mod) noexcept
+{
+    this->_ability_2.main_modifier = mod;
+    return ;
+}
+
+int ft_gear::get_ability_2_bonus_modifier() const noexcept
+{
+    return (this->_ability_2.bonus_modifier);
+}
+
+void ft_gear::set_ability_2_bonus_modifier(int mod) noexcept
+{
+    this->_ability_2.bonus_modifier = mod;
+    return ;
+}
+
+int ft_gear::get_ability_2_duration() const noexcept
+{
+    return (this->_ability_2.duration);
+}
+
+void ft_gear::set_ability_2_duration(int duration) noexcept
+{
+    this->_ability_2.duration = duration;
+    return ;
+}
+
+int ft_gear::get_ability_2_duration_modifier() const noexcept
+{
+    return (this->_ability_2.duration_modifier);
+}
+
+void ft_gear::set_ability_2_duration_modifier(int mod) noexcept
+{
+    this->_ability_2.duration_modifier = mod;
+    return ;
+}
+
+int ft_gear::get_ability_2_stat_modifier() const noexcept
+{
+    return (this->_ability_2.stat_modifier);
+}
+
+void ft_gear::set_ability_2_stat_modifier(int mod) noexcept
+{
+    this->_ability_2.stat_modifier = mod;
+    return ;
+}

--- a/Game/gear.hpp
+++ b/Game/gear.hpp
@@ -1,0 +1,140 @@
+#ifndef GEAR_HPP
+# define GEAR_HPP
+
+#include <cstdint>
+#include "character.hpp"
+
+# define FT_STAT_MIGHT             0x01
+# define FT_STAT_AGILITY           0x02
+# define FT_STAT_ENDURANCE         0x03
+# define FT_STAT_REASON            0x04
+# define FT_STAT_INSIGH            0x05
+# define FT_STAT_PRESENCE          0x06
+
+struct ft_item_ability
+{
+    uint8_t    stat_id;
+    int        main_modifier;
+    int        bonus_modifier;
+    int        duration;
+    int        duration_modifier;
+    int        stat_modifier;
+};
+
+class ft_gear
+{
+    private:
+        int _hit_points;
+        int _armor;
+        int _might;
+        int _agility;
+        int _endurance;
+        int _reason;
+        int _insigh;
+        int _presence;
+        int _coins;
+        ft_resistance _fire_res;
+        ft_resistance _frost_res;
+        ft_resistance _lightning_res;
+        ft_resistance _air_res;
+        ft_resistance _earth_res;
+        ft_resistance _chaos_res;
+        ft_resistance _physical_res;
+        ft_item_ability _ability_1;
+        ft_item_ability _ability_2;
+
+    public:
+        ft_gear() noexcept;
+        virtual ~ft_gear() = default;
+
+        int get_hit_points() const noexcept;
+        void set_hit_points(int hp) noexcept;
+
+        int get_armor() const noexcept;
+        void set_armor(int armor) noexcept;
+
+        int get_might() const noexcept;
+        void set_might(int might) noexcept;
+
+        int get_agility() const noexcept;
+        void set_agility(int agility) noexcept;
+
+        int get_endurance() const noexcept;
+        void set_endurance(int endurance) noexcept;
+
+        int get_reason() const noexcept;
+        void set_reason(int reason) noexcept;
+
+        int get_insigh() const noexcept;
+        void set_insigh(int insigh) noexcept;
+
+        int get_presence() const noexcept;
+        void set_presence(int presence) noexcept;
+
+        int get_coins() const noexcept;
+        void set_coins(int coins) noexcept;
+
+        ft_resistance get_fire_res() const noexcept;
+        void set_fire_res(int percent, int flat) noexcept;
+
+        ft_resistance get_frost_res() const noexcept;
+        void set_frost_res(int percent, int flat) noexcept;
+
+        ft_resistance get_lightning_res() const noexcept;
+        void set_lightning_res(int percent, int flat) noexcept;
+
+        ft_resistance get_air_res() const noexcept;
+        void set_air_res(int percent, int flat) noexcept;
+
+        ft_resistance get_earth_res() const noexcept;
+        void set_earth_res(int percent, int flat) noexcept;
+
+        ft_resistance get_chaos_res() const noexcept;
+        void set_chaos_res(int percent, int flat) noexcept;
+
+        ft_resistance get_physical_res() const noexcept;
+        void set_physical_res(int percent, int flat) noexcept;
+
+        ft_item_ability get_ability_1() const noexcept;
+        void set_ability_1(const ft_item_ability &ability) noexcept;
+
+        ft_item_ability get_ability_2() const noexcept;
+        void set_ability_2(const ft_item_ability &ability) noexcept;
+
+        uint8_t get_ability_1_stat_id() const noexcept;
+        void set_ability_1_stat_id(uint8_t id) noexcept;
+
+        int get_ability_1_main_modifier() const noexcept;
+        void set_ability_1_main_modifier(int mod) noexcept;
+
+        int get_ability_1_bonus_modifier() const noexcept;
+        void set_ability_1_bonus_modifier(int mod) noexcept;
+
+        int get_ability_1_duration() const noexcept;
+        void set_ability_1_duration(int duration) noexcept;
+
+        int get_ability_1_duration_modifier() const noexcept;
+        void set_ability_1_duration_modifier(int mod) noexcept;
+
+        int get_ability_1_stat_modifier() const noexcept;
+        void set_ability_1_stat_modifier(int mod) noexcept;
+
+        uint8_t get_ability_2_stat_id() const noexcept;
+        void set_ability_2_stat_id(uint8_t id) noexcept;
+
+        int get_ability_2_main_modifier() const noexcept;
+        void set_ability_2_main_modifier(int mod) noexcept;
+
+        int get_ability_2_bonus_modifier() const noexcept;
+        void set_ability_2_bonus_modifier(int mod) noexcept;
+
+        int get_ability_2_duration() const noexcept;
+        void set_ability_2_duration(int duration) noexcept;
+
+        int get_ability_2_duration_modifier() const noexcept;
+        void set_ability_2_duration_modifier(int mod) noexcept;
+
+        int get_ability_2_stat_modifier() const noexcept;
+        void set_ability_2_stat_modifier(int mod) noexcept;
+};
+#endif

--- a/Game/item.cpp
+++ b/Game/item.cpp
@@ -1,343 +1,182 @@
 #include "item.hpp"
 
 ft_item::ft_item() noexcept
-    : _hit_points(0), _armor(0), _might(0), _agility(0),
-      _endurance(0), _reason(0), _insigh(0), _presence(0),
-      _coins(0),
-      _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
-      _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
-      _physical_res{0, 0},
-      _ability_1{0, 0, 0, 0, 0, 0}, _ability_2{0, 0, 0, 0, 0, 0}
+    : _max_stack(0), _current_stack(0), _item_id(0),
+      _modifier1{0, 0}, _modifier2{0, 0}, _modifier3{0, 0}, _modifier4{0, 0}
 {
     return ;
 }
 
-int ft_item::get_hit_points() const noexcept
+int ft_item::get_max_stack() const noexcept
 {
-    return (this->_hit_points);
+    return (this->_max_stack);
 }
 
-void ft_item::set_hit_points(int hp) noexcept
+void ft_item::set_max_stack(int max) noexcept
 {
-    this->_hit_points = hp;
+    this->_max_stack = max;
     return ;
 }
 
-int ft_item::get_armor() const noexcept
+int ft_item::get_current_stack() const noexcept
 {
-    return (this->_armor);
+    return (this->_current_stack);
 }
 
-void ft_item::set_armor(int armor) noexcept
+void ft_item::set_current_stack(int amount) noexcept
 {
-    this->_armor = armor;
+    this->_current_stack = amount;
     return ;
 }
 
-int ft_item::get_might() const noexcept
+void ft_item::add_to_stack(int amount) noexcept
 {
-    return (this->_might);
-}
-
-void ft_item::set_might(int might) noexcept
-{
-    this->_might = might;
+    this->_current_stack += amount;
+    if (this->_current_stack > this->_max_stack)
+        this->_current_stack = this->_max_stack;
     return ;
 }
 
-int ft_item::get_agility() const noexcept
+int ft_item::get_item_id() const noexcept
 {
-    return (this->_agility);
+    return (this->_item_id);
 }
 
-void ft_item::set_agility(int agility) noexcept
+void ft_item::set_item_id(int id) noexcept
 {
-    this->_agility = agility;
+    this->_item_id = id;
     return ;
 }
 
-int ft_item::get_endurance() const noexcept
+ft_item_modifier ft_item::get_modifier1() const noexcept
 {
-    return (this->_endurance);
+    return (this->_modifier1);
 }
 
-void ft_item::set_endurance(int endurance) noexcept
+void ft_item::set_modifier1(const ft_item_modifier &mod) noexcept
 {
-    this->_endurance = endurance;
+    this->_modifier1 = mod;
     return ;
 }
 
-int ft_item::get_reason() const noexcept
+int ft_item::get_modifier1_id() const noexcept
 {
-    return (this->_reason);
+    return (this->_modifier1.id);
 }
 
-void ft_item::set_reason(int reason) noexcept
+void ft_item::set_modifier1_id(int id) noexcept
 {
-    this->_reason = reason;
+    this->_modifier1.id = id;
     return ;
 }
 
-int ft_item::get_insigh() const noexcept
+int ft_item::get_modifier1_value() const noexcept
 {
-    return (this->_insigh);
+    return (this->_modifier1.value);
 }
 
-void ft_item::set_insigh(int insigh) noexcept
+void ft_item::set_modifier1_value(int value) noexcept
 {
-    this->_insigh = insigh;
+    this->_modifier1.value = value;
     return ;
 }
 
-int ft_item::get_presence() const noexcept
+ft_item_modifier ft_item::get_modifier2() const noexcept
 {
-    return (this->_presence);
+    return (this->_modifier2);
 }
 
-void ft_item::set_presence(int presence) noexcept
+void ft_item::set_modifier2(const ft_item_modifier &mod) noexcept
 {
-    this->_presence = presence;
+    this->_modifier2 = mod;
     return ;
 }
 
-int ft_item::get_coins() const noexcept
+int ft_item::get_modifier2_id() const noexcept
 {
-    return (this->_coins);
+    return (this->_modifier2.id);
 }
 
-void ft_item::set_coins(int coins) noexcept
+void ft_item::set_modifier2_id(int id) noexcept
 {
-    this->_coins = coins;
+    this->_modifier2.id = id;
     return ;
 }
 
-ft_resistance ft_item::get_fire_res() const noexcept
+int ft_item::get_modifier2_value() const noexcept
 {
-    return (this->_fire_res);
+    return (this->_modifier2.value);
 }
 
-void ft_item::set_fire_res(int percent, int flat) noexcept
+void ft_item::set_modifier2_value(int value) noexcept
 {
-    this->_fire_res = {percent, flat};
+    this->_modifier2.value = value;
     return ;
 }
 
-ft_resistance ft_item::get_frost_res() const noexcept
+ft_item_modifier ft_item::get_modifier3() const noexcept
 {
-    return (this->_frost_res);
+    return (this->_modifier3);
 }
 
-void ft_item::set_frost_res(int percent, int flat) noexcept
+void ft_item::set_modifier3(const ft_item_modifier &mod) noexcept
 {
-    this->_frost_res = {percent, flat};
+    this->_modifier3 = mod;
     return ;
 }
 
-ft_resistance ft_item::get_lightning_res() const noexcept
+int ft_item::get_modifier3_id() const noexcept
 {
-    return (this->_lightning_res);
+    return (this->_modifier3.id);
 }
 
-void ft_item::set_lightning_res(int percent, int flat) noexcept
+void ft_item::set_modifier3_id(int id) noexcept
 {
-    this->_lightning_res = {percent, flat};
+    this->_modifier3.id = id;
     return ;
 }
 
-ft_resistance ft_item::get_air_res() const noexcept
+int ft_item::get_modifier3_value() const noexcept
 {
-    return (this->_air_res);
+    return (this->_modifier3.value);
 }
 
-void ft_item::set_air_res(int percent, int flat) noexcept
+void ft_item::set_modifier3_value(int value) noexcept
 {
-    this->_air_res = {percent, flat};
+    this->_modifier3.value = value;
     return ;
 }
 
-ft_resistance ft_item::get_earth_res() const noexcept
+ft_item_modifier ft_item::get_modifier4() const noexcept
 {
-    return (this->_earth_res);
+    return (this->_modifier4);
 }
 
-void ft_item::set_earth_res(int percent, int flat) noexcept
+void ft_item::set_modifier4(const ft_item_modifier &mod) noexcept
 {
-    this->_earth_res = {percent, flat};
+    this->_modifier4 = mod;
     return ;
 }
 
-ft_resistance ft_item::get_chaos_res() const noexcept
+int ft_item::get_modifier4_id() const noexcept
 {
-    return (this->_chaos_res);
+    return (this->_modifier4.id);
 }
 
-void ft_item::set_chaos_res(int percent, int flat) noexcept
+void ft_item::set_modifier4_id(int id) noexcept
 {
-    this->_chaos_res = {percent, flat};
+    this->_modifier4.id = id;
     return ;
 }
 
-ft_resistance ft_item::get_physical_res() const noexcept
+int ft_item::get_modifier4_value() const noexcept
 {
-    return (this->_physical_res);
+    return (this->_modifier4.value);
 }
 
-void ft_item::set_physical_res(int percent, int flat) noexcept
+void ft_item::set_modifier4_value(int value) noexcept
 {
-    this->_physical_res = {percent, flat};
+    this->_modifier4.value = value;
     return ;
 }
 
-ft_item_ability ft_item::get_ability_1() const noexcept
-{
-    return (this->_ability_1);
-}
-
-void ft_item::set_ability_1(const ft_item_ability &ability) noexcept
-{
-    this->_ability_1 = ability;
-    return ;
-}
-
-ft_item_ability ft_item::get_ability_2() const noexcept
-{
-    return (this->_ability_2);
-}
-
-void ft_item::set_ability_2(const ft_item_ability &ability) noexcept
-{
-    this->_ability_2 = ability;
-    return ;
-}
-
-uint8_t ft_item::get_ability_1_stat_id() const noexcept
-{
-    return (this->_ability_1.stat_id);
-}
-
-void ft_item::set_ability_1_stat_id(uint8_t id) noexcept
-{
-    this->_ability_1.stat_id = id;
-    return ;
-}
-
-int ft_item::get_ability_1_main_modifier() const noexcept
-{
-    return (this->_ability_1.main_modifier);
-}
-
-void ft_item::set_ability_1_main_modifier(int mod) noexcept
-{
-    this->_ability_1.main_modifier = mod;
-    return ;
-}
-
-int ft_item::get_ability_1_bonus_modifier() const noexcept
-{
-    return (this->_ability_1.bonus_modifier);
-}
-
-void ft_item::set_ability_1_bonus_modifier(int mod) noexcept
-{
-    this->_ability_1.bonus_modifier = mod;
-    return ;
-}
-
-int ft_item::get_ability_1_duration() const noexcept
-{
-    return (this->_ability_1.duration);
-}
-
-void ft_item::set_ability_1_duration(int duration) noexcept
-{
-    this->_ability_1.duration = duration;
-    return ;
-}
-
-int ft_item::get_ability_1_duration_modifier() const noexcept
-{
-    return (this->_ability_1.duration_modifier);
-}
-
-void ft_item::set_ability_1_duration_modifier(int mod) noexcept
-{
-    this->_ability_1.duration_modifier = mod;
-    return ;
-}
-
-int ft_item::get_ability_1_stat_modifier() const noexcept
-{
-    return (this->_ability_1.stat_modifier);
-}
-
-void ft_item::set_ability_1_stat_modifier(int mod) noexcept
-{
-    this->_ability_1.stat_modifier = mod;
-    return ;
-}
-
-uint8_t ft_item::get_ability_2_stat_id() const noexcept
-{
-    return (this->_ability_2.stat_id);
-}
-
-void ft_item::set_ability_2_stat_id(uint8_t id) noexcept
-{
-    this->_ability_2.stat_id = id;
-    return ;
-}
-
-int ft_item::get_ability_2_main_modifier() const noexcept
-{
-    return (this->_ability_2.main_modifier);
-}
-
-void ft_item::set_ability_2_main_modifier(int mod) noexcept
-{
-    this->_ability_2.main_modifier = mod;
-    return ;
-}
-
-int ft_item::get_ability_2_bonus_modifier() const noexcept
-{
-    return (this->_ability_2.bonus_modifier);
-}
-
-void ft_item::set_ability_2_bonus_modifier(int mod) noexcept
-{
-    this->_ability_2.bonus_modifier = mod;
-    return ;
-}
-
-int ft_item::get_ability_2_duration() const noexcept
-{
-    return (this->_ability_2.duration);
-}
-
-void ft_item::set_ability_2_duration(int duration) noexcept
-{
-    this->_ability_2.duration = duration;
-    return ;
-}
-
-int ft_item::get_ability_2_duration_modifier() const noexcept
-{
-    return (this->_ability_2.duration_modifier);
-}
-
-void ft_item::set_ability_2_duration_modifier(int mod) noexcept
-{
-    this->_ability_2.duration_modifier = mod;
-    return ;
-}
-
-int ft_item::get_ability_2_stat_modifier() const noexcept
-{
-    return (this->_ability_2.stat_modifier);
-}
-
-void ft_item::set_ability_2_stat_modifier(int mod) noexcept
-{
-    this->_ability_2.stat_modifier = mod;
-    return ;
-}

--- a/Game/item.hpp
+++ b/Game/item.hpp
@@ -1,141 +1,64 @@
 #ifndef ITEM_HPP
-# define ITEM_HPP
+#define ITEM_HPP
 
-#include <cstdint>
-#include "character.hpp"
-
-// Stat identifiers (8-bit)
-# define FT_STAT_MIGHT             0x01
-# define FT_STAT_AGILITY           0x02
-# define FT_STAT_ENDURANCE         0x03
-# define FT_STAT_REASON            0x04
-# define FT_STAT_INSIGH            0x05
-# define FT_STAT_PRESENCE          0x06
-
-struct ft_item_ability
+struct ft_item_modifier
 {
-    uint8_t    stat_id;
-    int        main_modifier;
-    int        bonus_modifier;
-    int        duration;
-    int        duration_modifier;
-    int        stat_modifier;
+    int id;
+    int value;
 };
 
 class ft_item
 {
     private:
-        int _hit_points;
-        int _armor;
-        int _might;
-        int _agility;
-        int _endurance;
-        int _reason;
-        int _insigh;
-        int _presence;
-        int _coins;
-        ft_resistance _fire_res;
-        ft_resistance _frost_res;
-        ft_resistance _lightning_res;
-        ft_resistance _air_res;
-        ft_resistance _earth_res;
-        ft_resistance _chaos_res;
-        ft_resistance _physical_res;
-        ft_item_ability _ability_1;
-        ft_item_ability _ability_2;
+        int _max_stack;
+        int _current_stack;
+        int _item_id;
+        ft_item_modifier _modifier1;
+        ft_item_modifier _modifier2;
+        ft_item_modifier _modifier3;
+        ft_item_modifier _modifier4;
 
     public:
         ft_item() noexcept;
         virtual ~ft_item() = default;
 
-        int get_hit_points() const noexcept;
-        void set_hit_points(int hp) noexcept;
+        int get_max_stack() const noexcept;
+        void set_max_stack(int max) noexcept;
 
-        int get_armor() const noexcept;
-        void set_armor(int armor) noexcept;
+        int get_current_stack() const noexcept;
+        void set_current_stack(int amount) noexcept;
+        void add_to_stack(int amount) noexcept;
 
-        int get_might() const noexcept;
-        void set_might(int might) noexcept;
+        int get_item_id() const noexcept;
+        void set_item_id(int id) noexcept;
 
-        int get_agility() const noexcept;
-        void set_agility(int agility) noexcept;
+        ft_item_modifier get_modifier1() const noexcept;
+        void set_modifier1(const ft_item_modifier &mod) noexcept;
+        int get_modifier1_id() const noexcept;
+        void set_modifier1_id(int id) noexcept;
+        int get_modifier1_value() const noexcept;
+        void set_modifier1_value(int value) noexcept;
 
-        int get_endurance() const noexcept;
-        void set_endurance(int endurance) noexcept;
+        ft_item_modifier get_modifier2() const noexcept;
+        void set_modifier2(const ft_item_modifier &mod) noexcept;
+        int get_modifier2_id() const noexcept;
+        void set_modifier2_id(int id) noexcept;
+        int get_modifier2_value() const noexcept;
+        void set_modifier2_value(int value) noexcept;
 
-        int get_reason() const noexcept;
-        void set_reason(int reason) noexcept;
+        ft_item_modifier get_modifier3() const noexcept;
+        void set_modifier3(const ft_item_modifier &mod) noexcept;
+        int get_modifier3_id() const noexcept;
+        void set_modifier3_id(int id) noexcept;
+        int get_modifier3_value() const noexcept;
+        void set_modifier3_value(int value) noexcept;
 
-        int get_insigh() const noexcept;
-        void set_insigh(int insigh) noexcept;
-
-        int get_presence() const noexcept;
-        void set_presence(int presence) noexcept;
-
-        int get_coins() const noexcept;
-        void set_coins(int coins) noexcept;
-
-        ft_resistance get_fire_res() const noexcept;
-        void set_fire_res(int percent, int flat) noexcept;
-
-        ft_resistance get_frost_res() const noexcept;
-        void set_frost_res(int percent, int flat) noexcept;
-
-        ft_resistance get_lightning_res() const noexcept;
-        void set_lightning_res(int percent, int flat) noexcept;
-
-        ft_resistance get_air_res() const noexcept;
-        void set_air_res(int percent, int flat) noexcept;
-
-        ft_resistance get_earth_res() const noexcept;
-        void set_earth_res(int percent, int flat) noexcept;
-
-        ft_resistance get_chaos_res() const noexcept;
-        void set_chaos_res(int percent, int flat) noexcept;
-
-        ft_resistance get_physical_res() const noexcept;
-        void set_physical_res(int percent, int flat) noexcept;
-
-        ft_item_ability get_ability_1() const noexcept;
-        void set_ability_1(const ft_item_ability &ability) noexcept;
-
-        ft_item_ability get_ability_2() const noexcept;
-        void set_ability_2(const ft_item_ability &ability) noexcept;
-
-        uint8_t get_ability_1_stat_id() const noexcept;
-        void set_ability_1_stat_id(uint8_t id) noexcept;
-
-        int get_ability_1_main_modifier() const noexcept;
-        void set_ability_1_main_modifier(int mod) noexcept;
-
-        int get_ability_1_bonus_modifier() const noexcept;
-        void set_ability_1_bonus_modifier(int mod) noexcept;
-
-        int get_ability_1_duration() const noexcept;
-        void set_ability_1_duration(int duration) noexcept;
-
-        int get_ability_1_duration_modifier() const noexcept;
-        void set_ability_1_duration_modifier(int mod) noexcept;
-
-        int get_ability_1_stat_modifier() const noexcept;
-        void set_ability_1_stat_modifier(int mod) noexcept;
-
-        uint8_t get_ability_2_stat_id() const noexcept;
-        void set_ability_2_stat_id(uint8_t id) noexcept;
-
-        int get_ability_2_main_modifier() const noexcept;
-        void set_ability_2_main_modifier(int mod) noexcept;
-
-        int get_ability_2_bonus_modifier() const noexcept;
-        void set_ability_2_bonus_modifier(int mod) noexcept;
-
-        int get_ability_2_duration() const noexcept;
-        void set_ability_2_duration(int duration) noexcept;
-
-        int get_ability_2_duration_modifier() const noexcept;
-        void set_ability_2_duration_modifier(int mod) noexcept;
-
-        int get_ability_2_stat_modifier() const noexcept;
-        void set_ability_2_stat_modifier(int mod) noexcept;
+        ft_item_modifier get_modifier4() const noexcept;
+        void set_modifier4(const ft_item_modifier &mod) noexcept;
+        int get_modifier4_id() const noexcept;
+        void set_modifier4_id(int id) noexcept;
+        int get_modifier4_value() const noexcept;
+        void set_modifier4_value(int value) noexcept;
 };
-#endif // ITEM_HPP
+
+#endif

--- a/Game/quest.hpp
+++ b/Game/quest.hpp
@@ -22,4 +22,4 @@ class ft_quest
         void set_current_phase(int phase) noexcept;
 };
 
-#endif // QUEST_HPP
+#endif

--- a/Game/reputation.hpp
+++ b/Game/reputation.hpp
@@ -43,4 +43,4 @@ class ft_reputation
         int get_error() const noexcept;
 };
 
-#endif // REPUTATION_HPP
+#endif

--- a/Game/world.hpp
+++ b/Game/world.hpp
@@ -23,4 +23,4 @@ class ft_world
         int get_error() const noexcept;
 };
 
-#endif // WORLD_HPP
+#endif

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ for the full interface of these templates.
 * **JSon** – simple JSON serialization helpers (`json_create_item`, `json_read_from_file`, etc.).
 * **File** – directory handling wrappers such as `ft_opendir` and `ft_readdir`.
 * **HTML** – minimal HTML node creation and searching utilities.
-* **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_map3d`, `ft_quest`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration).
+* **Game** – basic game related classes (`ft_character`, `ft_gear`, `ft_item`, `ft_map3d`, `ft_quest`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_item` provides a simple item container with stack counts and modifier identifiers.
 
 The project is a work in progress and not every component is documented here.
 Consult the individual header files for precise behavior and additional

--- a/Test/game_tests.cpp
+++ b/Test/game_tests.cpp
@@ -4,6 +4,7 @@
 #include "../Game/quest.hpp"
 #include "../Game/reputation.hpp"
 #include "../Game/map3d.hpp"
+#include "../Game/gear.hpp"
 #include "../Game/item.hpp"
 
 int test_game_simulation(void)
@@ -35,7 +36,7 @@ int test_game_simulation(void)
     if (hero.get_armor() != 3)
         return 0;
 
-    ft_item sword;
+    ft_gear sword;
     sword.set_might(3);
     hero.set_might(hero.get_might() + sword.get_might());
     if (hero.get_might() != 18)
@@ -64,3 +65,18 @@ int test_game_simulation(void)
     return 1;
 }
 
+
+int test_item_basic(void)
+{
+    ft_item item;
+    item.set_item_id(1);
+    item.set_max_stack(10);
+    item.set_current_stack(3);
+    item.set_modifier1_id(5);
+    item.set_modifier1_value(2);
+    if (item.get_item_id() != 1 || item.get_max_stack() != 10 ||
+        item.get_current_stack() != 3 || item.get_modifier1_id() != 5 ||
+        item.get_modifier1_value() != 2)
+        return 0;
+    return 1;
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -127,6 +127,7 @@ int test_cma_checked_free_basic(void);
 int test_cma_checked_free_offset(void);
 int test_cma_checked_free_invalid(void);
 int test_game_simulation(void);
+int test_item_basic(void);
 
 int main(void)
 {
@@ -230,7 +231,8 @@ int main(void)
         { test_cma_checked_free_basic, "cma_checked_free basic" },
         { test_cma_checked_free_offset, "cma_checked_free offset" },
         { test_cma_checked_free_invalid, "cma_checked_free invalid" },
-        { test_game_simulation, "game simulation" }
+        { test_game_simulation, "game simulation" },
+        { test_item_basic, "item basic" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
 


### PR DESCRIPTION
## Summary
- rename the previous `ft_item` class to `ft_gear`
- rename `ft_stack_item` to `ft_item` and move files accordingly
- expose the new header through `FullLibft.hpp`
- update build files, README and tests for the new names
- remove comments from game header files

## Testing
- `make -C Test`
- `make -C Test clean`
- `make fclean`


------
https://chatgpt.com/codex/tasks/task_e_6879fc967ec48331913a5f0507269e02