### PR TITLE
Add upgrade system

### DIFF
--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -43,6 +43,7 @@
 #include "Game/item.hpp"
 #include "Game/buff.hpp"
 #include "Game/debuff.hpp"
+#include "Game/upgrade.hpp"
 #include "Game/event.hpp"
 #include "Game/inventory.hpp"
 #include "Game/quest.hpp"

--- a/Game/Makefile
+++ b/Game/Makefile
@@ -2,10 +2,10 @@ TARGET := Game.a
 DEBUG_TARGET := Game_debug.a
 
 SRCS := map3d.cpp character.cpp quest.cpp reputation.cpp buff.cpp debuff.cpp \
-        event.cpp world.cpp item.cpp inventory.cpp
+        upgrade.cpp event.cpp world.cpp item.cpp inventory.cpp
 
 HEADERS := map3d.hpp character.hpp quest.hpp reputation.hpp buff.hpp debuff.hpp \
-           event.hpp world.hpp item.hpp inventory.hpp
+           upgrade.hpp event.hpp world.hpp item.hpp inventory.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Game/character.cpp
+++ b/Game/character.cpp
@@ -6,13 +6,15 @@ ft_character::ft_character() noexcept
       _coins(0), _x(0), _y(0), _z(0),
       _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
       _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
-      _physical_res{0, 0}, _buffs(), _debuffs(), _quests(), _reputation(),
+      _physical_res{0, 0}, _buffs(), _debuffs(), _upgrades(), _quests(), _reputation(),
       _error(ER_SUCCESS)
 {
     if (this->_buffs.get_error() != ER_SUCCESS)
         this->set_error(this->_buffs.get_error());
     else if (this->_debuffs.get_error() != ER_SUCCESS)
         this->set_error(this->_debuffs.get_error());
+    else if (this->_upgrades.get_error() != ER_SUCCESS)
+        this->set_error(this->_upgrades.get_error());
     else if (this->_quests.get_error() != ER_SUCCESS)
         this->set_error(this->_quests.get_error());
     else if (this->_reputation.get_error() != ER_SUCCESS)
@@ -248,6 +250,17 @@ const ft_map<int, ft_debuff> &ft_character::get_debuffs() const noexcept
 {
     return (this->_debuffs);
 }
+
+ft_map<int, ft_upgrade> &ft_character::get_upgrades() noexcept
+{
+    return (this->_upgrades);
+}
+
+const ft_map<int, ft_upgrade> &ft_character::get_upgrades() const noexcept
+{
+    return (this->_upgrades);
+}
+
 
 ft_map<int, ft_quest> &ft_character::get_quests() noexcept
 {

--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -6,6 +6,7 @@
 #include "reputation.hpp"
 #include "buff.hpp"
 #include "debuff.hpp"
+#include "upgrade.hpp"
 #include "inventory.hpp"
 
 struct ft_resistance
@@ -39,6 +40,7 @@ class ft_character
         ft_resistance 			_physical_res;
         ft_map<int, ft_buff>  	_buffs;
         ft_map<int, ft_debuff>	 _debuffs;
+        ft_map<int, ft_upgrade>        _upgrades;
         ft_map<int, ft_quest> 	_quests;
         ft_reputation         	_reputation;
 		ft_inventory			_inventory;
@@ -115,6 +117,8 @@ class ft_character
 
         ft_map<int, ft_debuff>       &get_debuffs() noexcept;
         const ft_map<int, ft_debuff> &get_debuffs() const noexcept;
+        ft_map<int, ft_upgrade>       &get_upgrades() noexcept;
+        const ft_map<int, ft_upgrade> &get_upgrades() const noexcept;
 
         ft_map<int, ft_quest>       &get_quests() noexcept;
         const ft_map<int, ft_quest> &get_quests() const noexcept;

--- a/Game/upgrade.cpp
+++ b/Game/upgrade.cpp
@@ -1,0 +1,118 @@
+#include "upgrade.hpp"
+
+ft_upgrade::ft_upgrade() noexcept
+    : _id(0), _current_level(0), _max_level(0),
+      _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0)
+{
+    return ;
+}
+
+int ft_upgrade::get_id() const noexcept
+{
+    return (this->_id);
+}
+
+void ft_upgrade::set_id(int id) noexcept
+{
+    this->_id = id;
+    return ;
+}
+
+uint16_t ft_upgrade::get_current_level() const noexcept
+{
+    return (this->_current_level);
+}
+
+void ft_upgrade::set_current_level(uint16_t level) noexcept
+{
+    this->_current_level = level;
+    return ;
+}
+
+void ft_upgrade::add_level(uint16_t level) noexcept
+{
+    this->_current_level += level;
+    if (this->_current_level > this->_max_level)
+        this->_current_level = this->_max_level;
+    return ;
+}
+
+uint16_t ft_upgrade::get_max_level() const noexcept
+{
+    return (this->_max_level);
+}
+
+void ft_upgrade::set_max_level(uint16_t level) noexcept
+{
+    this->_max_level = level;
+    return ;
+}
+
+int ft_upgrade::get_modifier1() const noexcept
+{
+    return (this->_modifier1);
+}
+
+void ft_upgrade::set_modifier1(int mod) noexcept
+{
+    this->_modifier1 = mod;
+    return ;
+}
+
+void ft_upgrade::add_modifier1(int mod) noexcept
+{
+    this->_modifier1 += mod;
+    return ;
+}
+
+int ft_upgrade::get_modifier2() const noexcept
+{
+    return (this->_modifier2);
+}
+
+void ft_upgrade::set_modifier2(int mod) noexcept
+{
+    this->_modifier2 = mod;
+    return ;
+}
+
+void ft_upgrade::add_modifier2(int mod) noexcept
+{
+    this->_modifier2 += mod;
+    return ;
+}
+
+int ft_upgrade::get_modifier3() const noexcept
+{
+    return (this->_modifier3);
+}
+
+void ft_upgrade::set_modifier3(int mod) noexcept
+{
+    this->_modifier3 = mod;
+    return ;
+}
+
+void ft_upgrade::add_modifier3(int mod) noexcept
+{
+    this->_modifier3 += mod;
+    return ;
+}
+
+int ft_upgrade::get_modifier4() const noexcept
+{
+    return (this->_modifier4);
+}
+
+void ft_upgrade::set_modifier4(int mod) noexcept
+{
+    this->_modifier4 = mod;
+    return ;
+}
+
+void ft_upgrade::add_modifier4(int mod) noexcept
+{
+    this->_modifier4 += mod;
+    return ;
+}
+

--- a/Game/upgrade.hpp
+++ b/Game/upgrade.hpp
@@ -1,0 +1,48 @@
+#ifndef UPGRADE_HPP
+# define UPGRADE_HPP
+
+#include <cstdint>
+
+class ft_upgrade
+{
+    private:
+        int      _id;
+        uint16_t _current_level;
+        uint16_t _max_level;
+        int      _modifier1;
+        int      _modifier2;
+        int      _modifier3;
+        int      _modifier4;
+
+    public:
+        ft_upgrade() noexcept;
+        virtual ~ft_upgrade() = default;
+
+        int get_id() const noexcept;
+        void set_id(int id) noexcept;
+
+        uint16_t get_current_level() const noexcept;
+        void set_current_level(uint16_t level) noexcept;
+        void add_level(uint16_t level) noexcept;
+
+        uint16_t get_max_level() const noexcept;
+        void set_max_level(uint16_t level) noexcept;
+
+        int get_modifier1() const noexcept;
+        void set_modifier1(int mod) noexcept;
+        void add_modifier1(int mod) noexcept;
+
+        int get_modifier2() const noexcept;
+        void set_modifier2(int mod) noexcept;
+        void add_modifier2(int mod) noexcept;
+
+        int get_modifier3() const noexcept;
+        void set_modifier3(int mod) noexcept;
+        void add_modifier3(int mod) noexcept;
+
+        int get_modifier4() const noexcept;
+        void set_modifier4(int mod) noexcept;
+        void add_modifier4(int mod) noexcept;
+};
+
+#endif


### PR DESCRIPTION
## Summary
- add new `ft_upgrade` class with tier tracking and modifiers
- store upgrades in `ft_character`
- expose upgrade accessors
- build support in Game Makefile and FullLibft header
- rename `tier` fields to `current_level` and `max_level`

## Testing
- `make -C Game`


------
https://chatgpt.com/codex/tasks/task_e_687a954bcd1083318c9b3eb8e5d8e3fd