### PR TITLE
Expand game simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Located in `CMA/`. Header: `CMA.hpp`. Provides memory helpers such as
 ```
 void   *cma_malloc(std::size_t size);
 void    cma_free(void *ptr);
+int     cma_checked_free(void *ptr);
 char   *cma_strdup(const char *string);
 void   *cma_memdup(const void *src, size_t size);
 void   *cma_calloc(std::size_t nmemb, std::size_t size);
@@ -261,7 +262,7 @@ for the full interface of these templates.
 * **JSon** – simple JSON serialization helpers (`json_create_item`, `json_read_from_file`, etc.).
 * **File** – directory handling wrappers such as `ft_opendir` and `ft_readdir`.
 * **HTML** – minimal HTML node creation and searching utilities.
-* **Game** – basic game related classes (`ft_character`, `ft_gear`, `ft_item`, `ft_map3d`, `ft_quest`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_item` provides a simple item container with stack counts and modifier identifiers.
+* **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_item` provides a simple item container with stack counts and modifier identifiers.
 
 The project is a work in progress and not every component is documented here.
 Consult the individual header files for precise behavior and additional

--- a/Test/game_tests.cpp
+++ b/Test/game_tests.cpp
@@ -4,8 +4,12 @@
 #include "../Game/quest.hpp"
 #include "../Game/reputation.hpp"
 #include "../Game/map3d.hpp"
-#include "../Game/gear.hpp"
 #include "../Game/item.hpp"
+#include "../Game/upgrade.hpp"
+#include "../Game/world.hpp"
+#include "../Game/event.hpp"
+#include "../Game/inventory.hpp"
+#include "../Errno/errno.hpp"
 
 int test_game_simulation(void)
 {
@@ -14,8 +18,8 @@ int test_game_simulation(void)
     hero.set_might(10);
     hero.set_armor(5);
 
-    ft_map3d world(3, 3, 1, 0);
-    world.set(1, 1, 0, 1);
+    ft_map3d grid(3, 3, 1, 0);
+    grid.set(1, 1, 0, 1);
     hero.set_x(1);
     hero.set_y(1);
     hero.set_z(0);
@@ -36,9 +40,14 @@ int test_game_simulation(void)
     if (hero.get_armor() != 3)
         return 0;
 
-    ft_gear sword;
-    sword.set_might(3);
-    hero.set_might(hero.get_might() + sword.get_might());
+    ft_upgrade upgrade;
+    upgrade.set_id(1);
+    upgrade.set_modifier1(3);
+    hero.get_upgrades().insert(upgrade.get_id(), upgrade);
+    Pair<int, ft_upgrade>* uentry = hero.get_upgrades().find(1);
+    if (!uentry)
+        return 0;
+    hero.set_might(hero.get_might() + uentry->value.get_modifier1());
     if (hero.get_might() != 18)
         return 0;
 
@@ -59,7 +68,32 @@ int test_game_simulation(void)
         hero.get_reputation().get_total_rep() != 4)
         return 0;
 
-    if (world.get(hero.get_x(), hero.get_y(), hero.get_z()) != 1)
+    ft_world overworld;
+    ft_event meeting;
+    meeting.set_id(1);
+    meeting.set_duration(5);
+    overworld.get_events().insert(meeting.get_id(), meeting);
+    Pair<int, ft_event>* eentry = overworld.get_events().find(1);
+    if (!eentry || eentry->value.get_duration() != 5)
+        return 0;
+
+    ft_inventory pack(2);
+    ft_item potion;
+    potion.set_item_id(1);
+    potion.set_max_stack(10);
+    potion.set_current_stack(5);
+    if (pack.add_item(potion) != ER_SUCCESS)
+        return 0;
+    ft_item more;
+    more.set_item_id(1);
+    more.set_max_stack(10);
+    more.set_current_stack(3);
+    pack.add_item(more);
+    Pair<int, ft_item>* ientry = pack.get_items().find(0);
+    if (!ientry || ientry->value.get_current_stack() != 8)
+        return 0;
+
+    if (grid.get(hero.get_x(), hero.get_y(), hero.get_z()) != 1)
         return 0;
 
     return 1;


### PR DESCRIPTION
## Summary
- widen the game simulation test to cover `ft_upgrade`, `ft_world`, `ft_event`, and `ft_inventory`

## Testing
- `make`
- `make -C Test`


------
https://chatgpt.com/codex/tasks/task_e_687a9bf564b483318722246bbcbe2910