### PR TITLE
Switch CMA internal allocations to malloc/free

### DIFF
--- a/CMA/cma_cleanup.cpp
+++ b/CMA/cma_cleanup.cpp
@@ -3,7 +3,6 @@
 #include "../CPP_class/nullptr.hpp"
 #include "../Printf/printf.hpp"
 #include <cstdlib>
-#include <new>
 
 extern Page *page_list;
 
@@ -21,11 +20,11 @@ void cma_cleanup()
 		{
 			if (DEBUG == 1)
 				pf_printf("freeing current page memory\n");
-            ::operator delete(current_page->start, std::align_val_t(8), std::nothrow);
+            std::free(current_page->start);
 		}
 		if (DEBUG == 1)
 			pf_printf("Freeing current page metadata\n");
-        ::operator delete(current_page, std::align_val_t(8), std::nothrow);
+        std::free(current_page);
         current_page = next_page;
     }
     page_list = ft_nullptr;

--- a/CMA/cma_free.cpp
+++ b/CMA/cma_free.cpp
@@ -13,7 +13,7 @@ void cma_free(void* ptr)
 {
     if (OFFSWITCH == 1)
     {
-        ::operator delete(ptr);
+        std::free(ptr);
         return ;
     }
 	if (!ptr)

--- a/CMA/cma_free_checked.cpp
+++ b/CMA/cma_free_checked.cpp
@@ -3,12 +3,13 @@
 #include "../CPP_class/nullptr.hpp"
 #include "../Errno/errno.hpp"
 #include "../PThread/mutex.hpp"
+#include <cstdlib>
 
 int cma_checked_free(void* ptr)
 {
     if (OFFSWITCH == 1)
     {
-        ::operator delete(ptr);
+        std::free(ptr);
         return (0);
     }
     if (!ptr)

--- a/CMA/cma_realloc.cpp
+++ b/CMA/cma_realloc.cpp
@@ -2,7 +2,6 @@
 #include <cstddef>
 #include <cstdio>
 #include <cassert>
-#include <new>
 #include <pthread.h>
 #include <csignal>
 #include "CMA.hpp"
@@ -37,16 +36,7 @@ void *cma_realloc(void* ptr, size_t new_size)
 {
     if (OFFSWITCH == 1)
     {
-        void* new_ptr = ::operator new(new_size, std::align_val_t(8), std::nothrow);
-        if (ptr && new_ptr)
-        {
-            Block* old_block = reinterpret_cast<Block*> ((static_cast<char*> (ptr)
-						- sizeof(Block)));
-            size_t copy_size = old_block->size < new_size ? old_block->size : new_size;
-            ft_memcpy(new_ptr, ptr, copy_size);
-        }
-        ::operator delete(ptr, std::align_val_t(8), std::nothrow);
-        return (new_ptr);
+        return std::realloc(ptr, new_size);
     }
 	g_malloc_mutex.lock(THREAD_ID);
     if (!ptr)

--- a/CMA/cma_utils.cpp
+++ b/CMA/cma_utils.cpp
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <cassert>
 #include <csignal>
-#include <new>
 #include "CMA_internal.hpp"
 #include "../CPP_class/nullptr.hpp"
 #include "../Printf/printf.hpp"
@@ -89,7 +88,7 @@ Page *create_page(size_t size)
     void* ptr;
     if (use_heap)
     {
-        ptr = ::operator new(page_size, std::align_val_t(8), std::nothrow);
+        ptr = std::malloc(page_size);
         if (!ptr)
             return (ft_nullptr);
     }
@@ -99,11 +98,11 @@ Page *create_page(size_t size)
         if (!ptr)
             return (ft_nullptr);
     }
-    Page* page = static_cast<Page*>(::operator new(page_size, std::align_val_t(8), std::nothrow));
+    Page* page = static_cast<Page*>(std::malloc(sizeof(Page)));
     if (!page)
     {
         if (use_heap)
-            ::operator delete(ptr, std::align_val_t(8), std::nothrow);
+            std::free(ptr);
         return (ft_nullptr);
     }
     page->heap = use_heap;


### PR DESCRIPTION
## Summary
- use `malloc` and `free` instead of `operator new/delete` in CMA internals
- adjust cleanup and realloc paths
- include `<cstdlib>` where needed
- rebuild CMA library to ensure compilation

## Testing
- `make -C CMA`

------
https://chatgpt.com/codex/tasks/task_e_687aa251ba148331b03bd1604a4ceca3