### PR TITLE
Add inventory helpers

### DIFF
--- a/Game/inventory.cpp
+++ b/Game/inventory.cpp
@@ -97,3 +97,22 @@ void ft_inventory::remove_item(int slot) noexcept
     return ;
 }
 
+int ft_inventory::count_item(int item_id) const noexcept
+{
+    const Pair<int, ft_item> *ptr = this->_items.end() - this->_items.getSize();
+    const Pair<int, ft_item> *end = this->_items.end();
+    int total = 0;
+    while (ptr != end)
+    {
+        if (ptr->value.get_item_id() == item_id)
+            total += ptr->value.get_current_stack();
+        ++ptr;
+    }
+    return (total);
+}
+
+bool ft_inventory::has_item(int item_id) const noexcept
+{
+    return (this->count_item(item_id) > 0);
+}
+

--- a/Game/inventory.hpp
+++ b/Game/inventory.hpp
@@ -30,6 +30,9 @@ class ft_inventory
 
         int  add_item(const ft_item &item) noexcept;
         void remove_item(int slot) noexcept;
+
+        int  count_item(int item_id) const noexcept;
+        bool has_item(int item_id) const noexcept;
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ for the full interface of these templates.
 * **JSon** – simple JSON serialization helpers (`json_create_item`, `json_read_from_file`, etc.).
 * **File** – directory handling wrappers such as `ft_opendir` and `ft_readdir`.
 * **HTML** – minimal HTML node creation and searching utilities.
-* **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_item` provides a simple item container with stack counts and modifier identifiers.
+* **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_item` provides a simple item container with stack counts and modifier identifiers. `ft_inventory` manages stacked items and can query item counts with `has_item` and `count_item`.
 
 The project is a work in progress and not every component is documented here.
 Consult the individual header files for precise behavior and additional

--- a/Test/game_tests.cpp
+++ b/Test/game_tests.cpp
@@ -114,3 +114,25 @@ int test_item_basic(void)
         return 0;
     return 1;
 }
+
+int test_inventory_count(void)
+{
+    ft_inventory inv(5);
+    ft_item potion;
+    potion.set_item_id(1);
+    potion.set_max_stack(10);
+    potion.set_current_stack(7);
+    inv.add_item(potion);
+
+    ft_item more;
+    more.set_item_id(1);
+    more.set_max_stack(10);
+    more.set_current_stack(4);
+    inv.add_item(more);
+
+    if (!inv.has_item(1) || inv.count_item(1) != 11)
+        return 0;
+    if (inv.has_item(2) || inv.count_item(2) != 0)
+        return 0;
+    return 1;
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -128,6 +128,7 @@ int test_cma_checked_free_offset(void);
 int test_cma_checked_free_invalid(void);
 int test_game_simulation(void);
 int test_item_basic(void);
+int test_inventory_count(void);
 
 int main(void)
 {
@@ -232,7 +233,8 @@ int main(void)
         { test_cma_checked_free_offset, "cma_checked_free offset" },
         { test_cma_checked_free_invalid, "cma_checked_free invalid" },
         { test_game_simulation, "game simulation" },
-        { test_item_basic, "item basic" }
+        { test_item_basic, "item basic" },
+        { test_inventory_count, "inventory count" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
 


### PR DESCRIPTION
## Summary
- extend inventory with `count_item` and `has_item`
- test the new inventory helpers
- document the helpers in README

## Testing
- `make`
- `make -C Test`
- `printf "all\nn\n" | ./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_687abb96a08c833189c39050f26daefd