### PR TITLE
Add is_full to inventory class and tests

### DIFF
--- a/Game/inventory.cpp
+++ b/Game/inventory.cpp
@@ -34,6 +34,11 @@ size_t ft_inventory::get_used() const noexcept
     return (this->_items.getSize());
 }
 
+bool ft_inventory::is_full() const noexcept
+{
+    return (this->_items.getSize() >= this->_capacity);
+}
+
 int ft_inventory::get_error() const noexcept
 {
     return (this->_error);

--- a/Game/inventory.hpp
+++ b/Game/inventory.hpp
@@ -25,6 +25,7 @@ class ft_inventory
         size_t get_capacity() const noexcept;
         void   resize(size_t capacity) noexcept;
         size_t get_used() const noexcept;
+        bool   is_full() const noexcept;
 
         int get_error() const noexcept;
 

--- a/Test/game_tests.cpp
+++ b/Test/game_tests.cpp
@@ -136,3 +136,19 @@ int test_inventory_count(void)
         return 0;
     return 1;
 }
+
+int test_inventory_full(void)
+{
+    ft_inventory inv(1);
+    ft_item item;
+    item.set_item_id(1);
+    item.set_max_stack(5);
+    item.set_current_stack(5);
+    if (inv.is_full())
+        return 0;
+    if (inv.add_item(item) != ER_SUCCESS)
+        return 0;
+    if (!inv.is_full())
+        return 0;
+    return 1;
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -129,6 +129,7 @@ int test_cma_checked_free_invalid(void);
 int test_game_simulation(void);
 int test_item_basic(void);
 int test_inventory_count(void);
+int test_inventory_full(void);
 
 int main(void)
 {
@@ -234,7 +235,8 @@ int main(void)
         { test_cma_checked_free_invalid, "cma_checked_free invalid" },
         { test_game_simulation, "game simulation" },
         { test_item_basic, "item basic" },
-        { test_inventory_count, "inventory count" }
+        { test_inventory_count, "inventory count" },
+        { test_inventory_full, "inventory full" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
 


### PR DESCRIPTION
## Summary
- extend `ft_inventory` with `is_full` helper
- test new helper in `inventory_full` unit test
- hook up new test in test suite

## Testing
- `make -C Game`
- `make -C Test`
- `echo -e "1\nn\n" | ./Test/libft_tests` (printed available tests)

------
https://chatgpt.com/codex/tasks/task_e_687abea179ac8331ab11371687e56080