### PR TITLE
Add subtract helpers for game classes

### DIFF
--- a/Game/buff.cpp
+++ b/Game/buff.cpp
@@ -34,6 +34,12 @@ void ft_buff::add_duration(int duration) noexcept
     return ;
 }
 
+void ft_buff::sub_duration(int duration) noexcept
+{
+    this->_duration -= duration;
+    return ;
+}
+
 int ft_buff::get_modifier1() const noexcept
 {
     return (this->_modifier1);
@@ -48,6 +54,12 @@ void ft_buff::set_modifier1(int mod) noexcept
 void ft_buff::add_modifier1(int mod) noexcept
 {
     this->_modifier1 += mod;
+    return ;
+}
+
+void ft_buff::sub_modifier1(int mod) noexcept
+{
+    this->_modifier1 -= mod;
     return ;
 }
 
@@ -68,6 +80,12 @@ void ft_buff::add_modifier2(int mod) noexcept
     return ;
 }
 
+void ft_buff::sub_modifier2(int mod) noexcept
+{
+    this->_modifier2 -= mod;
+    return ;
+}
+
 int ft_buff::get_modifier3() const noexcept
 {
     return (this->_modifier3);
@@ -85,6 +103,12 @@ void ft_buff::add_modifier3(int mod) noexcept
     return ;
 }
 
+void ft_buff::sub_modifier3(int mod) noexcept
+{
+    this->_modifier3 -= mod;
+    return ;
+}
+
 int ft_buff::get_modifier4() const noexcept
 {
     return (this->_modifier4);
@@ -99,5 +123,11 @@ void ft_buff::set_modifier4(int mod) noexcept
 void ft_buff::add_modifier4(int mod) noexcept
 {
     this->_modifier4 += mod;
+    return ;
+}
+
+void ft_buff::sub_modifier4(int mod) noexcept
+{
+    this->_modifier4 -= mod;
     return ;
 }

--- a/Game/buff.hpp
+++ b/Game/buff.hpp
@@ -21,22 +21,27 @@ class ft_buff
         int get_duration() const noexcept;
         void set_duration(int duration) noexcept;
         void add_duration(int duration) noexcept;
+        void sub_duration(int duration) noexcept;
 
         int get_modifier1() const noexcept;
         void set_modifier1(int mod) noexcept;
         void add_modifier1(int mod) noexcept;
+        void sub_modifier1(int mod) noexcept;
 
         int get_modifier2() const noexcept;
         void set_modifier2(int mod) noexcept;
         void add_modifier2(int mod) noexcept;
+        void sub_modifier2(int mod) noexcept;
 
         int get_modifier3() const noexcept;
         void set_modifier3(int mod) noexcept;
         void add_modifier3(int mod) noexcept;
+        void sub_modifier3(int mod) noexcept;
 
         int get_modifier4() const noexcept;
         void set_modifier4(int mod) noexcept;
         void add_modifier4(int mod) noexcept;
+        void sub_modifier4(int mod) noexcept;
 };
 
 #endif

--- a/Game/character.cpp
+++ b/Game/character.cpp
@@ -3,7 +3,7 @@
 ft_character::ft_character() noexcept
     : _hit_points(0), _armor(0), _might(0), _agility(0),
       _endurance(0), _reason(0), _insigh(0), _presence(0),
-      _coins(0), _x(0), _y(0), _z(0),
+      _coins(0), _valor(0), _x(0), _y(0), _z(0),
       _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
       _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
       _physical_res{0, 0}, _buffs(), _debuffs(), _upgrades(), _quests(), _reputation(),
@@ -118,6 +118,41 @@ int ft_character::get_coins() const noexcept
 void ft_character::set_coins(int coins) noexcept
 {
     this->_coins = coins;
+    return ;
+}
+
+void ft_character::add_coins(int coins) noexcept
+{
+    this->_coins += coins;
+    return ;
+}
+
+void ft_character::sub_coins(int coins) noexcept
+{
+    this->_coins -= coins;
+    return ;
+}
+
+int ft_character::get_valor() const noexcept
+{
+    return (this->_valor);
+}
+
+void ft_character::set_valor(int valor) noexcept
+{
+    this->_valor = valor;
+    return ;
+}
+
+void ft_character::add_valor(int valor) noexcept
+{
+    this->_valor += valor;
+    return ;
+}
+
+void ft_character::sub_valor(int valor) noexcept
+{
+    this->_valor -= valor;
     return ;
 }
 

--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -27,6 +27,7 @@ class ft_character
         int _insigh;
         int _presence;
         int _coins;
+        int _valor;
         int _x;
         int _y;
         int _z;
@@ -78,9 +79,13 @@ class ft_character
 
         int get_coins() const noexcept;
         void set_coins(int coins) noexcept;
+        void add_coins(int coins) noexcept;
+        void sub_coins(int coins) noexcept;
 
         int get_valor() const noexcept;
         void set_valor(int valor) noexcept;
+        void add_valor(int valor) noexcept;
+        void sub_valor(int valor) noexcept;
 
         int get_x() const noexcept;
         void set_x(int x) noexcept;

--- a/Game/debuff.cpp
+++ b/Game/debuff.cpp
@@ -34,6 +34,12 @@ void ft_debuff::add_duration(int duration) noexcept
     return ;
 }
 
+void ft_debuff::sub_duration(int duration) noexcept
+{
+    this->_duration -= duration;
+    return ;
+}
+
 int ft_debuff::get_modifier1() const noexcept
 {
     return (this->_modifier1);
@@ -48,6 +54,12 @@ void ft_debuff::set_modifier1(int mod) noexcept
 void ft_debuff::add_modifier1(int mod) noexcept
 {
     this->_modifier1 += mod;
+    return ;
+}
+
+void ft_debuff::sub_modifier1(int mod) noexcept
+{
+    this->_modifier1 -= mod;
     return ;
 }
 
@@ -68,6 +80,12 @@ void ft_debuff::add_modifier2(int mod) noexcept
     return ;
 }
 
+void ft_debuff::sub_modifier2(int mod) noexcept
+{
+    this->_modifier2 -= mod;
+    return ;
+}
+
 int ft_debuff::get_modifier3() const noexcept
 {
     return (this->_modifier3);
@@ -85,6 +103,12 @@ void ft_debuff::add_modifier3(int mod) noexcept
     return ;
 }
 
+void ft_debuff::sub_modifier3(int mod) noexcept
+{
+    this->_modifier3 -= mod;
+    return ;
+}
+
 int ft_debuff::get_modifier4() const noexcept
 {
     return (this->_modifier4);
@@ -99,5 +123,11 @@ void ft_debuff::set_modifier4(int mod) noexcept
 void ft_debuff::add_modifier4(int mod) noexcept
 {
     this->_modifier4 += mod;
+    return ;
+}
+
+void ft_debuff::sub_modifier4(int mod) noexcept
+{
+    this->_modifier4 -= mod;
     return ;
 }

--- a/Game/debuff.hpp
+++ b/Game/debuff.hpp
@@ -21,22 +21,27 @@ class ft_debuff
         int get_duration() const noexcept;
         void set_duration(int duration) noexcept;
         void add_duration(int duration) noexcept;
+        void sub_duration(int duration) noexcept;
 
         int get_modifier1() const noexcept;
         void set_modifier1(int mod) noexcept;
         void add_modifier1(int mod) noexcept;
+        void sub_modifier1(int mod) noexcept;
 
         int get_modifier2() const noexcept;
         void set_modifier2(int mod) noexcept;
         void add_modifier2(int mod) noexcept;
+        void sub_modifier2(int mod) noexcept;
 
         int get_modifier3() const noexcept;
         void set_modifier3(int mod) noexcept;
         void add_modifier3(int mod) noexcept;
+        void sub_modifier3(int mod) noexcept;
 
         int get_modifier4() const noexcept;
         void set_modifier4(int mod) noexcept;
         void add_modifier4(int mod) noexcept;
+        void sub_modifier4(int mod) noexcept;
 };
 
 #endif

--- a/Game/event.cpp
+++ b/Game/event.cpp
@@ -34,6 +34,12 @@ void ft_event::add_duration(int duration) noexcept
     return ;
 }
 
+void ft_event::sub_duration(int duration) noexcept
+{
+    this->_duration -= duration;
+    return ;
+}
+
 int ft_event::get_modifier1() const noexcept
 {
     return (this->_modifier1);
@@ -48,6 +54,12 @@ void ft_event::set_modifier1(int mod) noexcept
 void ft_event::add_modifier1(int mod) noexcept
 {
     this->_modifier1 += mod;
+    return ;
+}
+
+void ft_event::sub_modifier1(int mod) noexcept
+{
+    this->_modifier1 -= mod;
     return ;
 }
 
@@ -68,6 +80,12 @@ void ft_event::add_modifier2(int mod) noexcept
     return ;
 }
 
+void ft_event::sub_modifier2(int mod) noexcept
+{
+    this->_modifier2 -= mod;
+    return ;
+}
+
 int ft_event::get_modifier3() const noexcept
 {
     return (this->_modifier3);
@@ -85,6 +103,12 @@ void ft_event::add_modifier3(int mod) noexcept
     return ;
 }
 
+void ft_event::sub_modifier3(int mod) noexcept
+{
+    this->_modifier3 -= mod;
+    return ;
+}
+
 int ft_event::get_modifier4() const noexcept
 {
     return (this->_modifier4);
@@ -99,5 +123,11 @@ void ft_event::set_modifier4(int mod) noexcept
 void ft_event::add_modifier4(int mod) noexcept
 {
     this->_modifier4 += mod;
+    return ;
+}
+
+void ft_event::sub_modifier4(int mod) noexcept
+{
+    this->_modifier4 -= mod;
     return ;
 }

--- a/Game/event.hpp
+++ b/Game/event.hpp
@@ -21,22 +21,27 @@ class ft_event
         int get_duration() const noexcept;
         void set_duration(int duration) noexcept;
         void add_duration(int duration) noexcept;
+        void sub_duration(int duration) noexcept;
 
         int get_modifier1() const noexcept;
         void set_modifier1(int mod) noexcept;
         void add_modifier1(int mod) noexcept;
+        void sub_modifier1(int mod) noexcept;
 
         int get_modifier2() const noexcept;
         void set_modifier2(int mod) noexcept;
         void add_modifier2(int mod) noexcept;
+        void sub_modifier2(int mod) noexcept;
 
         int get_modifier3() const noexcept;
         void set_modifier3(int mod) noexcept;
         void add_modifier3(int mod) noexcept;
+        void sub_modifier3(int mod) noexcept;
 
         int get_modifier4() const noexcept;
         void set_modifier4(int mod) noexcept;
         void add_modifier4(int mod) noexcept;
+        void sub_modifier4(int mod) noexcept;
 };
 
 #endif

--- a/Game/item.cpp
+++ b/Game/item.cpp
@@ -37,6 +37,14 @@ void ft_item::add_to_stack(int amount) noexcept
     return ;
 }
 
+void ft_item::sub_from_stack(int amount) noexcept
+{
+    this->_current_stack -= amount;
+    if (this->_current_stack < 0)
+        this->_current_stack = 0;
+    return ;
+}
+
 int ft_item::get_item_id() const noexcept
 {
     return (this->_item_id);

--- a/Game/item.hpp
+++ b/Game/item.hpp
@@ -28,6 +28,7 @@ class ft_item
         int get_current_stack() const noexcept;
         void set_current_stack(int amount) noexcept;
         void add_to_stack(int amount) noexcept;
+        void sub_from_stack(int amount) noexcept;
 
         int get_item_id() const noexcept;
         void set_item_id(int id) noexcept;

--- a/Game/reputation.cpp
+++ b/Game/reputation.cpp
@@ -39,6 +39,12 @@ void ft_reputation::add_total_rep(int rep) noexcept
     return ;
 }
 
+void ft_reputation::sub_total_rep(int rep) noexcept
+{
+    this->_total_rep -= rep;
+    return ;
+}
+
 int ft_reputation::get_current_rep() const noexcept
 {
     return (this->_current_rep);
@@ -54,6 +60,13 @@ void ft_reputation::add_current_rep(int rep) noexcept
 {
     this->_current_rep += rep;
     this->_total_rep += rep;
+    return ;
+}
+
+void ft_reputation::sub_current_rep(int rep) noexcept
+{
+    this->_current_rep -= rep;
+    this->_total_rep -= rep;
     return ;
 }
 

--- a/Game/reputation.hpp
+++ b/Game/reputation.hpp
@@ -23,10 +23,12 @@ class ft_reputation
         int get_total_rep() const noexcept;
         void set_total_rep(int rep) noexcept;
         void add_total_rep(int rep) noexcept;
+        void sub_total_rep(int rep) noexcept;
 
         int get_current_rep() const noexcept;
         void set_current_rep(int rep) noexcept;
         void add_current_rep(int rep) noexcept;
+        void sub_current_rep(int rep) noexcept;
 
         ft_map<int, int>       &get_milestones() noexcept;
         const ft_map<int, int> &get_milestones() const noexcept;

--- a/Game/upgrade.cpp
+++ b/Game/upgrade.cpp
@@ -37,6 +37,15 @@ void ft_upgrade::add_level(uint16_t level) noexcept
     return ;
 }
 
+void ft_upgrade::sub_level(uint16_t level) noexcept
+{
+    if (level > this->_current_level)
+        this->_current_level = 0;
+    else
+        this->_current_level -= level;
+    return ;
+}
+
 uint16_t ft_upgrade::get_max_level() const noexcept
 {
     return (this->_max_level);
@@ -65,6 +74,12 @@ void ft_upgrade::add_modifier1(int mod) noexcept
     return ;
 }
 
+void ft_upgrade::sub_modifier1(int mod) noexcept
+{
+    this->_modifier1 -= mod;
+    return ;
+}
+
 int ft_upgrade::get_modifier2() const noexcept
 {
     return (this->_modifier2);
@@ -79,6 +94,12 @@ void ft_upgrade::set_modifier2(int mod) noexcept
 void ft_upgrade::add_modifier2(int mod) noexcept
 {
     this->_modifier2 += mod;
+    return ;
+}
+
+void ft_upgrade::sub_modifier2(int mod) noexcept
+{
+    this->_modifier2 -= mod;
     return ;
 }
 
@@ -99,6 +120,12 @@ void ft_upgrade::add_modifier3(int mod) noexcept
     return ;
 }
 
+void ft_upgrade::sub_modifier3(int mod) noexcept
+{
+    this->_modifier3 -= mod;
+    return ;
+}
+
 int ft_upgrade::get_modifier4() const noexcept
 {
     return (this->_modifier4);
@@ -113,6 +140,12 @@ void ft_upgrade::set_modifier4(int mod) noexcept
 void ft_upgrade::add_modifier4(int mod) noexcept
 {
     this->_modifier4 += mod;
+    return ;
+}
+
+void ft_upgrade::sub_modifier4(int mod) noexcept
+{
+    this->_modifier4 -= mod;
     return ;
 }
 

--- a/Game/upgrade.hpp
+++ b/Game/upgrade.hpp
@@ -24,6 +24,7 @@ class ft_upgrade
         uint16_t get_current_level() const noexcept;
         void set_current_level(uint16_t level) noexcept;
         void add_level(uint16_t level) noexcept;
+        void sub_level(uint16_t level) noexcept;
 
         uint16_t get_max_level() const noexcept;
         void set_max_level(uint16_t level) noexcept;
@@ -31,18 +32,22 @@ class ft_upgrade
         int get_modifier1() const noexcept;
         void set_modifier1(int mod) noexcept;
         void add_modifier1(int mod) noexcept;
+        void sub_modifier1(int mod) noexcept;
 
         int get_modifier2() const noexcept;
         void set_modifier2(int mod) noexcept;
         void add_modifier2(int mod) noexcept;
+        void sub_modifier2(int mod) noexcept;
 
         int get_modifier3() const noexcept;
         void set_modifier3(int mod) noexcept;
         void add_modifier3(int mod) noexcept;
+        void sub_modifier3(int mod) noexcept;
 
         int get_modifier4() const noexcept;
         void set_modifier4(int mod) noexcept;
         void add_modifier4(int mod) noexcept;
+        void sub_modifier4(int mod) noexcept;
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ for the full interface of these templates.
 * **JSon** – simple JSON serialization helpers (`json_create_item`, `json_read_from_file`, etc.).
 * **File** – directory handling wrappers such as `ft_opendir` and `ft_readdir`.
 * **HTML** – minimal HTML node creation and searching utilities.
-* **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_item` provides a simple item container with stack counts and modifier identifiers. `ft_inventory` manages stacked items and can query item counts with `has_item` and `count_item`.
+* **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_event`, `ft_upgrade`, `ft_item`, and `ft_reputation` also expose adders, and now each of these classes provides matching subtract helpers. `ft_inventory` manages stacked items and can query item counts with `has_item` and `count_item`. `ft_character` keeps track of coins and a `valor` attribute with helpers to add or subtract these values.
 
 The project is a work in progress and not every component is documented here.
 Consult the individual header files for precise behavior and additional

--- a/Test/game_tests.cpp
+++ b/Test/game_tests.cpp
@@ -152,3 +152,117 @@ int test_inventory_full(void)
         return 0;
     return 1;
 }
+
+int test_character_valor(void)
+{
+    ft_character hero;
+    hero.set_valor(42);
+    return (hero.get_valor() == 42);
+}
+
+int test_character_add_sub_coins(void)
+{
+    ft_character hero;
+    hero.add_coins(10);
+    hero.sub_coins(3);
+    return (hero.get_coins() == 7);
+}
+
+int test_character_add_sub_valor(void)
+{
+    ft_character hero;
+    hero.add_valor(5);
+    hero.sub_valor(2);
+    return (hero.get_valor() == 3);
+}
+
+int test_buff_subtracters(void)
+{
+    ft_buff buff;
+    buff.set_duration(10);
+    buff.sub_duration(3);
+    buff.set_modifier1(5);
+    buff.sub_modifier1(2);
+    buff.set_modifier2(4);
+    buff.sub_modifier2(1);
+    buff.set_modifier3(6);
+    buff.sub_modifier3(6);
+    buff.set_modifier4(8);
+    buff.sub_modifier4(3);
+    return (buff.get_duration() == 7 && buff.get_modifier1() == 3 &&
+            buff.get_modifier2() == 3 && buff.get_modifier3() == 0 &&
+            buff.get_modifier4() == 5);
+}
+
+int test_debuff_subtracters(void)
+{
+    ft_debuff debuff;
+    debuff.set_duration(8);
+    debuff.sub_duration(2);
+    debuff.set_modifier1(-1);
+    debuff.sub_modifier1(-1);
+    debuff.set_modifier2(3);
+    debuff.sub_modifier2(1);
+    debuff.set_modifier3(2);
+    debuff.sub_modifier3(2);
+    debuff.set_modifier4(0);
+    debuff.sub_modifier4(0);
+    return (debuff.get_duration() == 6 && debuff.get_modifier1() == 0 &&
+            debuff.get_modifier2() == 2 && debuff.get_modifier3() == 0 &&
+            debuff.get_modifier4() == 0);
+}
+
+int test_event_subtracters(void)
+{
+    ft_event ev;
+    ev.set_duration(5);
+    ev.sub_duration(1);
+    ev.set_modifier1(4);
+    ev.sub_modifier1(2);
+    ev.set_modifier2(3);
+    ev.sub_modifier2(3);
+    ev.set_modifier3(0);
+    ev.sub_modifier3(0);
+    ev.set_modifier4(-2);
+    ev.sub_modifier4(-1);
+    return (ev.get_duration() == 4 && ev.get_modifier1() == 2 &&
+            ev.get_modifier2() == 0 && ev.get_modifier3() == 0 &&
+            ev.get_modifier4() == -1);
+}
+
+int test_upgrade_subtracters(void)
+{
+    ft_upgrade up;
+    up.set_current_level(5);
+    up.sub_level(2);
+    up.set_modifier1(3);
+    up.sub_modifier1(1);
+    up.set_modifier2(4);
+    up.sub_modifier2(4);
+    up.set_modifier3(-2);
+    up.sub_modifier3(-2);
+    up.set_modifier4(7);
+    up.sub_modifier4(3);
+    return (up.get_current_level() == 3 && up.get_modifier1() == 2 &&
+            up.get_modifier2() == 0 && up.get_modifier3() == 0 &&
+            up.get_modifier4() == 4);
+}
+
+int test_item_stack_subtract(void)
+{
+    ft_item item;
+    item.set_max_stack(10);
+    item.set_current_stack(7);
+    item.sub_from_stack(3);
+    return (item.get_current_stack() == 4);
+}
+
+int test_reputation_subtracters(void)
+{
+    ft_reputation rep;
+    rep.set_total_rep(20);
+    rep.sub_total_rep(5);
+    rep.set_current_rep(10);
+    rep.sub_current_rep(3);
+    return (rep.get_total_rep() == 12 && rep.get_current_rep() == 7);
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -130,6 +130,15 @@ int test_game_simulation(void);
 int test_item_basic(void);
 int test_inventory_count(void);
 int test_inventory_full(void);
+int test_character_valor(void);
+int test_character_add_sub_coins(void);
+int test_character_add_sub_valor(void);
+int test_buff_subtracters(void);
+int test_debuff_subtracters(void);
+int test_event_subtracters(void);
+int test_upgrade_subtracters(void);
+int test_item_stack_subtract(void);
+int test_reputation_subtracters(void);
 
 int main(void)
 {
@@ -236,7 +245,16 @@ int main(void)
         { test_game_simulation, "game simulation" },
         { test_item_basic, "item basic" },
         { test_inventory_count, "inventory count" },
-        { test_inventory_full, "inventory full" }
+        { test_inventory_full, "inventory full" },
+        { test_character_valor, "character valor" },
+        { test_character_add_sub_coins, "character coin add/sub" },
+        { test_character_add_sub_valor, "character valor add/sub" },
+        { test_buff_subtracters, "buff subtracters" },
+        { test_debuff_subtracters, "debuff subtracters" },
+        { test_event_subtracters, "event subtracters" },
+        { test_upgrade_subtracters, "upgrade subtracters" },
+        { test_item_stack_subtract, "item stack subtract" },
+        { test_reputation_subtracters, "reputation subtracters" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
 


### PR DESCRIPTION
## Summary
- add `sub_*` helpers for buff, debuff, event, upgrade, item, and reputation classes
- implement corresponding subtraction logic in `.cpp` files
- document new helpers in README
- expand game tests to cover subtract helpers

## Testing
- `make -C Game`
- `make -C Test`


------
https://chatgpt.com/codex/tasks/task_e_687bdbc75e54833183764a474cce813d