### PR TITLE
Add experience table utilities

### DIFF
--- a/Game/character.cpp
+++ b/Game/character.cpp
@@ -340,6 +340,16 @@ const ft_reputation &ft_character::get_reputation() const noexcept
     return (this->_reputation);
 }
 
+ft_experience_table &ft_character::get_experience_table() noexcept
+{
+    return (this->_experience_table);
+}
+
+const ft_experience_table &ft_character::get_experience_table() const noexcept
+{
+    return (this->_experience_table);
+}
+
 int ft_character::get_error() const noexcept
 {
     return (this->_error);

--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -139,6 +139,9 @@ class ft_character
         ft_reputation       &get_reputation() noexcept;
         const ft_reputation &get_reputation() const noexcept;
 
+        ft_experience_table       &get_experience_table() noexcept;
+        const ft_experience_table &get_experience_table() const noexcept;
+
         int get_error() const noexcept;
 };
 

--- a/Game/experience_table.cpp
+++ b/Game/experience_table.cpp
@@ -116,6 +116,61 @@ void ft_experience_table::set_value(int index, int value) noexcept
     return ;
 }
 
+int ft_experience_table::set_levels(const int *levels, int count) noexcept
+{
+    this->_error = ER_SUCCESS;
+    if (count <= 0 || !levels)
+        return (this->resize(0));
+    if (this->resize(count) != ER_SUCCESS)
+        return (this->_error);
+    for (int i = 0; i < count; ++i)
+        this->_levels[i] = levels[i];
+    if (!this->is_valid(this->_count, this->_levels))
+        this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
+    return (this->_error);
+}
+
+int ft_experience_table::generate_levels_total(int count, int base,
+                                               double multiplier) noexcept
+{
+    this->_error = ER_SUCCESS;
+    if (count <= 0)
+        return (this->resize(0));
+    if (this->resize(count) != ER_SUCCESS)
+        return (this->_error);
+    double value = static_cast<double>(base);
+    for (int i = 0; i < count; ++i)
+    {
+        this->_levels[i] = static_cast<int>(value);
+        value *= multiplier;
+    }
+    if (!this->is_valid(this->_count, this->_levels))
+        this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
+    return (this->_error);
+}
+
+int ft_experience_table::generate_levels_scaled(int count, int base,
+                                                double multiplier) noexcept
+{
+    this->_error = ER_SUCCESS;
+    if (count <= 0)
+        return (this->resize(0));
+    if (this->resize(count) != ER_SUCCESS)
+        return (this->_error);
+    double increment = static_cast<double>(base);
+    double total = static_cast<double>(base);
+    this->_levels[0] = static_cast<int>(total);
+    for (int i = 1; i < count; ++i)
+    {
+        increment *= multiplier;
+        total += increment;
+        this->_levels[i] = static_cast<int>(total);
+    }
+    if (!this->is_valid(this->_count, this->_levels))
+        this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
+    return (this->_error);
+}
+
 int ft_experience_table::check_for_error() const noexcept
 {
     if (!this->_levels)

--- a/Game/experience_table.hpp
+++ b/Game/experience_table.hpp
@@ -19,6 +19,11 @@ class ft_experience_table
         int  get_level(int experience) const noexcept;
         int  get_value(int index) const noexcept;
         void set_value(int index, int value) noexcept;
+        int  set_levels(const int *levels, int count) noexcept;
+        int  generate_levels_total(int count, int base,
+                                   double multiplier) noexcept;
+        int  generate_levels_scaled(int count, int base,
+                                    double multiplier) noexcept;
         int  resize(int new_count) noexcept;
         int  check_for_error() const noexcept;
         int  get_error() const noexcept;


### PR DESCRIPTION
## Summary
- extend `ft_experience_table` with helper methods
- expose the experience table through `ft_character`
- implement level generation helpers for multiplicative and scaled tables

## Testing
- `make -C Game`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_687c932cb13c8331b46811f447ff3583