### PR TITLE
Add quest completion helpers

### DIFF
--- a/Game/quest.cpp
+++ b/Game/quest.cpp
@@ -38,3 +38,15 @@ void ft_quest::set_current_phase(int phase) noexcept
     this->_current_phase = phase;
     return ;
 }
+
+bool ft_quest::is_complete() const noexcept
+{
+    return (this->_current_phase >= this->_phases);
+}
+
+void ft_quest::advance_phase() noexcept
+{
+    if (this->_current_phase < this->_phases)
+        ++this->_current_phase;
+    return ;
+}

--- a/Game/quest.hpp
+++ b/Game/quest.hpp
@@ -20,6 +20,9 @@ class ft_quest
 
         int get_current_phase() const noexcept;
         void set_current_phase(int phase) noexcept;
+
+        bool is_complete() const noexcept;
+        void advance_phase() noexcept;
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ for the full interface of these templates.
 * **File** – directory handling wrappers such as `ft_opendir` and `ft_readdir`.
 * **HTML** – minimal HTML node creation and searching utilities.
 * **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_event`, `ft_upgrade`, `ft_item`, and `ft_reputation` also expose adders, and now each of these classes provides matching subtract helpers. `ft_inventory` manages stacked items and can query item counts with `has_item` and `count_item`. `ft_character` keeps track of coins and a `valor` attribute with helpers to add or subtract these values. The character's current level can be retrieved with `get_level()` which relies on an internal experience table.
+`ft_quest` objects can report completion with `is_complete()` and progress phases via `advance_phase()`.
 
 The project is a work in progress and not every component is documented here.
 Consult the individual header files for precise behavior and additional

--- a/Test/game_tests.cpp
+++ b/Test/game_tests.cpp
@@ -275,3 +275,20 @@ int test_character_level(void)
     hero.set_experience(150);
     return (hero.get_level() == 2);
 }
+
+int test_quest_progress(void)
+{
+    ft_quest q;
+    q.set_phases(3);
+    if (q.is_complete())
+        return 0;
+    q.advance_phase();
+    if (q.get_current_phase() != 1 || q.is_complete())
+        return 0;
+    q.advance_phase();
+    q.advance_phase();
+    if (!q.is_complete() || q.get_current_phase() != 3)
+        return 0;
+    q.advance_phase();
+    return (q.get_current_phase() == 3);
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -140,6 +140,7 @@ int test_upgrade_subtracters(void);
 int test_item_stack_subtract(void);
 int test_reputation_subtracters(void);
 int test_character_level(void);
+int test_quest_progress(void);
 
 int main(void)
 {
@@ -256,7 +257,8 @@ int main(void)
         { test_upgrade_subtracters, "upgrade subtracters" },
         { test_item_stack_subtract, "item stack subtract" },
         { test_reputation_subtracters, "reputation subtracters" },
-        { test_character_level, "character level" }
+        { test_character_level, "character level" },
+        { test_quest_progress, "quest progress" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
 


### PR DESCRIPTION
## Summary
- add `is_complete` and `advance_phase` helpers to quests
- test the new quest progress logic
- register the test driver
- document the quest helpers in README

## Testing
- `make -C Test`
- `printf "114\nn\n" | ./Test/libft_tests | tail -n 5` *(fails: produced only menu output)*

------
https://chatgpt.com/codex/tasks/task_e_687ce0c31f308331b44ee0e8f139bc10