### PR TITLE
Standardize error handling across modules

### DIFF
--- a/Game/character.cpp
+++ b/Game/character.cpp
@@ -1,4 +1,5 @@
 #include "character.hpp"
+#include "../Errno/errno.hpp"
 
 ft_character::ft_character() noexcept
     : _hit_points(0), _armor(0), _might(0), _agility(0),
@@ -358,6 +359,11 @@ int ft_character::get_level() const noexcept
 int ft_character::get_error() const noexcept
 {
     return (this->_error);
+}
+
+const char *ft_character::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
 }
 
 void ft_character::set_error(int err) const noexcept

--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -145,6 +145,7 @@ class ft_character
         int get_level() const noexcept;
 
         int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Game/experience_table.cpp
+++ b/Game/experience_table.cpp
@@ -192,3 +192,8 @@ int ft_experience_table::get_error() const noexcept
     return (this->_error);
 }
 
+const char *ft_experience_table::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+

--- a/Game/experience_table.hpp
+++ b/Game/experience_table.hpp
@@ -27,6 +27,7 @@ class ft_experience_table
         int  resize(int new_count) noexcept;
         int  check_for_error() const noexcept;
         int  get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Game/inventory.cpp
+++ b/Game/inventory.cpp
@@ -121,3 +121,8 @@ bool ft_inventory::has_item(int item_id) const noexcept
     return (this->count_item(item_id) > 0);
 }
 
+const char *ft_inventory::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+

--- a/Game/inventory.hpp
+++ b/Game/inventory.hpp
@@ -28,6 +28,7 @@ class ft_inventory
         bool   is_full() const noexcept;
 
         int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 
         int  add_item(const ft_item &item) noexcept;
         void remove_item(int slot) noexcept;

--- a/Game/map3d.cpp
+++ b/Game/map3d.cpp
@@ -28,6 +28,11 @@ int ft_map3d::get_error() const
     return (this->_error);
 }
 
+const char *ft_map3d::get_error_str() const
+{
+    return (ft_strerror(this->_error));
+}
+
 void ft_map3d::set_error(int err) const
 {
     ft_errno = err;

--- a/Game/map3d.hpp
+++ b/Game/map3d.hpp
@@ -33,6 +33,7 @@ class ft_map3d
         size_t  get_height() const;
         size_t  get_depth() const;
         int     get_error() const;
+        const char *get_error_str() const;
 };
 
 #endif

--- a/Game/reputation.cpp
+++ b/Game/reputation.cpp
@@ -143,6 +143,11 @@ int ft_reputation::get_error() const noexcept
     return (this->_error);
 }
 
+const char *ft_reputation::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+
 void ft_reputation::set_error(int err) const noexcept
 {
     ft_errno = err;

--- a/Game/reputation.hpp
+++ b/Game/reputation.hpp
@@ -43,6 +43,7 @@ class ft_reputation
         void set_rep(int id, int value) noexcept;
 
         int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Game/world.cpp
+++ b/Game/world.cpp
@@ -23,6 +23,11 @@ int ft_world::get_error() const noexcept
     return (this->_error);
 }
 
+const char *ft_world::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+
 void ft_world::set_error(int err) const noexcept
 {
     ft_errno = err;

--- a/Game/world.hpp
+++ b/Game/world.hpp
@@ -21,6 +21,7 @@ class ft_world
         const ft_map<int, ft_event> &get_events() const noexcept;
 
         int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Template/map.hpp
+++ b/Template/map.hpp
@@ -37,6 +37,7 @@ public:
     size_t      getSize() const;
     size_t      getCapacity() const;
     int         get_error() const;
+    const char* get_error_str() const;
 
     Pair<Key, MappedType>* end();
     MappedType &at(const Key& key);
@@ -290,6 +291,12 @@ template <typename Key, typename MappedType>
 int ft_map<Key, MappedType>::get_error() const
 {
     return (this->_error);
+}
+
+template <typename Key, typename MappedType>
+const char* ft_map<Key, MappedType>::get_error_str() const
+{
+    return (ft_strerror(this->_error));
 }
 
 template<typename Key, typename MappedType>

--- a/Template/unordened_map.hpp
+++ b/Template/unordened_map.hpp
@@ -83,6 +83,7 @@ public:
     size_t         getSize() const;
     size_t         getCapacity() const;
     int            get_error() const;
+    const char*    get_error_str() const;
     iterator       begin();
     iterator       end();
     const_iterator begin() const;
@@ -633,6 +634,12 @@ template <typename Key, typename MappedType>
 int ft_unord_map<Key, MappedType>::get_error() const
 {
     return (_error);
+}
+
+template <typename Key, typename MappedType>
+const char* ft_unord_map<Key, MappedType>::get_error_str() const
+{
+    return (ft_strerror(_error));
 }
 
 template <typename Key, typename MappedType>

--- a/Template/vector.hpp
+++ b/Template/vector.hpp
@@ -15,7 +15,7 @@ class ft_vector
     	ElementType	*_data;
     	size_t		_size;
     	size_t		_capacity;
-    	bool		_errorCode;
+    	int             _errorCode;
 
     	void	destroy_elements(size_t from, size_t to);
 
@@ -38,7 +38,8 @@ class ft_vector
 
     	size_t size() const;
     	size_t capacity() const;
-    	int get_error() const;
+        int get_error() const;
+        const char* get_error_str() const;
 
     	void push_back(const ElementType &value);
     	void push_back(ElementType &&value);
@@ -61,7 +62,7 @@ class ft_vector
 
 template <typename ElementType>
 ft_vector<ElementType>::ft_vector(size_t initial_capacity)
-    : _data(nullptr), _size(0), _capacity(0), _errorCode(false)
+    : _data(nullptr), _size(0), _capacity(0), _errorCode(ER_SUCCESS)
 {
     if (initial_capacity > 0)
     {
@@ -94,7 +95,7 @@ ft_vector<ElementType>::ft_vector(ft_vector<ElementType>&& other) noexcept
     other._data = nullptr;
     other._size = 0;
     other._capacity = 0;
-    other._errorCode = false;
+    other._errorCode = ER_SUCCESS;
 }
 
 template <typename ElementType>
@@ -112,7 +113,7 @@ ft_vector<ElementType>& ft_vector<ElementType>::operator=(ft_vector<ElementType>
         other._data = nullptr;
         other._size = 0;
         other._capacity = 0;
-        other._errorCode = false;
+        other._errorCode = ER_SUCCESS;
     }
     return (*this);
 }
@@ -140,7 +141,7 @@ size_t ft_vector<ElementType>::capacity() const
 template <typename ElementType>
 void ft_vector<ElementType>::setError(int errorCode)
 {
-    this->_errorCode = true;
+    this->_errorCode = errorCode;
     ft_errno = errorCode;
     return ;
 }
@@ -149,6 +150,12 @@ template <typename ElementType>
 int ft_vector<ElementType>::get_error() const
 {
     return (this->_errorCode);
+}
+
+template <typename ElementType>
+const char* ft_vector<ElementType>::get_error_str() const
+{
+    return (ft_strerror(this->_errorCode));
 }
 
 template <typename ElementType>
@@ -162,7 +169,7 @@ void ft_vector<ElementType>::push_back(const ElementType &value)
         else
             newCapacity = 1;
         reserve(newCapacity);
-        if (this->_errorCode)
+        if (this->_errorCode != ER_SUCCESS)
             return ;
     }
     construct_at(&this->_data[this->_size], value);
@@ -181,7 +188,7 @@ void ft_vector<ElementType>::push_back(ElementType &&value)
         else
             newCapacity = 1;
         reserve(newCapacity);
-        if (this->_errorCode)
+        if (this->_errorCode != ER_SUCCESS)
             return ;
     }
     construct_at(&this->_data[this->_size], std::forward<ElementType>(value));
@@ -260,7 +267,7 @@ void ft_vector<ElementType>::resize(size_t new_size, const ElementType& value)
     else if (new_size > this->_size)
     {
         reserve(new_size);
-        if (this->_errorCode)
+        if (this->_errorCode != ER_SUCCESS)
             return ;
         for (size_t index = this->_size; index < new_size; index++)
             construct_at(&this->_data[index], value);
@@ -283,7 +290,7 @@ typename ft_vector<ElementType>::iterator ft_vector<ElementType>::insert(iterato
         else
             new_capacity = 1;
         reserve(new_capacity);
-        if (this->_errorCode)
+        if (this->_errorCode != ER_SUCCESS)
             return (end());
         pos = this->_data + index;
     }


### PR DESCRIPTION
## Summary
- standardize error management with `get_error_str()` helpers
- track vector errors with numeric code
- expose `get_error_str()` for game classes and containers

## Testing
- `make`
- `make -C Test` (builds test suite)
- `./Test/libft_tests` *(fails: requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_687d052767ec833196b44bd894c3ef08