### PR TITLE
Fix duplicate ft_swap definition

### DIFF
--- a/Template/swap.hpp
+++ b/Template/swap.hpp
@@ -1,3 +1,6 @@
+#ifndef FT_SWAP_HPP
+# define FT_SWAP_HPP
+
 #include <utility>
 
 template<typename T>
@@ -7,3 +10,5 @@ void ft_swap(T& a, T& b)
     a = std::move(b);
     b = std::move(temp);
 }
+
+#endif


### PR DESCRIPTION
## Summary
- guard `ft_swap` header to avoid redefinition errors

## Testing
- `make -C Test`
- `echo all | ./Test/libft_tests` *(tests enumerate but require input)*

------
https://chatgpt.com/codex/tasks/task_e_687d1e050510833189d4370a74a3ec7b