### PR TITLE
Add read position controls to DataBuffer

### DIFF
--- a/CPP_class/data_buffer.cpp
+++ b/CPP_class/data_buffer.cpp
@@ -24,6 +24,23 @@ const std::vector<uint8_t>& DataBuffer::data() const noexcept
     return (this->_buffer);
 }
 
+size_t DataBuffer::tell() const noexcept
+{
+    return (this->_readPos);
+}
+
+bool DataBuffer::seek(size_t pos) noexcept
+{
+    if (pos <= this->_buffer.size())
+    {
+        this->_readPos = pos;
+        this->_ok = true;
+        return (true);
+    }
+    this->_ok = false;
+    return (false);
+}
+
 DataBuffer& DataBuffer::operator<<(size_t len)
 {
     auto ptr = reinterpret_cast<const uint8_t*>(&len);

--- a/CPP_class/data_buffer.hpp
+++ b/CPP_class/data_buffer.hpp
@@ -19,6 +19,8 @@ public:
     void clear() noexcept;
     size_t size() const noexcept;
     const std::vector<uint8_t>& data() const noexcept;
+    size_t tell() const noexcept;
+    bool seek(size_t pos) noexcept;
 
     explicit operator bool() const noexcept { return (this->_ok); }
     bool good() const noexcept { return (this->_ok); }


### PR DESCRIPTION
## Summary
- allow DataBuffer to report and reposition its read offset

## Testing
- `make -C CPP_class`

------
https://chatgpt.com/codex/tasks/task_e_688e7abedc108331835561b8b18668d3