### PR TITLE
Add integer RNG utility

### DIFF
--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -1,7 +1,7 @@
 TARGET := RNG.a
 DEBUG_TARGET := RNG_debug.a
 
-SRCS := dice_roll.cpp
+SRCS := dice_roll.cpp random_int.cpp
 
 HEADERS := dice_roll.hpp
 

--- a/RNG/dice_roll.hpp
+++ b/RNG/dice_roll.hpp
@@ -21,6 +21,7 @@ inline __attribute__((always_inline)) void ft_init_srand(void)
 	return ;
 }
 
+int ft_random_int(void);
 int ft_dice_roll(int number, int faces);
 
 #endif

--- a/RNG/random_int.cpp
+++ b/RNG/random_int.cpp
@@ -1,0 +1,10 @@
+#include "dice_roll.hpp"
+
+int ft_random_int(void)
+{
+    ft_init_srand();
+    int result = 0;
+    while (result == 0)
+        result = rand();
+    return result;
+}


### PR DESCRIPTION
## Summary
- move `ft_random_int` declaration into `dice_roll.hpp` and drop standalone header
- include the unified header from `random_int.cpp`
- update RNG build to reference only `dice_roll.hpp`

## Testing
- `make -C RNG`
- `make -C RNG fclean`


------
https://chatgpt.com/codex/tasks/task_e_6894da96d5a48331905ea1ab33265290