### PR TITLE
Use ft_nullptr across library

### DIFF
--- a/CPP_class/file.cpp
+++ b/CPP_class/file.cpp
@@ -3,6 +3,7 @@
 #include "../Errno/errno.hpp"
 #include "../Printf/printf_internal.hpp"
 #include "../Printf/printf.hpp"
+#include "nullptr.hpp"
 #include <cerrno>
 #include <cstdarg>
 #include <unistd.h>
@@ -154,7 +155,7 @@ ssize_t ft_file::read(char *buffer, int count) noexcept
 
 ssize_t ft_file::write(const char *string) noexcept
 {
-    if (string == nullptr)
+    if (string == ft_nullptr)
     {
         this->set_error(FT_EINVAL);
         return (-1);

--- a/CPP_class/string_constructors.cpp
+++ b/CPP_class/string_constructors.cpp
@@ -51,7 +51,7 @@ ft_string::ft_string(ft_string&& other) noexcept
       _capacity(other._capacity),
       _errorCode(other._errorCode)
 {
-    other._data = nullptr;
+    other._data = ft_nullptr;
     other._length = 0;
     other._capacity = 0;
     other._errorCode = 0;
@@ -109,7 +109,7 @@ ft_string& ft_string::operator=(ft_string&& other) noexcept
         this->_length = other._length;
         this->_capacity = other._capacity;
         this->_errorCode = other._errorCode;
-        other._data = nullptr;
+        other._data = ft_nullptr;
         other._length = 0;
         other._capacity = 0;
         other._errorCode = 0;
@@ -152,7 +152,7 @@ void ft_string::operator delete[](void* ptr) noexcept
 }
 
 ft_string::ft_string(int errorCode) noexcept
-    : _data(nullptr)
+    : _data(ft_nullptr)
     , _length(0)
     , _capacity(0)
     , _errorCode(errorCode)

--- a/CPP_class/string_methods.cpp
+++ b/CPP_class/string_methods.cpp
@@ -149,7 +149,7 @@ void ft_string::move(ft_string& other) noexcept
         this->_length = other._length;
         this->_capacity = other._capacity;
         this->_errorCode = other._errorCode;
-        other._data = nullptr;
+        other._data = ft_nullptr;
         other._length = 0;
         other._capacity = 0;
         other._errorCode = 0;

--- a/GetNextLine/get_next_line.cpp
+++ b/GetNextLine/get_next_line.cpp
@@ -145,14 +145,14 @@ char	*get_next_line(ft_file &file)
 	while (file == -1 && index < 4096)
 	{
 		cma_free(readed_string[index]);
-		readed_string[index] = nullptr;
+		readed_string[index] = ft_nullptr;
 		index++;
 	}
 	if (BUFFER_SIZE <= 0 || file < 0)
-		return (nullptr);
+		return (ft_nullptr);
 	readed_string[file] = read_fd(file, readed_string[file]);
 	if (!readed_string[file])
-		return (nullptr);
+		return (ft_nullptr);
 	string = fetch_line(readed_string[file]);
 	readed_string[file] = leftovers(readed_string[file]);
 	return (string);

--- a/Template/iterator.hpp
+++ b/Template/iterator.hpp
@@ -1,5 +1,7 @@
-#ifndef ITERATOR_HPP
-# define ITERATOR_HPP
+ #ifndef ITERATOR_HPP
+ # define ITERATOR_HPP
+
+#include "../CPP_class/nullptr.hpp"
 
 template <typename ValueType>
 class Iterator
@@ -42,8 +44,8 @@ Iterator<ValueType>& Iterator<ValueType>::operator=(const Iterator& other)
 template <typename ValueType>
 Iterator<ValueType>::Iterator(Iterator&& other) noexcept : m_ptr(other.m_ptr)
 {
-    other.m_ptr = nullptr;
-	return ;
+    other.m_ptr = ft_nullptr;
+        return ;
 }
 
 template <typename ValueType>
@@ -52,7 +54,7 @@ Iterator<ValueType>& Iterator<ValueType>::operator=(Iterator&& other) noexcept
     if (this != &other)
     {
         m_ptr = other.m_ptr;
-        other.m_ptr = nullptr;
+        other.m_ptr = ft_nullptr;
     }
     return (*this);
 }

--- a/Template/pool.hpp
+++ b/Template/pool.hpp
@@ -133,9 +133,9 @@ typename Pool<T>::Object Pool<T>::acquire(Args&&... args)
 
 template<typename T>
 Pool<T>::Object::Object() noexcept
-    : _pool(nullptr)
+    : _pool(ft_nullptr)
     , _idx(0)
-    , _ptr(nullptr)
+    , _ptr(ft_nullptr)
 {
 	return ;
 }
@@ -169,7 +169,7 @@ T* Pool<T>::Object::operator->() const noexcept
 template<typename T>
 Pool<T>::Object::operator bool() const noexcept
 {
-    return (this->_ptr != nullptr);
+    return (this->_ptr != ft_nullptr);
 }
 
 template<typename T>
@@ -178,8 +178,8 @@ Pool<T>::Object::Object(Object&& o) noexcept
     , _idx(o._idx)
     , _ptr(o._ptr)
 {
-    o._pool = nullptr;
-    o._ptr = nullptr;
+    o._pool = ft_nullptr;
+    o._ptr = ft_nullptr;
 	return ;
 }
 
@@ -191,8 +191,8 @@ typename Pool<T>::Object& Pool<T>::Object::operator=(Object&& o) noexcept
         _pool = o._pool;
         _idx = o._idx;
         _ptr = o._ptr;
-        o._pool = nullptr;
-        o._ptr = nullptr;
+        o._pool = ft_nullptr;
+        o._ptr = ft_nullptr;
     }
     return (*this);
 }

--- a/Template/shared_ptr.hpp
+++ b/Template/shared_ptr.hpp
@@ -97,7 +97,7 @@ class ft_sharedptr
 template <typename ManagedType>
 template <typename... Args, typename>
 ft_sharedptr<ManagedType>::ft_sharedptr(Args&&... args)
-    : _managedPointer(nullptr),
+    : _managedPointer(ft_nullptr),
       _referenceCount(new (std::nothrow) int),
       _arraySize(0),
       _isArrayType(false),
@@ -122,7 +122,7 @@ ft_sharedptr<ManagedType>::ft_sharedptr(Args&&... args)
 template <typename ManagedType>
 ft_sharedptr<ManagedType>::ft_sharedptr(ManagedType* pointer, bool isArray, size_t arraySize)
     : _managedPointer(pointer),
-      _referenceCount(pointer ? new (std::nothrow) int : nullptr),
+      _referenceCount(pointer ? new (std::nothrow) int : ft_nullptr),
       _arraySize(arraySize),
       _isArrayType(isArray),
       _errorCode(ER_SUCCESS)
@@ -135,8 +135,8 @@ ft_sharedptr<ManagedType>::ft_sharedptr(ManagedType* pointer, bool isArray, size
 
 template <typename ManagedType>
 ft_sharedptr<ManagedType>::ft_sharedptr()
-    : _managedPointer(nullptr),
-      _referenceCount(nullptr),
+    : _managedPointer(ft_nullptr),
+      _referenceCount(ft_nullptr),
       _arraySize(0),
       _isArrayType(false),
       _errorCode(ER_SUCCESS)
@@ -145,7 +145,7 @@ ft_sharedptr<ManagedType>::ft_sharedptr()
 
 template <typename ManagedType>
 ft_sharedptr<ManagedType>::ft_sharedptr(size_t size)
-    : _managedPointer(nullptr),
+    : _managedPointer(ft_nullptr),
       _referenceCount(new (std::nothrow) int),
       _arraySize(size),
       _isArrayType(true),
@@ -556,7 +556,7 @@ void ft_sharedptr<ManagedType>::remove(int index)
         return ;
     }
     size_t newSize = _arraySize - 1;
-    ManagedType* newArray = (newSize > 0) ? new (std::nothrow) ManagedType[newSize] : nullptr;
+    ManagedType* newArray = (newSize > 0) ? new (std::nothrow) ManagedType[newSize] : ft_nullptr;
     if (newSize > 0 && !newArray)
     {
         this->set_error(SHARED_PTR_ALLOCATION_FAILED);

--- a/Template/vector.hpp
+++ b/Template/vector.hpp
@@ -62,7 +62,7 @@ class ft_vector
 
 template <typename ElementType>
 ft_vector<ElementType>::ft_vector(size_t initial_capacity)
-    : _data(nullptr), _size(0), _capacity(0), _errorCode(ER_SUCCESS)
+    : _data(ft_nullptr), _size(0), _capacity(0), _errorCode(ER_SUCCESS)
 {
     if (initial_capacity > 0)
     {
@@ -80,7 +80,7 @@ template <typename ElementType>
 ft_vector<ElementType>::~ft_vector()
 {
     destroy_elements(0, this->_size);
-    if (this->_data != nullptr)
+    if (this->_data != ft_nullptr)
         cma_free(this->_data);
     return ;
 }
@@ -92,7 +92,7 @@ ft_vector<ElementType>::ft_vector(ft_vector<ElementType>&& other) noexcept
       _capacity(other._capacity),
       _errorCode(other._errorCode)
 {
-    other._data = nullptr;
+    other._data = ft_nullptr;
     other._size = 0;
     other._capacity = 0;
     other._errorCode = ER_SUCCESS;
@@ -104,13 +104,13 @@ ft_vector<ElementType>& ft_vector<ElementType>::operator=(ft_vector<ElementType>
     if (this != &other)
     {
         destroy_elements(0, this->_size);
-        if (this->_data != nullptr)
+        if (this->_data != ft_nullptr)
             cma_free(this->_data);
         this->_data = other._data;
         this->_size = other._size;
         this->_capacity = other._capacity;
         this->_errorCode = other._errorCode;
-        other._data = nullptr;
+        other._data = ft_nullptr;
         other._size = 0;
         other._capacity = 0;
         other._errorCode = ER_SUCCESS;
@@ -248,7 +248,7 @@ void ft_vector<ElementType>::reserve(size_t new_capacity)
     {
         ElementType* new_data = static_cast<ElementType*>(cma_realloc(this->_data,
                     new_capacity * sizeof(ElementType)));
-        if (new_data == nullptr)
+        if (new_data == ft_nullptr)
         {
             this->setError(VECTOR_ALLOC_FAIL);
             return ;

--- a/Test/template_tests.cpp
+++ b/Test/template_tests.cpp
@@ -142,7 +142,7 @@ int test_ft_unique_ptr_release(void)
 {
     ft_uniqueptr<int> up(new int(42));
     int* raw = up.release_ptr();
-    bool ok = (raw != nullptr && *raw == 42 && !up);
+    bool ok = (raw != ft_nullptr && *raw == 42 && !up);
     delete raw;
     return ok;
 }


### PR DESCRIPTION
## Summary
- Replace remaining uses of `nullptr` with the library's `ft_nullptr`
- Include `nullptr.hpp` where needed for pointer constants
- Update tests to reference `ft_nullptr`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6898daa7aea88331a822ba436f567334