### PR TITLE
Template-based min/max utilities

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -24,8 +24,8 @@ SRCS := ft_atoi.cpp \
 	ft_tolower.cpp \
 	ft_strncpy.cpp \
     ft_isspace.cpp \
-	ft_strlen_size_t.cpp \
-	ft_abs.cpp
+        ft_strlen_size_t.cpp \
+        ft_abs.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -36,6 +36,6 @@ void		ft_to_upper(char *string);
 char 		*ft_strncpy(char *destination, const char *source, size_t number_of_characters);
 void 		*ft_memset(void *destination, int value, size_t number_of_bytes);
 int 		ft_isspace(int character);
-int 		ft_abs(int number);
+int             ft_abs(int number);
 
 #endif

--- a/Template/math.hpp
+++ b/Template/math.hpp
@@ -1,40 +1,39 @@
 #ifndef MATH_HPP
 #define MATH_HPP
 
-#include <type_traits>
 #include <cstddef>
 #include <type_traits>
 
-template <typename T>
-const T& ft_max(const T& a, const T& b)
-{
-    if (a > b)
-		return (a);
-	return (b);
-}
-
-template <typename T, typename Compare>
-const T& ft_max(const T& a, const T& b, Compare comp)
-{
-	if (comp(a, b))
-        return (b);
-	return (a);
-}
-
-template <typename T>
-const T& ft_min(const T& a, const T& b)
+template <typename T, typename U>
+constexpr std::common_type_t<T, U> ft_max(const T& a, const U& b) noexcept
 {
     if (a < b)
-		return (a);
-	return (b);
+        return b;
+    return a;
 }
 
-template <typename T, typename Compare>
-const T& ft_min(const T& a, const T& b, Compare comp)
+template <typename T, typename U, typename Compare>
+constexpr std::common_type_t<T, U> ft_max(const T& a, const U& b, Compare comp) noexcept
 {
-	if (comp(a, b))
-        return (b);
-	return (a);
+    if (comp(a, b))
+        return b;
+    return a;
+}
+
+template <typename T, typename U>
+constexpr std::common_type_t<T, U> ft_min(const T& a, const U& b) noexcept
+{
+    if (b < a)
+        return b;
+    return a;
+}
+
+template <typename T, typename U, typename Compare>
+constexpr std::common_type_t<T, U> ft_min(const T& a, const U& b, Compare comp) noexcept
+{
+    if (comp(b, a))
+        return b;
+    return a;
 }
 
 template <typename... Args>
@@ -43,4 +42,4 @@ struct is_single_convertible_to_size_t : std::false_type {};
 template <typename Arg>
 struct is_single_convertible_to_size_t<Arg> : std::is_convertible<std::decay_t<Arg>, size_t> {};
 
-#endif
+#endif // MATH_HPP

--- a/ToDoList
+++ b/ToDoList
@@ -25,7 +25,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 - ft_fprintf: fprintf-like formatted output.
 
 ## General Utilities
-- ft_min / ft_max.
 - ft_swap.
 - ft_clamp.
 


### PR DESCRIPTION
## Summary
- replace int-only ft_min/ft_max with templated versions that support mixed numeric types
- drop dedicated source files and declarations from libft and adjust build list

## Testing
- `cd Libft && make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_689f36a9c7dc8331867da501487aa962