### PR TITLE
Implement ft_swap utility

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -25,7 +25,8 @@ SRCS := ft_atoi.cpp \
 	ft_strncpy.cpp \
     ft_isspace.cpp \
     ft_strlen_size_t.cpp \
-    ft_abs.cpp
+    ft_abs.cpp \
+    ft_swap.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/ft_swap.cpp
+++ b/Libft/ft_swap.cpp
@@ -1,0 +1,13 @@
+#include "libft.hpp"
+
+void ft_swap(int *a, int *b)
+{
+    int tmp;
+
+    if (!a || !b)
+        return;
+    tmp = *a;
+    *a = *b;
+    *b = tmp;
+}
+

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -37,5 +37,6 @@ char 		*ft_strncpy(char *destination, const char *source, size_t number_of_chara
 void 		*ft_memset(void *destination, int value, size_t number_of_bytes);
 int 		ft_isspace(int character);
 int         ft_abs(int number);
+void            ft_swap(int *a, int *b);
 
 #endif

--- a/Template/shared_ptr.hpp
+++ b/Template/shared_ptr.hpp
@@ -4,6 +4,7 @@
 #include "../Errno/errno.hpp"
 #include "../CPP_class/nullptr.hpp"
 #include "math.hpp"
+#include "swap.hpp"
 #include <cstddef>
 #include <utility>
 #include <type_traits>
@@ -510,11 +511,11 @@ void ft_sharedptr<ManagedType>::reset(ManagedType* pointer, size_t size, bool ar
 template <typename ManagedType>
 void ft_sharedptr<ManagedType>::swap(ft_sharedptr<ManagedType>& other)
 {
-    std::swap(_managedPointer, other._managedPointer);
-    std::swap(_referenceCount, other._referenceCount);
-    std::swap(_arraySize, other._arraySize);
-    std::swap(_isArrayType, other._isArrayType);
-    std::swap(_errorCode, other._errorCode);
+    ft_swap(_managedPointer, other._managedPointer);
+    ft_swap(_referenceCount, other._referenceCount);
+    ft_swap(_arraySize, other._arraySize);
+    ft_swap(_isArrayType, other._isArrayType);
+    ft_swap(_errorCode, other._errorCode);
     return ;
 }
 

--- a/Template/unique_ptr.hpp
+++ b/Template/unique_ptr.hpp
@@ -4,6 +4,7 @@
 #include "../Errno/errno.hpp"
 #include "../CPP_class/nullptr.hpp"
 #include "math.hpp"
+#include "swap.hpp"
 #include <cstddef>
 #include <utility>
 #include <type_traits>
@@ -381,10 +382,10 @@ ft_uniqueptr<ManagedType>::operator bool() const noexcept
 template <typename ManagedType>
 void ft_uniqueptr<ManagedType>::swap(ft_uniqueptr& other)
 {
-    std::swap(_managedPointer, other._managedPointer);
-    std::swap(_arraySize, other._arraySize);
-    std::swap(_isArrayType, other._isArrayType);
-    std::swap(_errorCode, other._errorCode);
+    ft_swap(_managedPointer, other._managedPointer);
+    ft_swap(_arraySize, other._arraySize);
+    ft_swap(_isArrayType, other._isArrayType);
+    ft_swap(_errorCode, other._errorCode);
 }
 
 template <typename ManagedType>

--- a/ToDoList
+++ b/ToDoList
@@ -25,7 +25,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 - ft_fprintf: fprintf-like formatted output.
 
 ## General Utilities
-- ft_swap.
 - ft_clamp.
 
 ## Mathematical Functions


### PR DESCRIPTION
## Summary
- add `ft_swap` function to Libft and expose in header
- update build script to compile `ft_swap`
- remove `ft_swap` from ToDo list
- use `ft_swap` in template smart pointers instead of `std::swap`

## Testing
- `make -C Libft`


------
https://chatgpt.com/codex/tasks/task_e_689f3be72fec83318c2eec130f6be21a