### PR TITLE
Add string mapping and iteration utilities

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -21,8 +21,10 @@ SRCS := ft_atoi.cpp \
     ft_isalnum.cpp \
     ft_strcmp.cpp \
 	ft_toupper.cpp \
-	ft_tolower.cpp \
-	ft_strncpy.cpp \
+        ft_tolower.cpp \
+        ft_strncpy.cpp \
+        ft_strmapi.cpp \
+        ft_striteri.cpp \
     ft_isspace.cpp \
     ft_strlen_size_t.cpp \
     ft_abs.cpp \

--- a/Libft/ft_striteri.cpp
+++ b/Libft/ft_striteri.cpp
@@ -1,0 +1,14 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+void ft_striteri(char *string, void (*function)(unsigned int, char *))
+{
+    if (string == ft_nullptr || function == ft_nullptr)
+        return;
+    unsigned int index = 0;
+    while (string[index] != '\0')
+    {
+        function(index, &string[index]);
+        index++;
+    }
+}

--- a/Libft/ft_strmapi.cpp
+++ b/Libft/ft_strmapi.cpp
@@ -1,0 +1,21 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include "../CMA/CMA.hpp"
+
+char *ft_strmapi(const char *string, char (*function)(unsigned int, char))
+{
+    if (string == ft_nullptr || function == ft_nullptr)
+        return (ft_nullptr);
+    size_t length = ft_strlen_size_t(string);
+    char *result = static_cast<char*>(cma_malloc(length + 1));
+    if (result == ft_nullptr)
+        return (ft_nullptr);
+    unsigned int index = 0;
+    while (index < length)
+    {
+        result[index] = function(index, string[index]);
+        index++;
+    }
+    result[length] = '\0';
+    return (result);
+}

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -38,5 +38,7 @@ void 		*ft_memset(void *destination, int value, size_t number_of_bytes);
 int 		ft_isspace(int character);
 int         ft_abs(int number);
 void        ft_swap(int *a, int *b);
+char            *ft_strmapi(const char *string, char (*function)(unsigned int, char));
+void            ft_striteri(char *string, void (*function)(unsigned int, char *));
 
 #endif

--- a/ToDoList
+++ b/ToDoList
@@ -4,8 +4,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 
 ## String Utilities
 - ft_strjoin_multiple: join an arbitrary number of strings.
-- ft_strmapi: apply a callback to each character and return a new string.
-- ft_striteri: apply a callback to each character in place.
 
 ## Memory Utilities
 - ft_memdup: duplicate a block of memory.


### PR DESCRIPTION
## Summary
- implement `ft_strmapi` to build a new string by applying a callback to each character
- add `ft_striteri` for in-place character iteration
- rename variables to use descriptive names for clarity

## Testing
- `make -C Libft`


------
https://chatgpt.com/codex/tasks/task_e_689f40d554808331ae430a98f89e2a65