### PR TITLE
Implement ft_clamp and ft_memdup utilities

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -7,6 +7,7 @@ SRCS := ft_atoi.cpp \
 	ft_memcmp.cpp \
 	ft_memcpy.cpp \
 	ft_memmove.cpp \
+        ft_memdup.cpp \
 	ft_memset.cpp \
 	ft_strchr.cpp \
 	ft_strlcat.cpp \
@@ -28,7 +29,8 @@ SRCS := ft_atoi.cpp \
     ft_isspace.cpp \
     ft_strlen_size_t.cpp \
     ft_abs.cpp \
-    ft_swap.cpp
+    ft_swap.cpp \
+    ft_clamp.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/ft_clamp.cpp
+++ b/Libft/ft_clamp.cpp
@@ -1,0 +1,10 @@
+#include "libft.hpp"
+
+int ft_clamp(int value, int min, int max)
+{
+    if (value < min)
+        return (min);
+    if (value > max)
+        return (max);
+    return (value);
+}

--- a/Libft/ft_memdup.cpp
+++ b/Libft/ft_memdup.cpp
@@ -1,0 +1,14 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include "../CMA/CMA.hpp"
+
+void *ft_memdup(const void *source, size_t size)
+{
+    if (source == ft_nullptr || size == 0)
+        return (ft_nullptr);
+    void *duplicate = cma_malloc(size);
+    if (duplicate == ft_nullptr)
+        return (ft_nullptr);
+    ft_memcpy(duplicate, source, size);
+    return (duplicate);
+}

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -19,6 +19,7 @@ void		ft_bzero(void *string, size_t size);
 void		*ft_memchr(const void *pointer, int character, size_t size);
 void		*ft_memcpy(void* destination, const void* source, size_t num);
 void		*ft_memmove(void *destination, const void *source, size_t size);
+void            *ft_memdup(const void *source, size_t size);
 char		*ft_strchr(const char *string, int char_to_find);
 size_t		ft_strlcat(char *destination, const char *source, size_t bufferSize);
 size_t		ft_strlcpy(char *destination, const char *source, size_t bufferSize);
@@ -38,6 +39,7 @@ void 		*ft_memset(void *destination, int value, size_t number_of_bytes);
 int 		ft_isspace(int character);
 int         ft_abs(int number);
 void        ft_swap(int *a, int *b);
+int         ft_clamp(int value, int min, int max);
 char        *ft_strmapi(const char *string, char (*function)(unsigned int, char));
 void        ft_striteri(char *string, void (*function)(unsigned int, char *));
 

--- a/ToDoList
+++ b/ToDoList
@@ -6,7 +6,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 - ft_strjoin_multiple: join an arbitrary number of strings.
 
 ## Memory Utilities
-- ft_memdup: duplicate a block of memory.
 - ft_array_resize: safe array resizing helper.
 
 ## Logging, Randomness and Timing
@@ -23,7 +22,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 - ft_fprintf: fprintf-like formatted output.
 
 ## General Utilities
-- ft_clamp.
 
 ## Mathematical Functions
 - ft_sqrt.


### PR DESCRIPTION
## Summary
- add `ft_clamp` to enforce numeric bounds
- add `ft_memdup` for duplicating memory blocks
- include new functions in the build and public header
- remove completed tasks from the to-do list

## Testing
- `make -C Libft`

------
https://chatgpt.com/codex/tasks/task_e_689f459693188331a8c086496fcd63b4