### PR TITLE
Add strtol and strtoul conversions

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -17,6 +17,8 @@ SRCS := ft_atoi.cpp \
 	ft_strnstr.cpp \
 	ft_strrchr.cpp \
 	ft_atol.cpp \
+        ft_strtol.cpp \
+        ft_strtoul.cpp \
     ft_isdigit.cpp \
     ft_isalpha.cpp \
     ft_isalnum.cpp \

--- a/Libft/ft_strtol.cpp
+++ b/Libft/ft_strtol.cpp
@@ -1,0 +1,54 @@
+#include "libft.hpp"
+
+static int ft_get_digit(char c)
+{
+    if (c >= '0' && c <= '9')
+        return (c - '0');
+    if (c >= 'a' && c <= 'z')
+        return (c - 'a' + 10);
+    if (c >= 'A' && c <= 'Z')
+        return (c - 'A' + 10);
+    return (-1);
+}
+
+long ft_strtol(const char *nptr, char **endptr, int base)
+{
+    const char *s = nptr;
+    long sign = 1;
+    unsigned long result = 0;
+    int digit;
+
+    while (*s == ' ' || (*s >= '\t' && *s <= '\r'))
+        s++;
+    if (*s == '+' || *s == '-')
+    {
+        if (*s == '-')
+            sign = -1;
+        s++;
+    }
+    if (base == 0)
+    {
+        if (*s == '0')
+        {
+            if (s[1] == 'x' || s[1] == 'X')
+            {
+                base = 16;
+                s += 2;
+            }
+            else
+                base = 8;
+        }
+        else
+            base = 10;
+    }
+    else if (base == 16 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+        s += 2;
+    while ((digit = ft_get_digit(*s)) >= 0 && digit < base)
+    {
+        result = result * base + digit;
+        s++;
+    }
+    if (endptr)
+        *endptr = (char *)s;
+    return ((long)(result * sign));
+}

--- a/Libft/ft_strtoul.cpp
+++ b/Libft/ft_strtoul.cpp
@@ -1,0 +1,7 @@
+#include "libft.hpp"
+
+unsigned long ft_strtoul(const char *nptr, char **endptr, int base)
+{
+    long value = ft_strtol(nptr, endptr, base);
+    return ((unsigned long)value);
+}

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -31,6 +31,8 @@ int			ft_isdigit(int character);
 int         ft_isalpha(int character);
 int         ft_isalnum(int character);
 long		ft_atol(const char *string);
+long            ft_strtol(const char *nptr, char **endptr, int base);
+unsigned long   ft_strtoul(const char *nptr, char **endptr, int base);
 int			ft_strcmp(const char *string1, const char *string2);
 void		ft_to_lower(char *string);
 void		ft_to_upper(char *string);

--- a/ToDoList
+++ b/ToDoList
@@ -11,7 +11,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 - ft_time: current time formatting and delta measurement.
 
 ## Conversion Functions
-- ft_strtol / ft_strtoul: string to long / unsigned long.
 
 ## File I/O
 - ft_fopen, ft_fclose, ft_fread, ft_fwrite.


### PR DESCRIPTION
## Summary
- implement `ft_strtol` and `ft_strtoul` for string to long conversions
- expose new functions in `libft.hpp` and build config
- remove completed todo entry

## Testing
- `make`
- `make -C Test`
- `./Test/libft_tests` (prompt displayed but interactive tests require user input)

------
https://chatgpt.com/codex/tasks/task_e_689f534f3c908331a94f3c42a5513e30