### PR TITLE
Add ft_getenv utility function

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -36,7 +36,8 @@ SRCS := ft_atoi.cpp \
     ft_clamp.cpp \
     ft_pow.cpp \
     ft_sqrt.cpp \
-    ft_exp.cpp
+    ft_exp.cpp \
+    ft_getenv.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/ft_getenv.cpp
+++ b/Libft/ft_getenv.cpp
@@ -1,0 +1,11 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdlib>
+
+char    *ft_getenv(const char *name)
+{
+    if (name == ft_nullptr)
+        return (ft_nullptr);
+    return (std::getenv(name));
+}
+

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -48,5 +48,6 @@ double      	ft_exp(double x);
 char        	*ft_strjoin_multiple(int count, ...);
 char        	*ft_strmapi(const char *string, char (*function)(unsigned int, char));
 void        	ft_striteri(char *string, void (*function)(unsigned int, char *));
+char            *ft_getenv(const char *name);
 
 #endif

--- a/ToDoList
+++ b/ToDoList
@@ -96,6 +96,5 @@ Asynchronous value communication.
 - Future: ft_future_get, ft_future_wait, ft_future_valid.
 
 ## Configuration & Environment
-- ft_getenv.
 - ft_setenv.
 - ft_config_parse.


### PR DESCRIPTION
## Summary
- implement `ft_getenv` to fetch environment variable values
- expose `ft_getenv` in library header and build system
- remove `ft_getenv` entry from the to-do list

## Testing
- `make -C Libft`


------
https://chatgpt.com/codex/tasks/task_e_689f564182948331b7f34bffe003c077