### PR TITLE
Add environment variable utilities

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -37,7 +37,9 @@ SRCS := ft_atoi.cpp \
     ft_pow.cpp \
     ft_sqrt.cpp \
     ft_exp.cpp \
-    ft_getenv.cpp
+    ft_getenv.cpp \
+    ft_setenv.cpp \
+    ft_unsetenv.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/ft_setenv.cpp
+++ b/Libft/ft_setenv.cpp
@@ -1,0 +1,17 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdlib>
+
+int ft_setenv(const char *name, const char *value, int overwrite)
+{
+    if (name == ft_nullptr || value == ft_nullptr)
+        return (-1);
+#if defined(_WIN32) || defined(_WIN64)
+    if (!overwrite && std::getenv(name) != ft_nullptr)
+        return (0);
+    return (_putenv_s(name, value));
+#else
+    return (setenv(name, value, overwrite));
+#endif
+}
+

--- a/Libft/ft_unsetenv.cpp
+++ b/Libft/ft_unsetenv.cpp
@@ -1,0 +1,15 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdlib>
+
+int ft_unsetenv(const char *name)
+{
+    if (name == ft_nullptr)
+        return (-1);
+#if defined(_WIN32) || defined(_WIN64)
+    return (_putenv_s(name, ""));
+#else
+    return (unsetenv(name));
+#endif
+}
+

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -49,5 +49,7 @@ char        	*ft_strjoin_multiple(int count, ...);
 char        	*ft_strmapi(const char *string, char (*function)(unsigned int, char));
 void        	ft_striteri(char *string, void (*function)(unsigned int, char *));
 char            *ft_getenv(const char *name);
+int             ft_setenv(const char *name, const char *value, int overwrite);
+int             ft_unsetenv(const char *name);
 
 #endif

--- a/ToDoList
+++ b/ToDoList
@@ -96,5 +96,4 @@ Asynchronous value communication.
 - Future: ft_future_get, ft_future_wait, ft_future_valid.
 
 ## Configuration & Environment
-- ft_setenv.
 - ft_config_parse.


### PR DESCRIPTION
## Summary
- add cross-platform `ft_unsetenv` for removing environment variables
- expose `ft_unsetenv` in the public header and build system

## Testing
- `make -C Libft`


------
https://chatgpt.com/codex/tasks/task_e_689f6afc3c808331a68abbb5e4015ce5