### PR TITLE
feat: add getenv and setenv utilities

### DIFF
--- a/Libft/ft_getenv.cpp
+++ b/Libft/ft_getenv.cpp
@@ -4,7 +4,7 @@
 
 char    *ft_getenv(const char *name)
 {
-    if (name == ft_nullptr)
+    if (name == ft_nullptr || *name == '\0')
         return (ft_nullptr);
     return (std::getenv(name));
 }

--- a/Libft/ft_setenv.cpp
+++ b/Libft/ft_setenv.cpp
@@ -4,7 +4,7 @@
 
 int ft_setenv(const char *name, const char *value, int overwrite)
 {
-    if (name == ft_nullptr || value == ft_nullptr)
+    if (name == ft_nullptr || value == ft_nullptr || *name == '\0' || ft_strchr(name, '=') != ft_nullptr)
         return (-1);
 #if defined(_WIN32) || defined(_WIN64)
     if (!overwrite && std::getenv(name) != ft_nullptr)

--- a/Test/extra_libft_tests.cpp
+++ b/Test/extra_libft_tests.cpp
@@ -294,3 +294,24 @@ int test_atol_longmin(void)
     return (ft_atol(s.c_str()) == LONG_MIN);
 }
 
+int test_setenv_getenv_basic(void)
+{
+    if (ft_setenv("LIBFT_TEST_VAR", "hello", 1) != 0)
+        return (0);
+    char *val = ft_getenv("LIBFT_TEST_VAR");
+    int ok = val != ft_nullptr && std::strcmp(val, "hello") == 0;
+    ft_unsetenv("LIBFT_TEST_VAR");
+    return (ok);
+}
+
+int test_setenv_no_overwrite(void)
+{
+    if (ft_setenv("LIBFT_TEST_VAR2", "first", 1) != 0)
+        return (0);
+    ft_setenv("LIBFT_TEST_VAR2", "second", 0);
+    char *val = ft_getenv("LIBFT_TEST_VAR2");
+    int ok = val != ft_nullptr && std::strcmp(val, "first") == 0;
+    ft_unsetenv("LIBFT_TEST_VAR2");
+    return (ok);
+}
+

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -95,6 +95,8 @@ int test_atol_basic(void);
 int test_atol_whitespace(void);
 int test_atol_longmax(void);
 int test_atol_longmin(void);
+int test_setenv_getenv_basic(void);
+int test_setenv_no_overwrite(void);
 int test_ft_string_append(void);
 int test_ft_string_concat(void);
 int test_data_buffer_io(void);
@@ -194,6 +196,8 @@ int main(void)
         { test_atol_whitespace, "atol whitespace" },
         { test_atol_longmax, "atol longmax" },
         { test_atol_longmin, "atol longmin" },
+        { test_setenv_getenv_basic, "setenv/getenv basic" },
+        { test_setenv_no_overwrite, "setenv no overwrite" },
         { test_strlen_size_t_empty, "strlen_size_t empty" },
         { test_bzero_zero, "bzero zero" },
         { test_memcpy_partial, "memcpy partial" },


### PR DESCRIPTION
## Summary
- safeguard ft_getenv against null or empty names
- improve ft_setenv with name validation and Windows overwrite handling
- add tests covering basic environment variable usage

## Testing
- `make -C Test`
- `script -q -c "printf 'all\nn\n' | ./Test/libft_tests" /tmp/test_run.log` *(fails: interactive tests require a TTY)*

------
https://chatgpt.com/codex/tasks/task_e_689f75464f3483318840ca46fc06fd48