### PR TITLE
feat(errno): add ft_exit helper

### DIFF
--- a/Errno/Makefile
+++ b/Errno/Makefile
@@ -2,7 +2,8 @@ TARGET := errno.a
 DEBUG_TARGET := errno_debug.a
 
 SRCS :=		strerror.cpp \
-		perror.cpp
+		perror.cpp \
+                exit.cpp
 
 HEADERS := errno.hpp
 

--- a/Errno/compile_commands.json
+++ b/Errno/compile_commands.json
@@ -10,11 +10,47 @@
       "-std=c++17",
       "-c",
       "-o",
-      "objs/errno.o",
-      "errno.cpp"
+      "objs/strerror.o",
+      "strerror.cpp"
     ],
-    "directory": "/home/adyem/DND_tools/libft/Errno",
-    "file": "/home/adyem/DND_tools/libft/Errno/errno.cpp",
-    "output": "/home/adyem/DND_tools/libft/Errno/objs/errno.o"
+    "directory": "/workspace/Libft/Errno",
+    "file": "/workspace/Libft/Errno/strerror.cpp",
+    "output": "/workspace/Libft/Errno/objs/strerror.o"
+  },
+  {
+    "arguments": [
+      "/usr/bin/g++",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g",
+      "-O0",
+      "-std=c++17",
+      "-c",
+      "-o",
+      "objs/perror.o",
+      "perror.cpp"
+    ],
+    "directory": "/workspace/Libft/Errno",
+    "file": "/workspace/Libft/Errno/perror.cpp",
+    "output": "/workspace/Libft/Errno/objs/perror.o"
+  },
+  {
+    "arguments": [
+      "/usr/bin/g++",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g",
+      "-O0",
+      "-std=c++17",
+      "-c",
+      "-o",
+      "objs/exit.o",
+      "exit.cpp"
+    ],
+    "directory": "/workspace/Libft/Errno",
+    "file": "/workspace/Libft/Errno/exit.cpp",
+    "output": "/workspace/Libft/Errno/objs/exit.o"
   }
 ]

--- a/Errno/errno.hpp
+++ b/Errno/errno.hpp
@@ -71,5 +71,6 @@ enum PTErrorCode
 
 const char* ft_strerror(int error_code);
 void		ft_perror(const char *error_msg);
+void            ft_exit(const char *error_msg, int exit_code);
 
 #endif

--- a/Errno/exit.cpp
+++ b/Errno/exit.cpp
@@ -1,0 +1,15 @@
+#include "errno.hpp"
+#include "../Printf/printf.hpp"
+#include <cstdlib>
+
+void	ft_exit(const char *error_msg, int exit_code)
+{
+	if (error_msg && ft_errno != ER_SUCCESS)
+		pf_printf_fd(2, "%s: %s\n", error_msg, ft_strerror(ft_errno));
+	else if (error_msg)
+		pf_printf_fd(2, "%s\n", error_msg);
+	else if (ft_errno != ER_SUCCESS)
+		pf_printf_fd(2, "%s\n", ft_strerror(ft_errno));
+	std::exit(exit_code);
+}
+

--- a/ToDoList
+++ b/ToDoList
@@ -79,7 +79,6 @@ Fixed-size buffer that wraps around.
 Functions: ft_circular_buffer_new, ft_circular_buffer_push, ft_circular_buffer_pop, ft_circular_buffer_is_full, ft_circular_buffer_is_empty.
 
 ## Error Handling
-- ft_exit: exit with message and clean-up.
 
 ## Additional Features
 - ft_printf_fd: broaden format specifiers and allow multiple descriptors.


### PR DESCRIPTION
## Summary
- add ft_exit function to print an error message and exit with a code
- wire ft_exit into errno module build files and headers
- update to-do list to reflect completed error handler

## Testing
- `make -C Errno`


------
https://chatgpt.com/codex/tasks/task_e_689f806ae9848331b031632c243b847f