### PR TITLE
feat(rng): add random float generator

### DIFF
--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -19,6 +19,7 @@
 #include "PThread/mutex.hpp"
 #include "Printf/printf.hpp"
 #include "Printf/printf_internal.hpp"
+#include "RNG/RNG.hpp"
 #include "RNG/deck.hpp"
 #include "RNG/dice_roll.hpp"
 #include "ReadLine/readline.hpp"

--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -1,7 +1,7 @@
 TARGET := RNG.a
 DEBUG_TARGET := RNG_debug.a
 
-SRCS := dice_roll.cpp random_int.cpp
+SRCS := dice_roll.cpp random_int.cpp random_float.cpp
 
 HEADERS := RNG.hpp
 

--- a/RNG/RNG.hpp
+++ b/RNG/RNG.hpp
@@ -10,5 +10,6 @@
 
 int ft_random_int(void);
 int ft_dice_roll(int number, int faces);
+float ft_random_float(void);
 
 #endif

--- a/RNG/random_float.cpp
+++ b/RNG/random_float.cpp
@@ -1,0 +1,12 @@
+#include "RNG.hpp"
+#include "RNG_internal.hpp"
+
+float ft_random_float(void)
+{
+    ft_init_srand();
+    float result = 0.0f;
+    while (result == 0.0f)
+        result = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    return result;
+}
+

--- a/ToDoList
+++ b/ToDoList
@@ -4,7 +4,7 @@ This document tracks outstanding work for the library. Items are grouped by doma
 
 ## Logging, Randomness and Timing
 - ft_logger: lightweight logging with levels (info, warn, error).
-- ft_random: random number generator (integers, floats, seeding).
+- ft_random: random number generator (integers, floats, seeding). (float support implemented)
 - ft_time: current time formatting and delta measurement.
 
 ## Conversion Functions


### PR DESCRIPTION
## Summary
- add `ft_random_float` to generate non-zero floating-point values
- expose random float API and build it into RNG and aggregate headers
- note completed float support in TODO list

## Testing
- `make -C RNG`
- `make -C Test`
- `./Test/libft_tests` *(prompts for input and exits without running tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f84797ce883319b722e5fc6110a22