### PR TITLE
Implement queue data structure

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -41,6 +41,7 @@ SRCS := ft_atoi.cpp \
     ft_setenv.cpp \
     ft_unsetenv.cpp \
     ft_stack.cpp \
+    ft_queue.cpp \
     ft_time.cpp
 
 ifeq ($(OS),Windows_NT)

--- a/Libft/ft_queue.cpp
+++ b/Libft/ft_queue.cpp
@@ -1,0 +1,85 @@
+#include "libft.hpp"
+#include "../CMA/CMA.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+
+t_queue *ft_queue_new(void)
+{
+    t_queue *queue = static_cast<t_queue*>(cma_malloc(sizeof(t_queue)));
+    if (queue == ft_nullptr)
+        return (ft_nullptr);
+    queue->front = ft_nullptr;
+    queue->rear = ft_nullptr;
+    queue->size = 0;
+    return (queue);
+}
+
+int ft_queue_enqueue(t_queue *queue, void *data)
+{
+    if (queue == ft_nullptr)
+        return (FAILURE);
+    t_queue_node *node = static_cast<t_queue_node*>(cma_malloc(sizeof(t_queue_node)));
+    if (node == ft_nullptr)
+        return (FAILURE);
+    node->data = data;
+    node->next = ft_nullptr;
+    if (queue->rear == ft_nullptr)
+    {
+        queue->front = node;
+        queue->rear = node;
+    }
+    else
+    {
+        queue->rear->next = node;
+        queue->rear = node;
+    }
+    queue->size++;
+    return (SUCCES);
+}
+
+void *ft_queue_dequeue(t_queue *queue)
+{
+    if (queue == ft_nullptr || queue->front == ft_nullptr)
+        return (ft_nullptr);
+    t_queue_node *node = queue->front;
+    void *data = node->data;
+    queue->front = node->next;
+    if (queue->front == ft_nullptr)
+        queue->rear = ft_nullptr;
+    queue->size--;
+    cma_free(node);
+    return (data);
+}
+
+void *ft_queue_front(t_queue *queue)
+{
+    if (queue == ft_nullptr || queue->front == ft_nullptr)
+        return (ft_nullptr);
+    return (queue->front->data);
+}
+
+size_t ft_queue_size(t_queue *queue)
+{
+    if (queue == ft_nullptr)
+        return (0);
+    return (queue->size);
+}
+
+void ft_queue_clear(t_queue *queue, void (*del)(void *))
+{
+    if (queue == ft_nullptr)
+        return;
+    t_queue_node *node = queue->front;
+    while (node != ft_nullptr)
+    {
+        t_queue_node *next = node->next;
+        if (del)
+            del(node->data);
+        cma_free(node);
+        node = next;
+    }
+    queue->front = ft_nullptr;
+    queue->rear = ft_nullptr;
+    queue->size = 0;
+}
+

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -74,4 +74,24 @@ void            *ft_stack_top(t_stack *stack);
 size_t          ft_stack_size(t_stack *stack);
 void            ft_stack_clear(t_stack *stack, void (*del)(void *));
 
+typedef struct s_queue_node
+{
+    void            *data;
+    s_queue_node    *next;
+}   t_queue_node;
+
+typedef struct s_queue
+{
+    t_queue_node    *front;
+    t_queue_node    *rear;
+    size_t          size;
+}   t_queue;
+
+t_queue        *ft_queue_new(void);
+int            ft_queue_enqueue(t_queue *queue, void *data);
+void           *ft_queue_dequeue(t_queue *queue);
+void           *ft_queue_front(t_queue *queue);
+size_t         ft_queue_size(t_queue *queue);
+void           ft_queue_clear(t_queue *queue, void (*del)(void *));
+
 #endif

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,7 +1,7 @@
 TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
-SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp game_tests.cpp
+SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp game_tests.cpp queue_tests.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -143,6 +143,7 @@ int test_item_stack_subtract(void);
 int test_reputation_subtracters(void);
 int test_character_level(void);
 int test_quest_progress(void);
+int test_queue_basic(void);
 
 int main(void)
 {
@@ -262,7 +263,8 @@ int main(void)
         { test_item_stack_subtract, "item stack subtract" },
         { test_reputation_subtracters, "reputation subtracters" },
         { test_character_level, "character level" },
-        { test_quest_progress, "quest progress" }
+        { test_quest_progress, "quest progress" },
+        { test_queue_basic, "queue basic" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
 

--- a/Test/queue_tests.cpp
+++ b/Test/queue_tests.cpp
@@ -1,0 +1,61 @@
+#include "../Libft/libft.hpp"
+#include "../CMA/CMA.hpp"
+#include "../CPP_class/nullptr.hpp"
+
+int test_queue_basic(void)
+{
+    t_queue *queue = ft_queue_new();
+    if (!queue)
+        return (0);
+    int a = 1;
+    int b = 2;
+    if (ft_queue_enqueue(queue, &a) != SUCCES)
+    {
+        ft_queue_clear(queue, ft_nullptr);
+        cma_free(queue);
+        return (0);
+    }
+    if (ft_queue_enqueue(queue, &b) != SUCCES)
+    {
+        ft_queue_clear(queue, ft_nullptr);
+        cma_free(queue);
+        return (0);
+    }
+    if (*(int *)ft_queue_front(queue) != 1)
+    {
+        ft_queue_clear(queue, ft_nullptr);
+        cma_free(queue);
+        return (0);
+    }
+    int *first = static_cast<int *>(ft_queue_dequeue(queue));
+    if (!first || *first != 1)
+    {
+        ft_queue_clear(queue, ft_nullptr);
+        cma_free(queue);
+        return (0);
+    }
+    int *second = static_cast<int *>(ft_queue_dequeue(queue));
+    if (!second || *second != 2)
+    {
+        ft_queue_clear(queue, ft_nullptr);
+        cma_free(queue);
+        return (0);
+    }
+    int *none = static_cast<int *>(ft_queue_dequeue(queue));
+    if (none != ft_nullptr)
+    {
+        ft_queue_clear(queue, ft_nullptr);
+        cma_free(queue);
+        return (0);
+    }
+    if (ft_queue_size(queue) != 0)
+    {
+        ft_queue_clear(queue, ft_nullptr);
+        cma_free(queue);
+        return (0);
+    }
+    ft_queue_clear(queue, ft_nullptr);
+    cma_free(queue);
+    return (1);
+}
+

--- a/ToDoList
+++ b/ToDoList
@@ -15,10 +15,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 
 ## Data Structures
 
-### Queue
-FIFO container.
-Functions: ft_queue_new, ft_queue_enqueue, ft_queue_dequeue, ft_queue_front, ft_queue_size, ft_queue_clear.
-
 ### Deque
 Double-ended queue.
 Functions: ft_deque_new, ft_deque_push_front, ft_deque_push_back, ft_deque_pop_front, ft_deque_pop_back, ft_deque_size, ft_deque_clear.


### PR DESCRIPTION
## Summary
- add queue container with basic operations
- document completion by removing queue item from ToDoList
- introduce queue unit test

## Testing
- `make -C Libft`
- `make -C Test`
- `printf 'all\nn\n' | ./Test/libft_tests` *(fails: interactive prompts prevent automation)*

------
https://chatgpt.com/codex/tasks/task_e_689fa349a0f88331865b213390a4df92