### PR TITLE
Add basic file I/O wrappers

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -40,6 +40,10 @@ SRCS := ft_atoi.cpp \
     ft_getenv.cpp \
     ft_setenv.cpp \
     ft_unsetenv.cpp \
+    ft_fopen.cpp \
+    ft_fclose.cpp \
+    ft_fread.cpp \
+    ft_fwrite.cpp \
     ft_stack.cpp \
     ft_queue.cpp \
     ft_time.cpp

--- a/Libft/ft_fclose.cpp
+++ b/Libft/ft_fclose.cpp
@@ -1,0 +1,11 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdio>
+
+int ft_fclose(FILE *stream)
+{
+    if (stream == ft_nullptr)
+        return (EOF);
+    return (std::fclose(stream));
+}
+

--- a/Libft/ft_fopen.cpp
+++ b/Libft/ft_fopen.cpp
@@ -1,0 +1,11 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdio>
+
+FILE *ft_fopen(const char *filename, const char *mode)
+{
+    if (filename == ft_nullptr || mode == ft_nullptr)
+        return (ft_nullptr);
+    return (std::fopen(filename, mode));
+}
+

--- a/Libft/ft_fread.cpp
+++ b/Libft/ft_fread.cpp
@@ -1,0 +1,11 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdio>
+
+size_t ft_fread(void *ptr, size_t size, size_t count, FILE *stream)
+{
+    if (ptr == ft_nullptr || stream == ft_nullptr)
+        return (0);
+    return (std::fread(ptr, size, count, stream));
+}
+

--- a/Libft/ft_fwrite.cpp
+++ b/Libft/ft_fwrite.cpp
@@ -1,0 +1,11 @@
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdio>
+
+size_t ft_fwrite(const void *ptr, size_t size, size_t count, FILE *stream)
+{
+    if (ptr == ft_nullptr || stream == ft_nullptr)
+        return (0);
+    return (std::fwrite(ptr, size, count, stream));
+}
+

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -52,6 +52,11 @@ char            *ft_getenv(const char *name);
 int             ft_setenv(const char *name, const char *value, int overwrite);
 int             ft_unsetenv(const char *name);
 
+FILE            *ft_fopen(const char *filename, const char *mode);
+int             ft_fclose(FILE *stream);
+size_t          ft_fread(void *ptr, size_t size, size_t count, FILE *stream);
+size_t          ft_fwrite(const void *ptr, size_t size, size_t count, FILE *stream);
+
 long            ft_time_ms(void);
 char            *ft_time_format(char *buffer, size_t buffer_size);
 

--- a/ToDoList
+++ b/ToDoList
@@ -7,7 +7,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 ## Conversion Functions
 
 ## File I/O
-- ft_fopen, ft_fclose, ft_fread, ft_fwrite.
 - ft_fseek, ft_ftell.
 - ft_fprintf: fprintf-like formatted output.
 


### PR DESCRIPTION
## Summary
- implement simple wrappers for `ft_fopen`, `ft_fclose`, `ft_fread` and `ft_fwrite`
- expose new file I/O APIs in `libft.hpp` and add them to the build
- remove the completed file I/O entry from the project ToDo list

## Testing
- `make -C Libft`


------
https://chatgpt.com/codex/tasks/task_e_689fa6b917b883318c238432277b94a6