### PR TITLE
Add custom ft_vfprintf implementation

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -44,11 +44,12 @@ SRCS := ft_atoi.cpp \
     ft_fclose.cpp \
     ft_fread.cpp \
     ft_fwrite.cpp \
-    ft_fseek.cpp \
-    ft_ftell.cpp \
-    ft_stack.cpp \
-    ft_queue.cpp \
-    ft_time.cpp
+        ft_fseek.cpp \
+        ft_ftell.cpp \
+        ft_fprintf.cpp \
+        ft_stack.cpp \
+        ft_queue.cpp \
+        ft_time.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/ft_fprintf.cpp
+++ b/Libft/ft_fprintf.cpp
@@ -1,0 +1,216 @@
+// Custom implementation of vfprintf-style formatting for FILE streams
+#include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdio>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+typedef enum
+{
+    LEN_NONE,
+    LEN_L,
+    LEN_Z
+} LengthModifier;
+
+static void ft_putchar_stream(const char c, FILE *stream, size_t *count)
+{
+    fputc(c, stream);
+    (*count)++;
+}
+
+static void ft_putstr_stream(const char *s, FILE *stream, size_t *count)
+{
+    if (!s)
+    {
+        fwrite("(null)", 1, 6, stream);
+        *count += 6;
+        return;
+    }
+    size_t len = strlen(s);
+    fwrite(s, 1, len, stream);
+    *count += len;
+}
+
+static void ft_putnbr_stream_recursive(long n, FILE *stream, size_t *count)
+{
+    if (n < 0)
+    {
+        ft_putchar_stream('-', stream, count);
+        n = -n;
+    }
+    if (n >= 10)
+        ft_putnbr_stream_recursive(n / 10, stream, count);
+    ft_putchar_stream(static_cast<char>('0' + (n % 10)), stream, count);
+}
+
+static void ft_putnbr_stream(long n, FILE *stream, size_t *count)
+{
+    ft_putnbr_stream_recursive(n, stream, count);
+}
+
+static void ft_putunsigned_stream_recursive(uintmax_t n, FILE *stream, size_t *count)
+{
+    if (n >= 10)
+        ft_putunsigned_stream_recursive(n / 10, stream, count);
+    ft_putchar_stream(static_cast<char>('0' + (n % 10)), stream, count);
+}
+
+static void ft_putunsigned_stream(uintmax_t n, FILE *stream, size_t *count)
+{
+    ft_putunsigned_stream_recursive(n, stream, count);
+}
+
+static void ft_puthex_stream_recursive(uintmax_t n, FILE *stream, bool uppercase, size_t *count)
+{
+    if (n >= 16)
+        ft_puthex_stream_recursive(n / 16, stream, uppercase, count);
+    uintmax_t digit = n % 16;
+    char c;
+    if (digit < 10)
+        c = static_cast<char>('0' + digit);
+    else
+        c = static_cast<char>((uppercase ? 'A' : 'a') + (digit - 10));
+    ft_putchar_stream(c, stream, count);
+}
+
+static void ft_puthex_stream(uintmax_t n, FILE *stream, bool uppercase, size_t *count)
+{
+    ft_puthex_stream_recursive(n, stream, uppercase, count);
+}
+
+static void ft_putptr_stream(void *ptr, FILE *stream, size_t *count)
+{
+    ft_putstr_stream("0x", stream, count);
+    ft_puthex_stream(reinterpret_cast<uintptr_t>(ptr), stream, false, count);
+}
+
+int ft_vfprintf(FILE *stream, const char *format, va_list args)
+{
+    if (stream == ft_nullptr || format == ft_nullptr)
+        return (0);
+    size_t count = 0;
+    size_t i = 0;
+    while (format[i])
+    {
+        if (format[i] == '%')
+        {
+            i++;
+            if (format[i] == '\0')
+                break;
+            LengthModifier len_mod = LEN_NONE;
+            if (format[i] == 'l')
+            {
+                len_mod = LEN_L;
+                i++;
+            }
+            else if (format[i] == 'z')
+            {
+                len_mod = LEN_Z;
+                i++;
+            }
+            char spec = format[i];
+            if (spec == '\0')
+                break;
+            if (spec == 'c')
+            {
+                char c = static_cast<char>(va_arg(args, int));
+                ft_putchar_stream(c, stream, &count);
+            }
+            else if (spec == 's')
+            {
+                char *s = va_arg(args, char *);
+                ft_putstr_stream(s, stream, &count);
+            }
+            else if (spec == 'd' || spec == 'i')
+            {
+                if (len_mod == LEN_L)
+                {
+                    long num = va_arg(args, long);
+                    ft_putnbr_stream(num, stream, &count);
+                }
+                else
+                {
+                    int num = va_arg(args, int);
+                    ft_putnbr_stream(num, stream, &count);
+                }
+            }
+            else if (spec == 'u')
+            {
+                if (len_mod == LEN_L)
+                {
+                    uintmax_t num = va_arg(args, unsigned long);
+                    ft_putunsigned_stream(num, stream, &count);
+                }
+                else if (len_mod == LEN_Z)
+                {
+                    size_t num = va_arg(args, size_t);
+                    ft_putunsigned_stream(num, stream, &count);
+                }
+                else
+                {
+                    unsigned int num = va_arg(args, unsigned int);
+                    ft_putunsigned_stream(num, stream, &count);
+                }
+            }
+            else if (spec == 'x' || spec == 'X')
+            {
+                bool uppercase = (spec == 'X');
+                if (len_mod == LEN_L)
+                {
+                    uintmax_t num = va_arg(args, unsigned long);
+                    ft_puthex_stream(num, stream, uppercase, &count);
+                }
+                else if (len_mod == LEN_Z)
+                {
+                    size_t num = va_arg(args, size_t);
+                    ft_puthex_stream(num, stream, uppercase, &count);
+                }
+                else
+                {
+                    unsigned int num = va_arg(args, unsigned int);
+                    ft_puthex_stream(num, stream, uppercase, &count);
+                }
+            }
+            else if (spec == 'p')
+            {
+                void *ptr = va_arg(args, void *);
+                ft_putptr_stream(ptr, stream, &count);
+            }
+            else if (spec == 'b')
+            {
+                int b = va_arg(args, int);
+                ft_putstr_stream(b ? "true" : "false", stream, &count);
+            }
+            else if (spec == '%')
+            {
+                ft_putchar_stream('%', stream, &count);
+            }
+            else
+            {
+                ft_putchar_stream('%', stream, &count);
+                ft_putchar_stream(spec, stream, &count);
+            }
+        }
+        else
+        {
+            ft_putchar_stream(format[i], stream, &count);
+        }
+        i++;
+    }
+    return (static_cast<int>(count));
+}
+
+int ft_fprintf(FILE *stream, const char *format, ...)
+{
+    if (stream == ft_nullptr || format == ft_nullptr)
+        return (0);
+    va_list args;
+    va_start(args, format);
+    int printed = ft_vfprintf(stream, format, args);
+    va_end(args);
+    return (printed);
+}
+

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdarg.h>
 
 size_t 			ft_strlen_size_t(const char *string);
 int				ft_strlen(const char *string);
@@ -58,6 +59,8 @@ size_t          ft_fread(void *ptr, size_t size, size_t count, FILE *stream);
 size_t          ft_fwrite(const void *ptr, size_t size, size_t count, FILE *stream);
 int             ft_fseek(FILE *stream, long offset, int origin);
 long            ft_ftell(FILE *stream);
+int             ft_vfprintf(FILE *stream, const char *format, va_list args);
+int             ft_fprintf(FILE *stream, const char *format, ...) __attribute__((format(printf, 2, 3), hot));
 
 long            ft_time_ms(void);
 char            *ft_time_format(char *buffer, size_t buffer_size);

--- a/ToDoList
+++ b/ToDoList
@@ -7,7 +7,6 @@ This document tracks outstanding work for the library. Items are grouped by doma
 ## Conversion Functions
 
 ## File I/O
-- ft_fprintf: fprintf-like formatted output.
 
 ## General Utilities
 


### PR DESCRIPTION
## Summary
- implement fully custom `ft_vfprintf` for formatted FILE output
- use the new formatter in `ft_fprintf`
- expose `ft_vfprintf` in the public header

## Testing
- `cd Libft && make`
- `cd Libft && make clean`


------
https://chatgpt.com/codex/tasks/task_e_68a026bb6f588331bd406738a947fb79