### PR TITLE
Move ft_fprintf into Printf module

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -46,7 +46,6 @@ SRCS := ft_atoi.cpp \
     ft_fwrite.cpp \
         ft_fseek.cpp \
         ft_ftell.cpp \
-        ft_fprintf.cpp \
         ft_stack.cpp \
         ft_queue.cpp \
         ft_time.cpp

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -59,9 +59,6 @@ size_t          ft_fread(void *ptr, size_t size, size_t count, FILE *stream);
 size_t          ft_fwrite(const void *ptr, size_t size, size_t count, FILE *stream);
 int             ft_fseek(FILE *stream, long offset, int origin);
 long            ft_ftell(FILE *stream);
-int             ft_vfprintf(FILE *stream, const char *format, va_list args);
-int             ft_fprintf(FILE *stream, const char *format, ...) __attribute__((format(printf, 2, 3), hot));
-
 long            ft_time_ms(void);
 char            *ft_time_format(char *buffer, size_t buffer_size);
 

--- a/Printf/Makefile
+++ b/Printf/Makefile
@@ -2,8 +2,9 @@ TARGET := Printf.a
 DEBUG_TARGET := Printf_debug.a
 
 SRCS := printf.cpp \
-		format.cpp \
-		print_args.cpp
+                format.cpp \
+                print_args.cpp \
+                ft_fprintf.cpp
 
 HEADERS := printf.hpp \
 		   printf_internal.hpp

--- a/Printf/ft_fprintf.cpp
+++ b/Printf/ft_fprintf.cpp
@@ -1,5 +1,5 @@
 // Custom implementation of vfprintf-style formatting for FILE streams
-#include "libft.hpp"
+#include "printf.hpp"
 #include "../CPP_class/nullptr.hpp"
 #include <cstdio>
 #include <stdarg.h>

--- a/Printf/printf.hpp
+++ b/Printf/printf.hpp
@@ -3,8 +3,11 @@
 
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdio.h>
 
 int pf_printf(const char *format, ...) __attribute__((format(printf, 1, 2), hot));
 int pf_printf_fd(int fd, const char *format, ...) __attribute__((format(printf, 2, 3), hot));
+int ft_vfprintf(FILE *stream, const char *format, va_list args);
+int ft_fprintf(FILE *stream, const char *format, ...) __attribute__((format(printf, 2, 3), hot));
 
 #endif


### PR DESCRIPTION
## Summary
- relocate `ft_fprintf.cpp` from Libft to Printf and adjust includes
- expose `ft_fprintf`/`ft_vfprintf` in Printf headers
- update Libft and Printf build scripts for new file location

## Testing
- `make -C Printf`
- `make -C Libft`


------
https://chatgpt.com/codex/tasks/task_e_68a046f9fb548331bb20208f7ddec5c0