### PR TITLE
Add template-based queue class

### DIFF
--- a/Errno/errno.hpp
+++ b/Errno/errno.hpp
@@ -69,6 +69,8 @@ enum PTErrorCode
     GAME_INVALID_MOVE,
     STACK_EMPTY,
     STACK_ALLOC_FAIL,
+    QUEUE_EMPTY,
+    QUEUE_ALLOC_FAIL,
 };
 
 const char* ft_strerror(int error_code);

--- a/Errno/strerror.cpp
+++ b/Errno/strerror.cpp
@@ -114,11 +114,15 @@ const char* ft_strerror(int error_code)
 		return ("General Ingame Error");
 	else if (error_code == GAME_INVALID_MOVE)
 		return ("Invalid Move");
-	else if (error_code == STACK_EMPTY)
-		return ("Stack is empty");
-	else if (error_code == STACK_ALLOC_FAIL)
-		return ("Stack memory allocation failed");
-	else if (error_code > ERRNO_OFFSET)
+        else if (error_code == STACK_EMPTY)
+                return ("Stack is empty");
+        else if (error_code == STACK_ALLOC_FAIL)
+                return ("Stack memory allocation failed");
+        else if (error_code == QUEUE_EMPTY)
+                return ("Queue is empty");
+        else if (error_code == QUEUE_ALLOC_FAIL)
+                return ("Queue memory allocation failed");
+        else if (error_code > ERRNO_OFFSET)
         {
         int standard_errno = error_code - ERRNO_OFFSET;
         const char *message = strerror(standard_errno);

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -38,6 +38,7 @@
 #include "Template/unordened_map.hpp"
 #include "Template/vector.hpp"
 #include "Template/stack.hpp"
+#include "Template/queue.hpp"
 #include "Windows/windows_file.hpp"
 #include "encryption/BasicEncryption.hpp"
 #include "file/open_dir.hpp"

--- a/Template/queue.hpp
+++ b/Template/queue.hpp
@@ -1,0 +1,243 @@
+#ifndef FT_QUEUE_HPP
+#define FT_QUEUE_HPP
+
+#include "constructor.hpp"
+#include "../CMA/CMA.hpp"
+#include "../Errno/errno.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstddef>
+#include <utility>
+
+// A simple queue implementation using a singly linked list.
+// Provides basic queue operations with error handling similar to other
+// template classes in the project.
+
+template <typename ElementType>
+class ft_queue
+{
+private:
+    struct QueueNode
+    {
+        ElementType data;
+        QueueNode* next;
+    };
+
+    QueueNode*  _front;
+    QueueNode*  _rear;
+    size_t      _size;
+    mutable int _errorCode;
+
+    void    setError(int error) const;
+
+public:
+    ft_queue();
+    ~ft_queue();
+
+    ft_queue(const ft_queue&) = delete;
+    ft_queue& operator=(const ft_queue&) = delete;
+
+    ft_queue(ft_queue&& other) noexcept;
+    ft_queue& operator=(ft_queue&& other) noexcept;
+
+    void enqueue(const ElementType& value);
+    void enqueue(ElementType&& value);
+    ElementType dequeue();
+
+    ElementType& front();
+    const ElementType& front() const;
+
+    size_t size() const;
+    bool empty() const;
+
+    int get_error() const;
+    const char* get_error_str() const;
+
+    void clear();
+};
+
+// Implementation
+
+template <typename ElementType>
+ft_queue<ElementType>::ft_queue()
+    : _front(ft_nullptr), _rear(ft_nullptr), _size(0), _errorCode(ER_SUCCESS)
+{
+    return ;
+}
+
+template <typename ElementType>
+ft_queue<ElementType>::~ft_queue()
+{
+    clear();
+    return ;
+}
+
+template <typename ElementType>
+ft_queue<ElementType>::ft_queue(ft_queue&& other) noexcept
+    : _front(other._front), _rear(other._rear), _size(other._size), _errorCode(other._errorCode)
+{
+    other._front = ft_nullptr;
+    other._rear = ft_nullptr;
+    other._size = 0;
+    other._errorCode = ER_SUCCESS;
+    return ;
+}
+
+template <typename ElementType>
+ft_queue<ElementType>& ft_queue<ElementType>::operator=(ft_queue&& other) noexcept
+{
+    if (this != &other)
+    {
+        clear();
+        _front = other._front;
+        _rear = other._rear;
+        _size = other._size;
+        _errorCode = other._errorCode;
+        other._front = ft_nullptr;
+        other._rear = ft_nullptr;
+        other._size = 0;
+        other._errorCode = ER_SUCCESS;
+    }
+    return (*this);
+}
+
+template <typename ElementType>
+void ft_queue<ElementType>::setError(int error) const
+{
+    _errorCode = error;
+    ft_errno = error;
+    return ;
+}
+
+template <typename ElementType>
+void ft_queue<ElementType>::enqueue(const ElementType& value)
+{
+    QueueNode* node = static_cast<QueueNode*>(cma_malloc(sizeof(QueueNode)));
+    if (node == ft_nullptr)
+    {
+        setError(QUEUE_ALLOC_FAIL);
+        return ;
+    }
+    construct_at(&node->data, value);
+    node->next = ft_nullptr;
+    if (_rear == ft_nullptr)
+    {
+        _front = node;
+        _rear = node;
+    }
+    else
+    {
+        _rear->next = node;
+        _rear = node;
+    }
+    ++_size;
+    return ;
+}
+
+template <typename ElementType>
+void ft_queue<ElementType>::enqueue(ElementType&& value)
+{
+    QueueNode* node = static_cast<QueueNode*>(cma_malloc(sizeof(QueueNode)));
+    if (node == ft_nullptr)
+    {
+        setError(QUEUE_ALLOC_FAIL);
+        return ;
+    }
+    construct_at(&node->data, std::move(value));
+    node->next = ft_nullptr;
+    if (_rear == ft_nullptr)
+    {
+        _front = node;
+        _rear = node;
+    }
+    else
+    {
+        _rear->next = node;
+        _rear = node;
+    }
+    ++_size;
+    return ;
+}
+
+template <typename ElementType>
+ElementType ft_queue<ElementType>::dequeue()
+{
+    if (_front == ft_nullptr)
+    {
+        setError(QUEUE_EMPTY);
+        return (ElementType());
+    }
+    QueueNode* node = _front;
+    _front = node->next;
+    if (_front == ft_nullptr)
+        _rear = ft_nullptr;
+    ElementType value = std::move(node->data);
+    destroy_at(&node->data);
+    cma_free(node);
+    --_size;
+    return (value);
+}
+
+template <typename ElementType>
+ElementType& ft_queue<ElementType>::front()
+{
+    static ElementType errorElement = ElementType();
+    if (_front == ft_nullptr)
+    {
+        setError(QUEUE_EMPTY);
+        return (errorElement);
+    }
+    return (_front->data);
+}
+
+template <typename ElementType>
+const ElementType& ft_queue<ElementType>::front() const
+{
+    static ElementType errorElement = ElementType();
+    if (_front == ft_nullptr)
+    {
+        setError(QUEUE_EMPTY);
+        return (errorElement);
+    }
+    return (_front->data);
+}
+
+template <typename ElementType>
+size_t ft_queue<ElementType>::size() const
+{
+    return (_size);
+}
+
+template <typename ElementType>
+bool ft_queue<ElementType>::empty() const
+{
+    return (_size == 0);
+}
+
+template <typename ElementType>
+int ft_queue<ElementType>::get_error() const
+{
+    return (_errorCode);
+}
+
+template <typename ElementType>
+const char* ft_queue<ElementType>::get_error_str() const
+{
+    return (ft_strerror(_errorCode));
+}
+
+template <typename ElementType>
+void ft_queue<ElementType>::clear()
+{
+    while (_front != ft_nullptr)
+    {
+        QueueNode* node = _front;
+        _front = _front->next;
+        destroy_at(&node->data);
+        cma_free(node);
+    }
+    _rear = ft_nullptr;
+    _size = 0;
+    return ;
+}
+
+#endif

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,7 +1,7 @@
 TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
-SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp game_tests.cpp queue_tests.cpp
+SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp game_tests.cpp queue_tests.cpp queue_class_tests.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -144,6 +144,7 @@ int test_reputation_subtracters(void);
 int test_character_level(void);
 int test_quest_progress(void);
 int test_queue_basic(void);
+int test_ft_queue_class_basic(void);
 
 int main(void)
 {
@@ -264,7 +265,8 @@ int main(void)
         { test_reputation_subtracters, "reputation subtracters" },
         { test_character_level, "character level" },
         { test_quest_progress, "quest progress" },
-        { test_queue_basic, "queue basic" }
+        { test_queue_basic, "queue basic" },
+        { test_ft_queue_class_basic, "queue class basic" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
 

--- a/Test/queue_class_tests.cpp
+++ b/Test/queue_class_tests.cpp
@@ -1,0 +1,22 @@
+#include "../Template/queue.hpp"
+#include "../Errno/errno.hpp"
+
+int test_ft_queue_class_basic(void)
+{
+    ft_queue<int> q;
+    q.enqueue(1);
+    q.enqueue(2);
+    if (q.get_error() != ER_SUCCESS || q.front() != 1 || q.size() != 2)
+        return (0);
+    int first = q.dequeue();
+    if (first != 1)
+        return (0);
+    int second = q.dequeue();
+    if (second != 2)
+        return (0);
+    q.dequeue();
+    if (q.get_error() != QUEUE_EMPTY)
+        return (0);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- add `ft_queue` template implementing a singly linked queue with custom allocator and error reporting
- expose queue error codes and messages
- include new queue template in full library and basic tests

## Testing
- `g++ -std=c++17 -I. /tmp/queue_class_run.cpp Full_Libft.a -o /tmp/queue_class_run && /tmp/queue_class_run`


------
https://chatgpt.com/codex/tasks/task_e_68a1c6619f708331965690b30e14e152