### PR TITLE
Add promise template, thread-local ID tracking, and async helper

### DIFF
--- a/PThread/PThread.hpp
+++ b/PThread/PThread.hpp
@@ -2,10 +2,12 @@
 # define PTHREAD_HPP
 
 #include <pthread.h>
+#include "../Template/promise.hpp"
+#include <utility>
 
 int pt_thread_join(pthread_t thread, void **retval);
 int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,
-		void *(*start_routine)(void *), void *arg);
+                void *(*start_routine)(void *), void *arg);
 
 #define SLEEP_TIME 100
 #define MAX_SLEEP 10000
@@ -13,10 +15,43 @@ int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,
 
 #ifdef _WIN32
     #include <windows.h>
+    using pt_thread_id_type = DWORD;
     #define THREAD_ID GetCurrentThreadId()
 #else
     #include <pthread.h>
+    using pt_thread_id_type = pthread_t;
     #define THREAD_ID pthread_self()
 #endif
+
+extern thread_local pt_thread_id_type pt_thread_id;
+
+template <typename ValueType, typename Function>
+int pt_async(ft_promise<ValueType>& promise, Function function)
+{
+    struct AsyncData
+    {
+        ft_promise<ValueType>* promise;
+        Function function;
+    };
+
+    auto start_routine = [](void* arg) -> void*
+    {
+        AsyncData* data = static_cast<AsyncData*>(arg);
+        data->promise->set_value(data->function());
+        delete data;
+        return nullptr;
+    };
+
+    AsyncData* data = new AsyncData{&promise, std::move(function)};
+    pthread_t thread;
+    int ret = pt_thread_create(&thread, nullptr, start_routine, data);
+    if (ret != 0)
+    {
+        delete data;
+        return ret;
+    }
+    pthread_detach(thread);
+    return ret;
+}
 
 #endif

--- a/PThread/thread_create.cpp
+++ b/PThread/thread_create.cpp
@@ -3,11 +3,13 @@
 #include "PThread.hpp"
 #include "../Errno/errno.hpp"
 
+thread_local pt_thread_id_type pt_thread_id = THREAD_ID;
+
 int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,
-		void *(*start_routine)(void *), void *arg)
+                void *(*start_routine)(void *), void *arg)
 {
-	int return_value = pthread_create(thread, attr, start_routine, arg);
-	if (return_value != 0)
-		ft_errno = errno + ERRNO_OFFSET;
-	return (return_value);
+        int return_value = pthread_create(thread, attr, start_routine, arg);
+        if (return_value != 0)
+                ft_errno = errno + ERRNO_OFFSET;
+        return (return_value);
 }

--- a/Template/promise.hpp
+++ b/Template/promise.hpp
@@ -1,0 +1,66 @@
+#ifndef FT_PROMISE_HPP
+#define FT_PROMISE_HPP
+
+#include "../Errno/errno.hpp"
+#include <atomic>
+#include <utility>
+
+// Simple promise-like container for asynchronous value sharing
+// stores a value of type ValueType and an atomic flag indicating readiness
+
+template <typename ValueType>
+class ft_promise
+{
+private:
+    ValueType _value;
+    std::atomic_bool _ready;
+    mutable int _errorCode;
+
+    void setError(int error) const
+    {
+        _errorCode = error;
+        ft_errno = error;
+    }
+
+public:
+    ft_promise() : _value(), _ready(false), _errorCode(ER_SUCCESS) {}
+
+    void set_value(const ValueType& value)
+    {
+        _value = value;
+        _ready.store(true, std::memory_order_release);
+    }
+
+    void set_value(ValueType&& value)
+    {
+        _value = std::move(value);
+        _ready.store(true, std::memory_order_release);
+    }
+
+    ValueType get() const
+    {
+        if (!_ready.load(std::memory_order_acquire))
+        {
+            setError(FT_EINVAL);
+            return (ValueType());
+        }
+        return (_value);
+    }
+
+    bool is_ready() const
+    {
+        return (_ready.load(std::memory_order_acquire));
+    }
+
+    int get_error() const
+    {
+        return (_errorCode);
+    }
+
+    const char* get_error_str() const
+    {
+        return (ft_strerror(_errorCode));
+    }
+};
+
+#endif // FT_PROMISE_HPP


### PR DESCRIPTION
## Summary
- introduce `ft_promise` template for asynchronous value sharing with atomic readiness tracking
- expose thread-local `pt_thread_id` in PThread to identify the calling thread
- add `pt_async` helper to run a callable in a detached thread and fulfill a promise on completion

## Testing
- `make -C PThread`
- `g++ -std=c++17 -Wall -Wextra -Werror -I. /tmp/test.cpp -c -o /tmp/test.o`


------
https://chatgpt.com/codex/tasks/task_e_68a2156947a08331a4b449d13bc13525