### PR TITLE
Document ft_promise and thread helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ int pf_printf_fd(int fd, const char *format, ...);
 int pt_thread_join(pthread_t thread, void **retval);
 int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,
                      void *(*start_routine)(void *), void *arg);
+int pt_thread_detach(pthread_t thread);
+template <typename ValueType, typename Function>
+int pt_async(ft_promise<ValueType>& promise, Function function);
 ```
 
 ### ReadLine
@@ -276,6 +279,22 @@ int         join_multicast_group(const SocketConfig &config);
 `Template/` contains several generic helpers such as `ft_vector`, `ft_map`,
 `ft_pair`, smart pointers and mathematical helpers. Refer to the header files
 for the full interface of these templates.
+
+#### `ft_promise`
+
+`Template/promise.hpp` implements a minimal promise type for passing values
+between threads. A promise stores a value set by a worker thread and reports
+errors through the shared `ft_errno` system.
+
+```
+ft_promise();
+void set_value(const ValueType& value);
+void set_value(ValueType&& value);
+ValueType get() const;
+bool is_ready() const;
+int  get_error() const;
+const char *get_error_str() const;
+```
 
 ### Additional Modules
 

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,7 +1,7 @@
 TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
-SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp game_tests.cpp queue_tests.cpp queue_class_tests.cpp
+SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp game_tests.cpp queue_tests.cpp queue_class_tests.cpp promise_tests.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -145,6 +145,9 @@ int test_character_level(void);
 int test_quest_progress(void);
 int test_queue_basic(void);
 int test_ft_queue_class_basic(void);
+int test_ft_promise_set_get(void);
+int test_ft_promise_not_ready(void);
+int test_pt_async_basic(void);
 
 int main(void)
 {
@@ -266,7 +269,10 @@ int main(void)
         { test_character_level, "character level" },
         { test_quest_progress, "quest progress" },
         { test_queue_basic, "queue basic" },
-        { test_ft_queue_class_basic, "queue class basic" }
+        { test_ft_queue_class_basic, "queue class basic" },
+        { test_ft_promise_set_get, "ft_promise set/get" },
+        { test_ft_promise_not_ready, "ft_promise not ready" },
+        { test_pt_async_basic, "pt_async basic" }
     };
     const int total = sizeof(tests) / sizeof(tests[0]);
 

--- a/Test/promise_tests.cpp
+++ b/Test/promise_tests.cpp
@@ -1,0 +1,32 @@
+#include <utility>
+#ifndef ft_move
+# define ft_move std::move
+#endif
+#include "../Template/promise.hpp"
+#include "../PThread/PThread.hpp"
+#include "../Errno/errno.hpp"
+#include <unistd.h>
+
+int test_ft_promise_set_get(void)
+{
+    ft_promise<int> p;
+    p.set_value(42);
+    return (p.is_ready() && p.get() == 42 && p.get_error() == ER_SUCCESS);
+}
+
+int test_ft_promise_not_ready(void)
+{
+    ft_promise<int> p;
+    p.get();
+    return (p.get_error() == FT_EINVAL);
+}
+
+int test_pt_async_basic(void)
+{
+    ft_promise<int> p;
+    if (pt_async(p, []() { return 7; }) != 0)
+        return 0;
+    while (!p.is_ready())
+        usleep(1000);
+    return (p.get() == 7);
+}


### PR DESCRIPTION
## Summary
- Document `ft_promise` and new thread helpers in README
- Add promise and async thread tests and integrate into test suite

## Testing
- `make -C Test`
- `g++ -std=c++17 -I. /tmp/run_new_tests.cpp Full_Libft.a -pthread -o /tmp/run_new`
- `/tmp/run_new`


------
https://chatgpt.com/codex/tasks/task_e_68a21c0bc104833194f269c2eb1d6b37