### PR TITLE
Add thread sleep helper to PThread library

### DIFF
--- a/PThread/Makefile
+++ b/PThread/Makefile
@@ -7,6 +7,7 @@ SRCS := lock_mutex.cpp \
         thread_join.cpp \
         thread_create.cpp \
         thread_detach.cpp \
+        thread_sleep.cpp \
         mutex.cpp
 
 HEADERS := PThread.hpp

--- a/PThread/PThread.hpp
+++ b/PThread/PThread.hpp
@@ -10,6 +10,7 @@ int pt_thread_join(pthread_t thread, void **retval);
 int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,
                 void *(*start_routine)(void *), void *arg);
 int pt_thread_detach(pthread_t thread);
+int pt_thread_sleep(unsigned int milliseconds);
 
 #define SLEEP_TIME 100
 #define MAX_SLEEP 10000

--- a/PThread/thread_sleep.cpp
+++ b/PThread/thread_sleep.cpp
@@ -1,0 +1,24 @@
+#include "PThread.hpp"
+#include "../Errno/errno.hpp"
+#include <cerrno>
+
+#ifdef _WIN32
+# include <windows.h>
+#else
+# include <unistd.h>
+#endif
+
+int pt_thread_sleep(unsigned int milliseconds)
+{
+#ifdef _WIN32
+    Sleep(milliseconds);
+    return 0;
+#else
+    if (usleep(milliseconds * 1000) == -1)
+    {
+        ft_errno = errno + ERRNO_OFFSET;
+        return -1;
+    }
+    return 0;
+#endif
+}


### PR DESCRIPTION
## Summary
- add cross-platform `pt_thread_sleep` to pause current thread for a duration
- expose `pt_thread_sleep` in `PThread.hpp` and integrate into PThread build

## Testing
- `make -C PThread`

------
https://chatgpt.com/codex/tasks/task_e_68a22781bc408331800fd76e0c40c97d