### PR TITLE
Add thread self helper to PThread library

### DIFF
--- a/PThread/Makefile
+++ b/PThread/Makefile
@@ -9,6 +9,7 @@ SRCS := lock_mutex.cpp \
         thread_detach.cpp \
         thread_sleep.cpp \
         thread_yield.cpp \
+        thread_self.cpp \
         mutex.cpp
 
 HEADERS := PThread.hpp

--- a/PThread/PThread.hpp
+++ b/PThread/PThread.hpp
@@ -28,6 +28,7 @@ int pt_thread_yield();
 #endif
 
 extern thread_local pt_thread_id_type pt_thread_id;
+pt_thread_id_type pt_thread_self();
 
 template <typename ValueType, typename Function>
 int pt_async(ft_promise<ValueType>& promise, Function function)

--- a/PThread/thread_self.cpp
+++ b/PThread/thread_self.cpp
@@ -1,0 +1,7 @@
+#include "PThread.hpp"
+
+pt_thread_id_type pt_thread_self()
+{
+    return pt_thread_id;
+}
+


### PR DESCRIPTION
## Summary
- add `pt_thread_self` to retrieve current thread identifier
- include new source in PThread build

## Testing
- `make -C PThread`


------
https://chatgpt.com/codex/tasks/task_e_68a231de74ac8331987acf1337b2a410