### PR TITLE
Add pthread thread equality helper

### DIFF
--- a/PThread/Makefile
+++ b/PThread/Makefile
@@ -10,6 +10,7 @@ SRCS := lock_mutex.cpp \
         thread_sleep.cpp \
         thread_yield.cpp \
         thread_self.cpp \
+        thread_equal.cpp \
         mutex.cpp
 
 HEADERS := PThread.hpp

--- a/PThread/PThread.hpp
+++ b/PThread/PThread.hpp
@@ -12,6 +12,7 @@ int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,
 int pt_thread_detach(pthread_t thread);
 int pt_thread_sleep(unsigned int milliseconds);
 int pt_thread_yield();
+int pt_thread_equal(pthread_t thread1, pthread_t thread2);
 
 #define SLEEP_TIME 100
 #define MAX_SLEEP 10000

--- a/PThread/compile_commands.json
+++ b/PThread/compile_commands.json
@@ -52,5 +52,23 @@
     "directory": "/home/adyem/DND_tools/Other/Libft/PThread",
     "file": "/home/adyem/DND_tools/Other/Libft/PThread/try_lock_mutex.cpp",
     "output": "/home/adyem/DND_tools/Other/Libft/PThread/objs/try_lock_mutex.o"
+  },
+  {
+    "arguments": [
+      "/usr/bin/g++",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g",
+      "-O0",
+      "-std=c++17",
+      "-c",
+      "-o",
+      "objs/thread_equal.o",
+      "thread_equal.cpp"
+    ],
+    "directory": "/home/adyem/DND_tools/Other/Libft/PThread",
+    "file": "/home/adyem/DND_tools/Other/Libft/PThread/thread_equal.cpp",
+    "output": "/home/adyem/DND_tools/Other/Libft/PThread/objs/thread_equal.o"
   }
 ]

--- a/PThread/thread_equal.cpp
+++ b/PThread/thread_equal.cpp
@@ -1,0 +1,11 @@
+#include "PThread.hpp"
+
+int pt_thread_equal(pthread_t thread1, pthread_t thread2)
+{
+#ifdef _WIN32
+    return thread1 == thread2;
+#else
+    return pthread_equal(thread1, thread2);
+#endif
+}
+

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1105,5 +1105,23 @@
     "directory": "/home/adyem/DND_tools/libft/Linux",
     "file": "/home/adyem/DND_tools/libft/Linux/system_call_wrappers.cpp",
     "output": "/home/adyem/DND_tools/libft/Linux/objs/system_call_wrappers.o"
+  },
+  {
+    "arguments": [
+      "/usr/bin/g++",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g",
+      "-O0",
+      "-std=c++17",
+      "-c",
+      "-o",
+      "objs/thread_equal.o",
+      "thread_equal.cpp"
+    ],
+    "directory": "/home/adyem/DND_tools/libft/PThread",
+    "file": "/home/adyem/DND_tools/libft/PThread/thread_equal.cpp",
+    "output": "/home/adyem/DND_tools/libft/PThread/objs/thread_equal.o"
   }
 ]


### PR DESCRIPTION
## Summary
- add pt_thread_equal wrapper to compare thread identifiers
- wire up new source file in build system and compile commands

## Testing
- `make -C PThread`


------
https://chatgpt.com/codex/tasks/task_e_68a235f146648331b3fc29c0bb99860e