### PR TITLE
Add pthread cancel wrapper

### DIFF
--- a/PThread/Makefile
+++ b/PThread/Makefile
@@ -7,6 +7,7 @@ SRCS := lock_mutex.cpp \
         thread_join.cpp \
         thread_create.cpp \
         thread_detach.cpp \
+        thread_cancel.cpp \
         thread_sleep.cpp \
         thread_yield.cpp \
         thread_self.cpp \

--- a/PThread/PThread.hpp
+++ b/PThread/PThread.hpp
@@ -10,6 +10,7 @@ int pt_thread_join(pthread_t thread, void **retval);
 int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,
                 void *(*start_routine)(void *), void *arg);
 int pt_thread_detach(pthread_t thread);
+int pt_thread_cancel(pthread_t thread);
 int pt_thread_sleep(unsigned int milliseconds);
 int pt_thread_yield();
 int pt_thread_equal(pthread_t thread1, pthread_t thread2);

--- a/PThread/thread_cancel.cpp
+++ b/PThread/thread_cancel.cpp
@@ -1,0 +1,21 @@
+#include <cerrno>
+#include "PThread.hpp"
+#include "../Errno/errno.hpp"
+
+int pt_thread_cancel(pthread_t thread)
+{
+#ifdef _WIN32
+    if (TerminateThread((HANDLE)thread, 0) == 0)
+    {
+        ft_errno = GetLastError() + ERRNO_OFFSET;
+        return -1;
+    }
+    return 0;
+#else
+    int return_value = pthread_cancel(thread);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return return_value;
+#endif
+}
+


### PR DESCRIPTION
## Summary
- add pt_thread_cancel wrapper for pthread_cancel
- register new source in PThread build
- support Windows via TerminateThread fallback

## Testing
- `cd PThread && make && make clean && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68a238ca4f0c8331b7d56346399fff8f