### PR TITLE
Add efficiency benchmarks and interactive test menu

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,7 +1,11 @@
 TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
-SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp cma_tests.cpp game_tests.cpp queue_tests.cpp queue_class_tests.cpp promise_tests.cpp
+SRCS := main.cpp atoi_tests.cpp isdigit_tests.cpp memset_tests.cpp strcmp_tests.cpp strlen_tests.cpp \
+       toupper_tests.cpp html_tests.cpp networking_tests.cpp extra_libft_tests.cpp \
+       cpp_class_tests.cpp template_tests.cpp printf_tests.cpp get_next_line_tests.cpp \
+       cma_tests.cpp game_tests.cpp queue_tests.cpp queue_class_tests.cpp \
+       promise_tests.cpp efficiency_tests.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/efficiency_tests.cpp
+++ b/Test/efficiency_tests.cpp
@@ -1,0 +1,76 @@
+#include "../Libft/libft.hpp"
+#include "../Printf/printf.hpp"
+
+#include <cstring>
+#include <chrono>
+#include <string>
+#include <vector>
+
+using clock_type = std::chrono::high_resolution_clock;
+
+static long long elapsed_us(clock_type::time_point start, clock_type::time_point end)
+{
+    return (std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
+}
+
+int test_efficiency_strlen(void)
+{
+    const size_t iterations = 100000;
+    std::string s(1000, 'a');
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        std::strlen(s.c_str());
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        ft_strlen(s.c_str());
+    auto end_ft = clock_type::now();
+
+    pf_printf("strlen std: %lld us\n", elapsed_us(start_std, end_std));
+    pf_printf("strlen ft : %lld us\n", elapsed_us(start_ft, end_ft));
+    return (1);
+}
+
+int test_efficiency_memcpy(void)
+{
+    const size_t iterations = 50000;
+    std::vector<char> src(4096, 'a');
+    std::vector<char> dst(4096);
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        std::memcpy(dst.data(), src.data(), src.size());
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        ft_memcpy(dst.data(), src.data(), src.size());
+    auto end_ft = clock_type::now();
+
+    pf_printf("memcpy std: %lld us\n", elapsed_us(start_std, end_std));
+    pf_printf("memcpy ft : %lld us\n", elapsed_us(start_ft, end_ft));
+    return (1);
+}
+
+int test_efficiency_isdigit(void)
+{
+    const size_t iterations = 1000000;
+    int result = 0;
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        result += std::isdigit('5');
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        result += ft_isdigit('5');
+    auto end_ft = clock_type::now();
+
+    pf_printf("isdigit std: %lld us\n", elapsed_us(start_std, end_std));
+    pf_printf("isdigit ft : %lld us\n", elapsed_us(start_ft, end_ft));
+    return (result ? 1 : 0);
+}
+


### PR DESCRIPTION
## Summary
- add benchmarking tests comparing stdlib functions with custom Libft versions
- rework test runner with menu for functional vs efficiency tests and exit/return options
- include efficiency tests in build
- match project style by spacing `break ;`, wrapping return values, and adding explicit `return ;` in void functions

## Testing
- `make -C Test`

------
https://chatgpt.com/codex/tasks/task_e_68a34a927bf08331b873a733338b6654