### PR TITLE
Add command-line test runners, expand efficiency suite, and fix experience table validation

### DIFF
--- a/Game/experience_table.cpp
+++ b/Game/experience_table.cpp
@@ -64,6 +64,7 @@ int ft_experience_table::resize(int new_count) noexcept
         this->_count = 0;
         return (ER_SUCCESS);
     }
+    int old_count = this->_count;
     int *new_levels = static_cast<int*>(cma_realloc(this->_levels,
                     sizeof(int) * new_count));
     if (!new_levels)
@@ -71,14 +72,15 @@ int ft_experience_table::resize(int new_count) noexcept
         this->set_error(CMA_BAD_ALLOC);
         return (this->_error);
     }
-    if (new_count > this->_count)
+    if (new_count > old_count)
     {
-        for (int i = this->_count; i < new_count; i++)
+        for (int i = old_count; i < new_count; i++)
             new_levels[i] = 0;
     }
     this->_levels = new_levels;
     this->_count = new_count;
-    if (!this->is_valid(this->_count, this->_levels))
+    int check_count = old_count < new_count ? old_count : new_count;
+    if (!this->is_valid(check_count, this->_levels))
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
     return (this->_error);
 }

--- a/Test/efficiency_tests.cpp
+++ b/Test/efficiency_tests.cpp
@@ -60,6 +60,68 @@ int test_efficiency_memcpy(void)
     return (1);
 }
 
+int test_efficiency_memmove(void)
+{
+    const size_t iterations = 50000;
+    std::vector<char> buf(4096, 'a');
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        std::memmove(buf.data() + 1, buf.data(), buf.size() - 1);
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        ft_memmove(buf.data() + 1, buf.data(), buf.size() - 1);
+    auto end_ft = clock_type::now();
+
+    print_comparison("memmove", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (1);
+}
+
+int test_efficiency_memset(void)
+{
+    const size_t iterations = 50000;
+    std::vector<char> buf(4096);
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        std::memset(buf.data(), 'a', buf.size());
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        ft_memset(buf.data(), 'a', buf.size());
+    auto end_ft = clock_type::now();
+
+    print_comparison("memset", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (1);
+}
+
+int test_efficiency_strcmp(void)
+{
+    const size_t iterations = 500000;
+    const char *s1 = "abcdefghijklmnopqrstuvwxyz";
+    const char *s2 = "abcdefghijklmnopqrstuvwxyz";
+    int result = 0;
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        result += std::strcmp(s1, s2);
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+        result += ft_strcmp(s1, s2);
+    auto end_ft = clock_type::now();
+
+    print_comparison("strcmp", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (result == 0 ? 1 : 0);
+}
+
 int test_efficiency_isdigit(void)
 {
     const size_t iterations = 1000000;

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -119,6 +119,9 @@ int test_ft_vector_push_back(void);
 int test_ft_vector_insert_erase(void);
 int test_ft_vector_reserve_resize(void);
 int test_ft_vector_clear(void);
+int test_ft_vector_vs_std_push_back(void);
+int test_ft_vector_vs_std_insert_erase(void);
+int test_ft_vector_vs_std_reserve_resize(void);
 int test_ft_map_insert_find(void);
 int test_ft_map_remove(void);
 int test_ft_map_at(void);
@@ -165,9 +168,12 @@ int test_pt_async_basic(void);
 
 int test_efficiency_strlen(void);
 int test_efficiency_memcpy(void);
+int test_efficiency_memmove(void);
+int test_efficiency_memset(void);
+int test_efficiency_strcmp(void);
 int test_efficiency_isdigit(void);
 
-int main(void)
+int main(int argc, char **argv)
 {
     const s_test tests[] = {
         { test_strlen_nullptr, "strlen nullptr" },
@@ -248,6 +254,9 @@ int main(void)
         { test_ft_vector_insert_erase, "ft_vector insert/erase" },
         { test_ft_vector_reserve_resize, "ft_vector reserve/resize" },
         { test_ft_vector_clear, "ft_vector clear" },
+        { test_ft_vector_vs_std_push_back, "ft_vector vs std::vector push_back" },
+        { test_ft_vector_vs_std_insert_erase, "ft_vector vs std::vector insert/erase" },
+        { test_ft_vector_vs_std_reserve_resize, "ft_vector vs std::vector reserve/resize" },
         { test_ft_map_insert_find, "ft_map insert/find" },
         { test_ft_map_remove, "ft_map remove" },
         { test_ft_map_at, "ft_map at" },
@@ -296,11 +305,33 @@ int main(void)
     const s_perf_test perf_tests[] = {
         { test_efficiency_strlen, "strlen" },
         { test_efficiency_memcpy, "memcpy" },
+        { test_efficiency_memmove, "memmove" },
+        { test_efficiency_memset, "memset" },
+        { test_efficiency_strcmp, "strcmp" },
         { test_efficiency_isdigit, "isdigit" }
     };
 
     const int total = sizeof(tests) / sizeof(tests[0]);
     const int perf_total = sizeof(perf_tests) / sizeof(perf_tests[0]);
+
+    if (argc > 1)
+    {
+        std::string arg(argv[1]);
+        if (arg == "--all")
+        {
+            int passed = 0;
+            for (int i = 0; i < total; ++i)
+                run_test(i + 1, &tests[i], &passed);
+            printf("%d/%d tests passed\n", passed, total);
+            return (0);
+        }
+        else if (arg == "--perf-all")
+        {
+            for (int i = 0; i < perf_total; ++i)
+                run_efficiency_test(i + 1, &perf_tests[i]);
+            return (0);
+        }
+    }
 
     while (true)
     {

--- a/Test/template_tests.cpp
+++ b/Test/template_tests.cpp
@@ -4,6 +4,7 @@
 #include "../Template/unique_ptr.hpp"
 #include "../Errno/errno.hpp"
 #include <cstring>
+#include <vector>
 
 int test_ft_vector_push_back(void)
 {
@@ -72,6 +73,59 @@ int test_ft_vector_clear(void)
     v.push_back(3);
     v.clear();
     return (v.size() == 0);
+}
+int test_ft_vector_vs_std_push_back(void)
+{
+    ft_vector<int> ft;
+    std::vector<int> stdv;
+    for (int i = 0; i < 100; ++i)
+    {
+        ft.push_back(i);
+        stdv.push_back(i);
+    }
+    if (ft.size() != stdv.size())
+        return 0;
+    for (size_t i = 0; i < ft.size(); ++i)
+        if (ft[i] != stdv[i])
+            return 0;
+    return 1;
+}
+
+int test_ft_vector_vs_std_insert_erase(void)
+{
+    ft_vector<int> ft;
+    std::vector<int> stdv;
+    for (int i = 0; i < 5; ++i)
+    {
+        ft.push_back(i);
+        stdv.push_back(i);
+    }
+    ft.insert(ft.begin() + 2, 42);
+    stdv.insert(stdv.begin() + 2, 42);
+    ft.erase(ft.begin() + 1);
+    stdv.erase(stdv.begin() + 1);
+    if (ft.size() != stdv.size())
+        return 0;
+    for (size_t i = 0; i < ft.size(); ++i)
+        if (ft[i] != stdv[i])
+            return 0;
+    return 1;
+}
+
+int test_ft_vector_vs_std_reserve_resize(void)
+{
+    ft_vector<int> ft;
+    std::vector<int> stdv;
+    ft.reserve(10);
+    stdv.reserve(10);
+    ft.resize(6, 3);
+    stdv.resize(6, 3);
+    if (ft.size() != stdv.size())
+        return 0;
+    for (size_t i = 0; i < ft.size(); ++i)
+        if (ft[i] != stdv[i])
+            return 0;
+    return (ft.capacity() >= 10 && stdv.capacity() >= 10);
 }
 
 


### PR DESCRIPTION
## Summary
- Allow running all normal or performance tests via `--all` and `--perf-all` options
- Add efficiency benchmarks for `memmove`, `memset`, and `strcmp`
- Introduce std::vector comparison tests for `ft_vector`
- Fix experience table resize validation so character levels compute correctly

## Testing
- `make -C Test`
- `Test/libft_tests --all`
- `Test/libft_tests --perf-all`


------
https://chatgpt.com/codex/tasks/task_e_68a35fea7f38833190d0c1cb88af53a7