### PR TITLE
Fix memory duplication efficiency test and guard benchmarks from optimization

### DIFF
--- a/Test/efficiency/efficiency_cma_calloc.cpp
+++ b/Test/efficiency/efficiency_cma_calloc.cpp
@@ -14,6 +14,8 @@ int test_efficiency_cma_calloc(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = std::calloc(count, size);
+        ((volatile char*)p)[0] = 0;
+        prevent_optimization(p);
         std::free(p);
     }
     auto end_std = clock_type::now();
@@ -22,6 +24,8 @@ int test_efficiency_cma_calloc(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = cma_calloc(count, size);
+        ((volatile char*)p)[0] = 0;
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_cma_malloc.cpp
+++ b/Test/efficiency/efficiency_cma_malloc.cpp
@@ -13,6 +13,8 @@ int test_efficiency_cma_malloc(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = std::malloc(size);
+        ((volatile char*)p)[0] = 0;
+        prevent_optimization(p);
         std::free(p);
     }
     auto end_std = clock_type::now();
@@ -21,6 +23,8 @@ int test_efficiency_cma_malloc(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = cma_malloc(size);
+        ((volatile char*)p)[0] = 0;
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_cma_memdup.cpp
+++ b/Test/efficiency/efficiency_cma_memdup.cpp
@@ -15,7 +15,8 @@ int test_efficiency_cma_memdup(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = ft_memdup(data.data(), data.size());
-        std::free(p);
+        prevent_optimization(p);
+        cma_free(p);
     }
     auto end_std = clock_type::now();
 
@@ -23,6 +24,7 @@ int test_efficiency_cma_memdup(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = cma_memdup(data.data(), data.size());
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_cma_realloc.cpp
+++ b/Test/efficiency/efficiency_cma_realloc.cpp
@@ -14,6 +14,7 @@ int test_efficiency_cma_realloc(void)
         void *p = std::malloc(size);
         p = std::realloc(p, size * 2);
         p = std::realloc(p, size * 4);
+        prevent_optimization(p);
         std::free(p);
     }
     auto end_std = clock_type::now();
@@ -25,6 +26,7 @@ int test_efficiency_cma_realloc(void)
         void *p = cma_malloc(size);
         p = cma_realloc(p, size * 2);
         p = cma_realloc(p, size * 4);
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_cma_strdup.cpp
+++ b/Test/efficiency/efficiency_cma_strdup.cpp
@@ -15,6 +15,7 @@ int test_efficiency_cma_strdup(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = ::strdup(s.c_str());
+        prevent_optimization(p);
         std::free(p);
     }
     auto end_std = clock_type::now();
@@ -23,6 +24,7 @@ int test_efficiency_cma_strdup(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = cma_strdup(s.c_str());
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_utils.hpp
+++ b/Test/efficiency/efficiency_utils.hpp
@@ -3,6 +3,17 @@
 #include <chrono>
 #include <cstdio>
 
+inline volatile void* g_efficiency_sink;
+
+inline void prevent_optimization(void* p)
+{
+#if defined(__GNUG__)
+    asm volatile("" : : "g"(p) : "memory");
+#else
+    g_efficiency_sink = p;
+#endif
+}
+
 using clock_type = std::chrono::high_resolution_clock;
 
 inline long long elapsed_us(clock_type::time_point start, clock_type::time_point end)


### PR DESCRIPTION
## Summary
- Prevent invalid free in `cma_memdup` efficiency test by using `cma_free`
- Use a volatile sink to stop allocation benchmarks from being optimized away
- Touch allocated memory in `cma_malloc` and `cma_calloc` efficiency tests so std implementations are timed

## Testing
- `make` (in `Test`)
- `./libft_tests` with `perf` → `all`

------
https://chatgpt.com/codex/tasks/task_e_68a4a31a5f608331ad684d831e046461