### PR TITLE
Fix memory duplication efficiency test and harden benchmarks against optimization

### DIFF
--- a/Test/efficiency/efficiency_bzero.cpp
+++ b/Test/efficiency/efficiency_bzero.cpp
@@ -14,17 +14,22 @@ int test_efficiency_bzero(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(buf_std.data());
         sink = std_bzero(buf_std.data(), 0, buf_std.size());
+        prevent_optimization(buf_std.data());
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
     {
+        prevent_optimization(buf_ft.data());
         ft_bzero(buf_ft.data(), buf_ft.size());
         sink = buf_ft.data();
+        prevent_optimization(buf_ft.data());
     }
     auto end_ft = clock_type::now();
-
     (void)sink;
     print_comparison("bzero", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));

--- a/Test/efficiency/efficiency_cma_calloc.cpp
+++ b/Test/efficiency/efficiency_cma_calloc.cpp
@@ -14,6 +14,8 @@ int test_efficiency_cma_calloc(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = std::calloc(count, size);
+        ((volatile char*)p)[0] = 0;
+        prevent_optimization(p);
         std::free(p);
     }
     auto end_std = clock_type::now();
@@ -22,6 +24,8 @@ int test_efficiency_cma_calloc(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = cma_calloc(count, size);
+        ((volatile char*)p)[0] = 0;
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_cma_malloc.cpp
+++ b/Test/efficiency/efficiency_cma_malloc.cpp
@@ -13,6 +13,8 @@ int test_efficiency_cma_malloc(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = std::malloc(size);
+        ((volatile char*)p)[0] = 0;
+        prevent_optimization(p);
         std::free(p);
     }
     auto end_std = clock_type::now();
@@ -21,6 +23,8 @@ int test_efficiency_cma_malloc(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = cma_malloc(size);
+        ((volatile char*)p)[0] = 0;
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_cma_memdup.cpp
+++ b/Test/efficiency/efficiency_cma_memdup.cpp
@@ -15,7 +15,8 @@ int test_efficiency_cma_memdup(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = ft_memdup(data.data(), data.size());
-        std::free(p);
+        prevent_optimization(p);
+        cma_free(p);
     }
     auto end_std = clock_type::now();
 
@@ -23,6 +24,7 @@ int test_efficiency_cma_memdup(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = cma_memdup(data.data(), data.size());
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_cma_realloc.cpp
+++ b/Test/efficiency/efficiency_cma_realloc.cpp
@@ -14,6 +14,7 @@ int test_efficiency_cma_realloc(void)
         void *p = std::malloc(size);
         p = std::realloc(p, size * 2);
         p = std::realloc(p, size * 4);
+        prevent_optimization(p);
         std::free(p);
     }
     auto end_std = clock_type::now();
@@ -25,6 +26,7 @@ int test_efficiency_cma_realloc(void)
         void *p = cma_malloc(size);
         p = cma_realloc(p, size * 2);
         p = cma_realloc(p, size * 4);
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_cma_strdup.cpp
+++ b/Test/efficiency/efficiency_cma_strdup.cpp
@@ -15,6 +15,7 @@ int test_efficiency_cma_strdup(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = ::strdup(s.c_str());
+        prevent_optimization(p);
         std::free(p);
     }
     auto end_std = clock_type::now();
@@ -23,6 +24,7 @@ int test_efficiency_cma_strdup(void)
     for (size_t i = 0; i < iterations; ++i)
     {
         p = cma_strdup(s.c_str());
+        prevent_optimization(p);
         cma_free(p);
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_memchr.cpp
+++ b/Test/efficiency/efficiency_memchr.cpp
@@ -14,15 +14,21 @@ int test_efficiency_memchr(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(buf.data());
         result = std_memchr(buf.data(), 'b', buf.size());
+        prevent_optimization(const_cast<void*>(result));
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(buf.data());
         result = ft_memchr(buf.data(), 'b', buf.size());
+        prevent_optimization(const_cast<void*>(result));
+    }
     auto end_ft = clock_type::now();
-
-    (void)result;
     print_comparison("memchr", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));
     return (1);

--- a/Test/efficiency/efficiency_memcmp.cpp
+++ b/Test/efficiency/efficiency_memcmp.cpp
@@ -15,15 +15,23 @@ int test_efficiency_memcmp(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(a.data());
+        prevent_optimization(b.data());
         result += std_memcmp(a.data(), b.data(), a.size());
+        prevent_optimization((void*)&result);
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(a.data());
+        prevent_optimization(b.data());
         result += ft_memcmp(a.data(), b.data(), a.size());
+        prevent_optimization((void*)&result);
+    }
     auto end_ft = clock_type::now();
-
-    (void)result;
     print_comparison("memcmp", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));
     return (1);

--- a/Test/efficiency/efficiency_memcpy.cpp
+++ b/Test/efficiency/efficiency_memcpy.cpp
@@ -15,14 +15,23 @@ int test_efficiency_memcpy(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(src.data());
+        prevent_optimization(dst_std.data());
         sink = std_memcpy(dst_std.data(), src.data(), src.size());
+        prevent_optimization(dst_std.data());
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(src.data());
+        prevent_optimization(dst_ft.data());
         sink = ft_memcpy(dst_ft.data(), src.data(), src.size());
+        prevent_optimization(dst_ft.data());
+    }
     auto end_ft = clock_type::now();
-
     (void)sink;
     print_comparison("memcpy", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));

--- a/Test/efficiency/efficiency_memmove.cpp
+++ b/Test/efficiency/efficiency_memmove.cpp
@@ -14,14 +14,21 @@ int test_efficiency_memmove(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(buf_std.data());
         sink = std_memmove(buf_std.data() + 1, buf_std.data(), buf_std.size() - 1);
+        prevent_optimization(buf_std.data());
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(buf_ft.data());
         sink = ft_memmove(buf_ft.data() + 1, buf_ft.data(), buf_ft.size() - 1);
+        prevent_optimization(buf_ft.data());
+    }
     auto end_ft = clock_type::now();
-
     (void)sink;
     print_comparison("memmove", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));

--- a/Test/efficiency/efficiency_memset.cpp
+++ b/Test/efficiency/efficiency_memset.cpp
@@ -14,14 +14,21 @@ int test_efficiency_memset(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(buf_std.data());
         sink = std_memset(buf_std.data(), 'a', buf_std.size());
+        prevent_optimization(buf_std.data());
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(buf_ft.data());
         sink = ft_memset(buf_ft.data(), 'a', buf_ft.size());
+        prevent_optimization(buf_ft.data());
+    }
     auto end_ft = clock_type::now();
-
     (void)sink;
     print_comparison("memset", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));

--- a/Test/efficiency/efficiency_strchr.cpp
+++ b/Test/efficiency/efficiency_strchr.cpp
@@ -14,15 +14,21 @@ int test_efficiency_strchr(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(const_cast<char*>(s.data()));
         result = std_strchr(s.c_str(), 'b');
+        prevent_optimization(const_cast<char*>(result));
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(const_cast<char*>(s.data()));
         result = ft_strchr(s.c_str(), 'b');
+        prevent_optimization(const_cast<char*>(result));
+    }
     auto end_ft = clock_type::now();
-
-    (void)result;
     print_comparison("strchr", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));
     return (1);

--- a/Test/efficiency/efficiency_strcmp.cpp
+++ b/Test/efficiency/efficiency_strcmp.cpp
@@ -2,23 +2,34 @@
 #include "efficiency_utils.hpp"
 
 #include <cstring>
+#include <string>
 
 int test_efficiency_strcmp(void)
 {
     const size_t iterations = 500000;
-    const char *s1 = "abcdefghijklmnopqrstuvwxyz";
-    const char *s2 = "abcdefghijklmnopqrstuvwxyz";
+    std::string s1 = "abcdefghijklmnopqrstuvwxyz";
+    std::string s2 = "abcdefghijklmnopqrstuvwxyz";
     volatile int result = 0;
     auto std_strcmp = static_cast<int (*)(const char *, const char *)>(std::strcmp);
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
-        result += std_strcmp(s1, s2);
+    {
+        prevent_optimization(s1.data());
+        prevent_optimization(s2.data());
+        result += std_strcmp(s1.c_str(), s2.c_str());
+        prevent_optimization((void*)&result);
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
-        result += ft_strcmp(s1, s2);
+    {
+        prevent_optimization(s1.data());
+        prevent_optimization(s2.data());
+        result += ft_strcmp(s1.c_str(), s2.c_str());
+        prevent_optimization((void*)&result);
+    }
     auto end_ft = clock_type::now();
 
     print_comparison("strcmp", elapsed_us(start_std, end_std),

--- a/Test/efficiency/efficiency_strlen.cpp
+++ b/Test/efficiency/efficiency_strlen.cpp
@@ -13,15 +13,21 @@ int test_efficiency_strlen(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(s.data());
         sink += std_strlen(s.c_str());
+        prevent_optimization((void*)&sink);
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(s.data());
         sink += ft_strlen(s.c_str());
+        prevent_optimization((void*)&sink);
+    }
     auto end_ft = clock_type::now();
-
-    (void)sink;
     print_comparison("strlen", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));
     return (1);

--- a/Test/efficiency/efficiency_strncmp.cpp
+++ b/Test/efficiency/efficiency_strncmp.cpp
@@ -15,15 +15,23 @@ int test_efficiency_strncmp(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(a.data());
+        prevent_optimization(b.data());
         result += std_strncmp(a.c_str(), b.c_str(), a.size());
+        prevent_optimization((void*)&result);
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(a.data());
+        prevent_optimization(b.data());
         result += ft_strncmp(a.c_str(), b.c_str(), a.size());
+        prevent_optimization((void*)&result);
+    }
     auto end_ft = clock_type::now();
-
-    (void)result;
     print_comparison("strncmp", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));
     return (1);

--- a/Test/efficiency/efficiency_strrchr.cpp
+++ b/Test/efficiency/efficiency_strrchr.cpp
@@ -14,15 +14,22 @@ int test_efficiency_strrchr(void)
 
     auto start_std = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(const_cast<char*>(s.data()));
         result = std_strrchr(s.c_str(), 'b');
+        prevent_optimization(const_cast<char*>(result));
+    }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
     for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization(const_cast<char*>(s.data()));
         result = ft_strrchr(s.c_str(), 'b');
+        prevent_optimization(const_cast<char*>(result));
+    }
     auto end_ft = clock_type::now();
 
-    (void)result;
     print_comparison("strrchr", elapsed_us(start_std, end_std),
                      elapsed_us(start_ft, end_ft));
     return (1);

--- a/Test/efficiency/efficiency_utils.hpp
+++ b/Test/efficiency/efficiency_utils.hpp
@@ -3,6 +3,17 @@
 #include <chrono>
 #include <cstdio>
 
+inline volatile void* g_efficiency_sink;
+
+inline void prevent_optimization(void* p)
+{
+#if defined(__GNUG__)
+    asm volatile("" : : "g"(p) : "memory");
+#else
+    g_efficiency_sink = p;
+#endif
+}
+
 using clock_type = std::chrono::high_resolution_clock;
 
 inline long long elapsed_us(clock_type::time_point start, clock_type::time_point end)


### PR DESCRIPTION
## Summary
- Prevent invalid free in `cma_memdup` efficiency test by using `cma_free`
- Use a volatile sink to stop allocation benchmarks from being optimized away
- Touch allocated memory in `cma_malloc` and `cma_calloc` efficiency tests so std implementations are timed
- Block constant folding in string and memory benchmarks by clobbering inputs and outputs

## Testing
- `make -C Test`
- `./Test/libft_tests` with `perf` → `all`


------
https://chatgpt.com/codex/tasks/task_e_68a4a31a5f608331ad684d831e046461