### PR TITLE
Remove std::strlen usage in ft_strlen

### DIFF
--- a/Libft/ft_limits.hpp
+++ b/Libft/ft_limits.hpp
@@ -1,0 +1,14 @@
+#ifndef FT_LIMITS_HPP
+#define FT_LIMITS_HPP
+
+#define FT_CHAR_BIT 8
+
+#define FT_INT_MAX ((int)(~0U >> 1))
+#define FT_INT_MIN (-FT_INT_MAX - 1)
+#define FT_UINT_MAX (~0U)
+
+#define FT_LONG_MAX ((long)(~0UL >> 1))
+#define FT_LONG_MIN (-FT_LONG_MAX - 1L)
+#define FT_ULONG_MAX (~0UL)
+
+#endif

--- a/Libft/ft_strlen.cpp
+++ b/Libft/ft_strlen.cpp
@@ -1,30 +1,11 @@
 #include "libft.hpp"
-#include <cstddef>
-#include <cstdint>
-
-static inline bool has_zero(size_t value)
-{
-    const size_t mask01 = ~static_cast<size_t>(0) / 0xFF;
-    const size_t mask80 = mask01 << 7;
-    return ((value - mask01) & (~value) & mask80) != 0;
-}
+#include "ft_limits.hpp"
 
 int ft_strlen(const char *string)
 {
-	if (!string)
-        return (0);
-    const char *ptr = string;
-    while (reinterpret_cast<uintptr_t>(ptr) & (sizeof(size_t) - 1))
-    {
-        if (*ptr == '\0')
-            return (static_cast<int>(ptr - string));
-        ++ptr;
-    }
-    const size_t *word_ptr = reinterpret_cast<const size_t*>(ptr);
-    while (!has_zero(*word_ptr))
-        ++word_ptr;
-    ptr = reinterpret_cast<const char*>(word_ptr);
-    while (*ptr)
-        ++ptr;
-    return (static_cast<int>(ptr - string));
+    size_t len = ft_strlen_size_t(string);
+    if (len > static_cast<size_t>(FT_INT_MAX))
+        return (FT_INT_MAX);
+    return (static_cast<int>(len));
 }
+

--- a/Libft/ft_strlen_size_t.cpp
+++ b/Libft/ft_strlen_size_t.cpp
@@ -2,16 +2,12 @@
 #include <cstddef>
 #include <cstdint>
 
-static inline bool has_zero_size_t(size_t value)
-{
-    const size_t mask01 = ~static_cast<size_t>(0) / 0xFF;
-    const size_t mask80 = mask01 << 7;
-    return ((value - mask01) & (~value) & mask80) != 0;
-}
+#define FT_REPEAT_BYTE(x) (~static_cast<size_t>(0) / 0xFF * (x))
+#define FT_HAS_ZERO(x) (((x) - FT_REPEAT_BYTE(0x01)) & ~(x) & FT_REPEAT_BYTE(0x80))
 
 size_t ft_strlen_size_t(const char *string)
 {
-	if (!string)
+    if (!string)
         return (0);
     const char *ptr = string;
     while (reinterpret_cast<uintptr_t>(ptr) & (sizeof(size_t) - 1))
@@ -21,10 +17,13 @@ size_t ft_strlen_size_t(const char *string)
         ++ptr;
     }
     const size_t *word_ptr = reinterpret_cast<const size_t*>(ptr);
-    while (!has_zero_size_t(*word_ptr))
+    while (!FT_HAS_ZERO(*word_ptr))
         ++word_ptr;
     ptr = reinterpret_cast<const char*>(word_ptr);
     while (*ptr)
         ++ptr;
     return (static_cast<size_t>(ptr - string));
 }
+
+#undef FT_REPEAT_BYTE
+#undef FT_HAS_ZERO


### PR DESCRIPTION
## Summary
- introduce internal `ft_limits.hpp` macros instead of <climits>
- optimize `ft_strlen_size_t` with macro zero-byte detection
- keep `ft_strlen` overflow guard via `FT_INT_MAX`

## Testing
- `make -C Libft`
- `make -C Test`
- `./Test/libft_tests --all`


------
https://chatgpt.com/codex/tasks/task_e_68a4b3c5146c8331ab16991bdd861182