### PR TITLE
Add performance tests for ft_vector

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -2,16 +2,16 @@ TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
 EFF_SRCS := efficiency/efficiency_strlen.cpp efficiency/efficiency_memcpy.cpp \
-            efficiency/efficiency_memmove.cpp efficiency/efficiency_memset.cpp \
-            efficiency/efficiency_strcmp.cpp efficiency/efficiency_isdigit.cpp \
-            efficiency/efficiency_bzero.cpp efficiency/efficiency_memcmp.cpp \
-            efficiency/efficiency_strchr.cpp efficiency/efficiency_strncmp.cpp \
-            efficiency/efficiency_isalpha.cpp efficiency/efficiency_isalnum.cpp \
-            efficiency/efficiency_memchr.cpp efficiency/efficiency_strrchr.cpp \
-            efficiency/efficiency_isspace.cpp efficiency/efficiency_abs.cpp \
-            efficiency/efficiency_cma_malloc.cpp efficiency/efficiency_cma_calloc.cpp \
-            efficiency/efficiency_cma_strdup.cpp efficiency/efficiency_cma_memdup.cpp \
-            efficiency/efficiency_cma_realloc.cpp
+	    efficiency/efficiency_memmove.cpp efficiency/efficiency_memset.cpp \
+	    efficiency/efficiency_strcmp.cpp efficiency/efficiency_isdigit.cpp \
+	    efficiency/efficiency_bzero.cpp efficiency/efficiency_memcmp.cpp \
+	    efficiency/efficiency_strchr.cpp efficiency/efficiency_strncmp.cpp \
+	    efficiency/efficiency_isalpha.cpp efficiency/efficiency_isalnum.cpp \
+	    efficiency/efficiency_memchr.cpp efficiency/efficiency_strrchr.cpp \
+	    efficiency/efficiency_isspace.cpp efficiency/efficiency_abs.cpp \
+	    efficiency/efficiency_cma_malloc.cpp efficiency/efficiency_cma_calloc.cpp \
+	    efficiency/efficiency_cma_strdup.cpp efficiency/efficiency_cma_memdup.cpp \
+	    efficiency/efficiency_cma_realloc.cpp efficiency/efficiency_vector.cpp
 
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp test_strlen.cpp \
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \
@@ -49,11 +49,10 @@ endif
 
 CXX       := g++
 
-ifdef COMPILE_FLAGS
-CFLAGS := $(COMPILE_FLAGS) $(OPT_FLAGS)
-else
-CFLAGS ?= -Wall -Wextra -Werror -std=c++17 $(OPT_FLAGS)
-endif
+COMPILE_FLAGS ?= -Wall -Wextra -Werror -std=c++17
+COMPILE_FLAGS += $(OPT_FLAGS)
+CFLAGS := $(COMPILE_FLAGS)
+export COMPILE_FLAGS
 
 OBJDIR       := objs
 DEBUG_OBJDIR := objs_debug
@@ -81,10 +80,10 @@ $(DEBUG_OBJDIR)/%.o: %.cpp
 	$(CXX) $(CFLAGS) -c $< -o $@
 
 ../Full_Libft.a:
-	$(MAKE) -C ..
+	$(MAKE) -C .. COMPILE_FLAGS="$(COMPILE_FLAGS)"
 
 ../Full_Libft_debug.a:
-	$(MAKE) -C .. debug
+	$(MAKE) -C .. debug COMPILE_FLAGS="$(COMPILE_FLAGS)"
 
 CLEAN_OBJS := $(shell find $(OBJDIR) $(DEBUG_OBJDIR) -type f -name '*.o' 2>/dev/null)
 
@@ -96,12 +95,12 @@ endif
 
 clean:
 	-$(RM) $(CLEAN_FILES)
-	$(MAKE) -C .. clean
+	$(MAKE) -C .. clean COMPILE_FLAGS="$(COMPILE_FLAGS)"
 
 fclean:
 	-$(RM) $(CLEAN_FILES)
 	-$(RM) $(TARGET) $(DEBUG_TARGET)
-	$(MAKE) -C .. fclean
+	$(MAKE) -C .. fclean COMPILE_FLAGS="$(COMPILE_FLAGS)"
 
 re: fclean all
 

--- a/Test/efficiency/efficiency_vector.cpp
+++ b/Test/efficiency/efficiency_vector.cpp
@@ -1,0 +1,109 @@
+#include "../../Template/vector.hpp"
+#include "efficiency_utils.hpp"
+
+#include <vector>
+
+int test_efficiency_vector_push_back(void)
+{
+    const size_t iterations = 20000;
+    std::vector<int> stdv;
+    ft_vector<int> ftv;
+    stdv.reserve(iterations);
+    ftv.reserve(iterations);
+    volatile long long sum = 0;
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)&stdv);
+        stdv.push_back(static_cast<int>(i));
+    }
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)&ftv);
+        ftv.push_back(static_cast<int>(i));
+    }
+    auto end_ft = clock_type::now();
+
+    for (size_t i = 0; i < stdv.size(); ++i)
+        sum += stdv[i];
+    for (size_t i = 0; i < ftv.size(); ++i)
+        sum += ftv[i];
+    prevent_optimization((void*)&sum);
+
+    print_comparison("vector push_back", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (stdv.size() == ftv.size() ? 1 : 0);
+}
+
+int test_efficiency_vector_insert_erase(void)
+{
+    const size_t base = 1000;
+    const size_t iterations = 5000;
+    std::vector<int> stdv(base, 1);
+    ft_vector<int> ftv;
+    ftv.resize(base, 1);
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        size_t pos = stdv.size() / 2;
+        stdv.insert(stdv.begin() + pos, static_cast<int>(i));
+        stdv.erase(stdv.begin() + pos);
+    }
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        size_t pos = ftv.size() / 2;
+        ftv.insert(ftv.begin() + pos, static_cast<int>(i));
+        ftv.erase(ftv.begin() + pos);
+    }
+    auto end_ft = clock_type::now();
+
+    if (!stdv.empty())
+        prevent_optimization(stdv.data());
+    if (ftv.size() > 0)
+        prevent_optimization(&ftv[0]);
+
+    print_comparison("vector insert/erase", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (stdv.size() == ftv.size() ? 1 : 0);
+}
+
+int test_efficiency_vector_reserve_resize(void)
+{
+    const size_t iterations = 5000;
+    std::vector<int> stdv;
+    ft_vector<int> ftv;
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        stdv.reserve(i);
+        stdv.resize(i, 0);
+    }
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        ftv.reserve(i);
+        ftv.resize(i, 0);
+    }
+    auto end_ft = clock_type::now();
+
+    if (!stdv.empty())
+        prevent_optimization(stdv.data());
+    if (ftv.size() > 0)
+        prevent_optimization(&ftv[0]);
+
+    print_comparison("vector reserve/resize", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (stdv.size() == ftv.size() ? 1 : 0);
+}
+

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -187,6 +187,9 @@ int test_efficiency_cma_calloc(void);
 int test_efficiency_cma_strdup(void);
 int test_efficiency_cma_memdup(void);
 int test_efficiency_cma_realloc(void);
+int test_efficiency_vector_push_back(void);
+int test_efficiency_vector_insert_erase(void);
+int test_efficiency_vector_reserve_resize(void);
 
 int main(int argc, char **argv)
 {
@@ -338,7 +341,10 @@ int main(int argc, char **argv)
         { test_efficiency_cma_calloc, "cma_calloc" },
         { test_efficiency_cma_strdup, "cma_strdup" },
         { test_efficiency_cma_memdup, "cma_memdup" },
-        { test_efficiency_cma_realloc, "cma_realloc" }
+        { test_efficiency_cma_realloc, "cma_realloc" },
+        { test_efficiency_vector_push_back, "ft_vector push_back" },
+        { test_efficiency_vector_insert_erase, "ft_vector insert/erase" },
+        { test_efficiency_vector_reserve_resize, "ft_vector reserve/resize" },
     };
 
     const int total = sizeof(tests) / sizeof(tests[0]);


### PR DESCRIPTION
## Summary
- Benchmark ft_vector against std::vector for push_back, insert/erase, and reserve/resize
- Include new benchmarks in test build and runner
- Allow test Makefile to propagate compile flags so libft builds with same optimizations

## Testing
- `make -C Test`
- `./Test/libft_tests --perf-all`


------
https://chatgpt.com/codex/tasks/task_e_68a8db78cf008331a9ed036dbb9a444c