### PR TITLE
Add performance tests for atoi, atol, and map

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -10,8 +10,10 @@ EFF_SRCS := efficiency/efficiency_strlen.cpp efficiency/efficiency_memcpy.cpp \
 	    efficiency/efficiency_memchr.cpp efficiency/efficiency_strrchr.cpp \
 	    efficiency/efficiency_isspace.cpp efficiency/efficiency_abs.cpp \
 	    efficiency/efficiency_cma_malloc.cpp efficiency/efficiency_cma_calloc.cpp \
-	    efficiency/efficiency_cma_strdup.cpp efficiency/efficiency_cma_memdup.cpp \
-	    efficiency/efficiency_cma_realloc.cpp efficiency/efficiency_vector.cpp
+            efficiency/efficiency_cma_strdup.cpp efficiency/efficiency_cma_memdup.cpp \
+            efficiency/efficiency_cma_realloc.cpp efficiency/efficiency_vector.cpp \
+            efficiency/efficiency_map.cpp \
+            efficiency/efficiency_atoi.cpp efficiency/efficiency_atol.cpp
 
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp test_strlen.cpp \
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \

--- a/Test/efficiency/efficiency_atoi.cpp
+++ b/Test/efficiency/efficiency_atoi.cpp
@@ -1,0 +1,34 @@
+#include "../../Libft/libft.hpp"
+#include "efficiency_utils.hpp"
+
+#include <cstdlib>
+
+int test_efficiency_atoi(void)
+{
+    const size_t iterations = 100000;
+    const char *s = "12345";
+    volatile int result = 0;
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)s);
+        result += std::atoi(s);
+        prevent_optimization((void*)&result);
+    }
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)s);
+        result += ft_atoi(s);
+        prevent_optimization((void*)&result);
+    }
+    auto end_ft = clock_type::now();
+
+    print_comparison("atoi", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (result ? 1 : 0);
+}
+

--- a/Test/efficiency/efficiency_atol.cpp
+++ b/Test/efficiency/efficiency_atol.cpp
@@ -1,0 +1,34 @@
+#include "../../Libft/libft.hpp"
+#include "efficiency_utils.hpp"
+
+#include <cstdlib>
+
+int test_efficiency_atol(void)
+{
+    const size_t iterations = 100000;
+    const char *s = "123456789";
+    volatile long result = 0;
+
+    auto start_std = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)s);
+        result += std::atol(s);
+        prevent_optimization((void*)&result);
+    }
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)s);
+        result += ft_atol(s);
+        prevent_optimization((void*)&result);
+    }
+    auto end_ft = clock_type::now();
+
+    print_comparison("atol", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (result ? 1 : 0);
+}
+

--- a/Test/efficiency/efficiency_map.cpp
+++ b/Test/efficiency/efficiency_map.cpp
@@ -1,0 +1,83 @@
+#include "../../Template/map.hpp"
+#include "efficiency_utils.hpp"
+
+#include <map>
+
+int test_efficiency_map_insert_find(void)
+{
+    const int iterations = 10000;
+    std::map<int, int> stdm;
+    ft_map<int, int> ftm;
+    long long sum = 0;
+
+    auto start_std = clock_type::now();
+    for (int i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)&stdm);
+        stdm.insert(std::make_pair(i, i));
+    }
+    for (int i = 0; i < iterations; ++i)
+    {
+        std::map<int, int>::iterator it = stdm.find(i);
+        if (it != stdm.end())
+            sum += it->second;
+    }
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (int i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)&ftm);
+        ftm.insert(i, i);
+    }
+    for (int i = 0; i < iterations; ++i)
+    {
+        Pair<int, int>* p = ftm.find(i);
+        if (p)
+            sum += p->value;
+    }
+    auto end_ft = clock_type::now();
+
+    prevent_optimization((void*)&sum);
+
+    print_comparison("map insert/find", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (stdm.size() == ftm.getSize() ? 1 : 0);
+}
+
+int test_efficiency_map_insert_remove(void)
+{
+    const int iterations = 10000;
+    std::map<int, int> stdm;
+    ft_map<int, int> ftm;
+
+    auto start_std = clock_type::now();
+    for (int i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)&stdm);
+        stdm.insert(std::make_pair(i, i));
+    }
+    for (int i = 0; i < iterations; ++i)
+        stdm.erase(i);
+    auto end_std = clock_type::now();
+
+    auto start_ft = clock_type::now();
+    for (int i = 0; i < iterations; ++i)
+    {
+        prevent_optimization((void*)&ftm);
+        ftm.insert(i, i);
+    }
+    for (int i = 0; i < iterations; ++i)
+        ftm.remove(i);
+    auto end_ft = clock_type::now();
+
+    if (!stdm.empty())
+        prevent_optimization((void*)&*stdm.begin());
+    if (!ftm.empty())
+        prevent_optimization((void*)ftm.find(0));
+
+    print_comparison("map insert/remove", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return (stdm.empty() == ftm.empty() ? 1 : 0);
+}
+

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -182,6 +182,8 @@ int test_efficiency_memchr(void);
 int test_efficiency_strrchr(void);
 int test_efficiency_isspace(void);
 int test_efficiency_abs(void);
+int test_efficiency_atoi(void);
+int test_efficiency_atol(void);
 int test_efficiency_cma_malloc(void);
 int test_efficiency_cma_calloc(void);
 int test_efficiency_cma_strdup(void);
@@ -190,6 +192,8 @@ int test_efficiency_cma_realloc(void);
 int test_efficiency_vector_push_back(void);
 int test_efficiency_vector_insert_erase(void);
 int test_efficiency_vector_reserve_resize(void);
+int test_efficiency_map_insert_find(void);
+int test_efficiency_map_insert_remove(void);
 
 int main(int argc, char **argv)
 {
@@ -337,6 +341,8 @@ int main(int argc, char **argv)
         { test_efficiency_strrchr, "strrchr" },
         { test_efficiency_isspace, "isspace" },
         { test_efficiency_abs, "abs" },
+        { test_efficiency_atoi, "atoi" },
+        { test_efficiency_atol, "atol" },
         { test_efficiency_cma_malloc, "cma_malloc" },
         { test_efficiency_cma_calloc, "cma_calloc" },
         { test_efficiency_cma_strdup, "cma_strdup" },
@@ -345,6 +351,8 @@ int main(int argc, char **argv)
         { test_efficiency_vector_push_back, "ft_vector push_back" },
         { test_efficiency_vector_insert_erase, "ft_vector insert/erase" },
         { test_efficiency_vector_reserve_resize, "ft_vector reserve/resize" },
+        { test_efficiency_map_insert_find, "ft_map insert/find" },
+        { test_efficiency_map_insert_remove, "ft_map insert/remove" },
     };
 
     const int total = sizeof(tests) / sizeof(tests[0]);


### PR DESCRIPTION
## Summary
- Add efficiency tests for `ft_map` vs `std::map`
- Register map benchmarks in test runner and build system
- Add efficiency tests for `ft_atoi` and `ft_atol`

## Testing
- `make -C Test`
- `./Test/libft_tests --perf-all`


------
https://chatgpt.com/codex/tasks/task_e_68a96efc169c8331af17984a456378e2