### PR TITLE
Add pt_mutex performance comparison

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -20,7 +20,8 @@ EFF_SRCS := efficiency/efficiency_strlen.cpp efficiency/efficiency_memcpy.cpp \
             efficiency/efficiency_sqrt.cpp efficiency/efficiency_exp.cpp \
             efficiency/efficiency_clamp.cpp \
             efficiency/efficiency_atoi.cpp efficiency/efficiency_atol.cpp \
-            efficiency/efficiency_pool.cpp efficiency/efficiency_swap.cpp
+            efficiency/efficiency_pool.cpp efficiency/efficiency_swap.cpp \
+            efficiency/efficiency_mutex.cpp
 
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp test_strlen.cpp \
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \
@@ -59,7 +60,7 @@ endif
 CXX       := g++
 
 COMPILE_FLAGS ?= -Wall -Wextra -Werror -std=c++17
-COMPILE_FLAGS += $(OPT_FLAGS)
+COMPILE_FLAGS += $(OPT_FLAGS) -pthread
 CFLAGS := $(COMPILE_FLAGS)
 export COMPILE_FLAGS
 

--- a/Test/efficiency/efficiency_mutex.cpp
+++ b/Test/efficiency/efficiency_mutex.cpp
@@ -1,0 +1,58 @@
+#include "../../PThread/mutex.hpp"
+#include "../../PThread/PThread.hpp"
+#include "efficiency_utils.hpp"
+
+#include <mutex>
+#include <thread>
+#include <vector>
+
+int test_efficiency_mutex_lock(void)
+{
+    const int iterations = 10000;
+    const int thread_count = 4;
+
+    std::mutex std_mtx;
+    pt_mutex ft_mtx;
+
+    auto std_worker = [&]() {
+        for (int i = 0; i < iterations; ++i)
+        {
+            std_mtx.lock();
+            prevent_optimization((void*)&std_mtx);
+            std_mtx.unlock();
+        }
+    };
+
+    auto ft_worker = [&]() {
+        pt_thread_id_type id = THREAD_ID;
+        for (int i = 0; i < iterations; ++i)
+        {
+            ft_mtx.lock(id);
+            prevent_optimization((void*)&ft_mtx);
+            ft_mtx.unlock(id);
+        }
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(thread_count);
+
+    auto start_std = clock_type::now();
+    for (int i = 0; i < thread_count; ++i)
+        threads.emplace_back(std_worker);
+    for (std::thread &t : threads)
+        t.join();
+    auto end_std = clock_type::now();
+
+    threads.clear();
+
+    auto start_ft = clock_type::now();
+    for (int i = 0; i < thread_count; ++i)
+        threads.emplace_back(ft_worker);
+    for (std::thread &t : threads)
+        t.join();
+    auto end_ft = clock_type::now();
+
+    print_comparison("mutex lock/unlock", elapsed_us(start_std, end_std),
+                     elapsed_us(start_ft, end_ft));
+    return 1;
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -240,6 +240,7 @@ int test_efficiency_exp(void);
 int test_efficiency_clamp(void);
 int test_efficiency_pool_acquire_release(void);
 int test_efficiency_swap_large(void);
+int test_efficiency_mutex_lock(void);
 
 int main(int argc, char **argv)
 {
@@ -445,6 +446,7 @@ int main(int argc, char **argv)
         { test_efficiency_clamp, "ft_clamp" },
         { test_efficiency_pool_acquire_release, "ft_pool acquire/release" },
         { test_efficiency_swap_large, "ft_swap large struct" },
+        { test_efficiency_mutex_lock, "ft_mutex lock/unlock" },
     };
 
     const int total = sizeof(tests) / sizeof(tests[0]);


### PR DESCRIPTION
## Summary
- add efficiency test to compare std::mutex and pt_mutex lock/unlock
- build tests with pthread support

## Testing
- `cd Test && make clean && make`
- `./libft_tests --perf-all`

------
https://chatgpt.com/codex/tasks/task_e_68aa270c58048331a87ab50410548dd5