### PR TITLE
Reset mutex release flag after locking

### DIFF
--- a/PThread/lock_mutex.cpp
+++ b/PThread/lock_mutex.cpp
@@ -28,6 +28,7 @@ int pt_mutex::lock(pthread_t thread_id)
             if (__sync_bool_compare_and_swap(&this->_lock, false, true))
             {
                 this->_thread_id = thread_id;
+                this->_lock_released = false;
                 return (SUCCES);
             }
         }
@@ -64,6 +65,7 @@ int pt_mutex::lock(pthread_t thread_id)
             if (__sync_bool_compare_and_swap(&this->_lock, false, true))
             {
                 this->_thread_id = thread_id;
+                this->_lock_released = false;
                 return (SUCCES);
             }
         }

--- a/PThread/try_lock_mutex.cpp
+++ b/PThread/try_lock_mutex.cpp
@@ -15,8 +15,9 @@ int pt_mutex::try_lock(pthread_t thread_id)
 	}
     if (__sync_bool_compare_and_swap(&this->_lock, false, true))
     {
-		ft_errno = SUCCES;
+                ft_errno = SUCCES;
         this->_thread_id = thread_id;
+        this->_lock_released = false;
         return (SUCCES);
     }
     return (PT_ALREADDY_LOCKED);


### PR DESCRIPTION
## Summary
- Reset mutex's release flag whenever a thread acquires the lock
- Ensure try_lock also clears the release indicator

## Testing
- `make -C Test`
- `./Test/libft_tests` (run -> exit)


------
https://chatgpt.com/codex/tasks/task_e_68aa2b1676808331b545d697c7129b13