### PR TITLE
Refactor synchronization and collections

### DIFF
--- a/Libft/ft_memchr.cpp
+++ b/Libft/ft_memchr.cpp
@@ -1,19 +1,45 @@
 #include "libft.hpp"
 #include "../CPP_class/nullptr.hpp"
+#include <cstdint>
 
 void* ft_memchr(const void* pointer, int number, size_t size)
 {
-    size_t index;
-    const unsigned char *string = static_cast<const unsigned char*>(pointer);
-    unsigned char character = static_cast<unsigned char>(number);
-
-    index = 0;
-    while (index < size)
+    if (!pointer)
+        return (ft_nullptr);
+    const unsigned char* p = static_cast<const unsigned char*>(pointer);
+    unsigned char c = static_cast<unsigned char>(number);
+    while (size && (reinterpret_cast<uintptr_t>(p) % sizeof(size_t)))
     {
-        if (*string == character)
-            return (const_cast<void*>(static_cast<const void*>(string)));
-        string++;
-        index++;
+        if (*p == c)
+            return (const_cast<unsigned char*>(p));
+        ++p;
+        --size;
+    }
+    const size_t ones = ~static_cast<size_t>(0) / 0xFF;
+    const size_t high_bits = ones * 0x80;
+    const size_t char_mask = ones * c;
+    const size_t* lp = reinterpret_cast<const size_t*>(p);
+    while (size >= sizeof(size_t))
+    {
+        size_t x = *lp ^ char_mask;
+        if (((x - ones) & ~x & high_bits) != 0)
+        {
+            p = reinterpret_cast<const unsigned char*>(lp);
+            for (size_t i = 0; i < sizeof(size_t); ++i)
+            {
+                if (p[i] == c)
+                    return (const_cast<unsigned char*>(p + i));
+            }
+        }
+        ++lp;
+        size -= sizeof(size_t);
+    }
+    p = reinterpret_cast<const unsigned char*>(lp);
+    while (size--)
+    {
+        if (*p == c)
+            return (const_cast<unsigned char*>(p));
+        ++p;
     }
     return (ft_nullptr);
 }

--- a/Libft/ft_memmove.cpp
+++ b/Libft/ft_memmove.cpp
@@ -1,33 +1,41 @@
 #include "libft.hpp"
 #include "../CPP_class/nullptr.hpp"
+#include <cstdint>
 
 void *ft_memmove(void *destination, const void *source, size_t size)
 {
-	unsigned char *dest_ptr = static_cast<unsigned char *>(destination);
-	const unsigned char *src_ptr = static_cast<const unsigned char *>(source);
-	size_t i;
-
-	if (size == 0 || destination == source)
-		return (destination);
-	if (!destination || !source)
-		return (ft_nullptr);
-	if (dest_ptr < src_ptr)
-	{
-		i = 0;
-		while (i < size)
-		{
-			dest_ptr[i] = src_ptr[i];
-			i++;
-		}
-	}
-	else
-	{
-		i = size;
-		while (i > 0)
-		{
-			dest_ptr[i - 1] = src_ptr[i - 1];
-			i--;
-		}
-	}
-	return (destination);
+    if (!destination || !source)
+        return (ft_nullptr);
+    unsigned char *dest_ptr = static_cast<unsigned char*>(destination);
+    const unsigned char *src_ptr = static_cast<const unsigned char*>(source);
+    if (dest_ptr == src_ptr || size == 0)
+        return (destination);
+    if (dest_ptr < src_ptr)
+    {
+        size_t i = 0;
+        while (i + sizeof(size_t) <= size)
+        {
+            *reinterpret_cast<size_t*>(dest_ptr + i) =
+                *reinterpret_cast<const size_t*>(src_ptr + i);
+            i += sizeof(size_t);
+        }
+        while (i < size)
+        {
+            dest_ptr[i] = src_ptr[i];
+            ++i;
+        }
+    }
+    else
+    {
+        size_t i = size;
+        while (i >= sizeof(size_t))
+        {
+            i -= sizeof(size_t);
+            *reinterpret_cast<size_t*>(dest_ptr + i) =
+                *reinterpret_cast<const size_t*>(src_ptr + i);
+        }
+        while (i-- > 0)
+            dest_ptr[i] = src_ptr[i];
+    }
+    return (destination);
 }

--- a/Libft/ft_strchr.cpp
+++ b/Libft/ft_strchr.cpp
@@ -1,24 +1,19 @@
 #include "libft.hpp"
 #include "../CPP_class/nullptr.hpp"
 
-char	*ft_strchr(const char *string, int char_to_find)
+char *ft_strchr(const char *string, int char_to_find)
 {
-	char	target_char;
-	char	*last_occurrence;
-
-	if (!string)
-		return (ft_nullptr);
     if (!string)
         return (ft_nullptr);
-    target_char = static_cast<char>(char_to_find);
-    last_occurrence = ft_nullptr;
-    while (*string)
-	{
-        if (*string == target_char)
-            last_occurrence = const_cast<char *>(string);
-        string++;
-	}
-    if (target_char == '\0')
-        return (const_cast<char *>(string));
-    return (last_occurrence);
+    const unsigned char *s = reinterpret_cast<const unsigned char*>(string);
+    unsigned char c = static_cast<unsigned char>(char_to_find);
+    while (*s)
+    {
+        if (*s == c)
+            return (reinterpret_cast<char*>(const_cast<unsigned char*>(s)));
+        ++s;
+    }
+    if (c == 0)
+        return (reinterpret_cast<char*>(const_cast<unsigned char*>(s)));
+    return (ft_nullptr);
 }

--- a/Libft/ft_strncmp.cpp
+++ b/Libft/ft_strncmp.cpp
@@ -1,23 +1,17 @@
 #include "libft.hpp"
-#include <unistd.h>
 
 int ft_strncmp(const char *string_1, const char *string_2, size_t max_len)
 {
-    unsigned int current_index = 0;
-
-    while (string_1[current_index] != '\0' &&
-           string_2[current_index] != '\0' &&
-           current_index < max_len)
+    if (!string_1 || !string_2)
+        return (string_1 ? 1 : (string_2 ? -1 : 0));
+    size_t i = 0;
+    while (i < max_len)
     {
-        unsigned char char1 = static_cast<unsigned char>(string_1[current_index]);
-        unsigned char char2 = static_cast<unsigned char>(string_2[current_index]);
-        if (char1 != char2)
-            return (char1 - char2);
-        current_index++;
+        unsigned char c1 = static_cast<unsigned char>(string_1[i]);
+        unsigned char c2 = static_cast<unsigned char>(string_2[i]);
+        if (c1 != c2 || c1 == '\0' || c2 == '\0')
+            return (c1 - c2);
+        ++i;
     }
-    if (current_index == max_len)
-        return (0);
-
-    return (static_cast<unsigned char>(string_1[current_index]) -
-           static_cast<unsigned char>(string_2[current_index]));
+    return (0);
 }

--- a/PThread/lock_mutex.cpp
+++ b/PThread/lock_mutex.cpp
@@ -1,73 +1,32 @@
 #include "PThread.hpp"
 #include "mutex.hpp"
 #include "../Errno/errno.hpp"
-#include "../Libft/libft.hpp"
-#include <unistd.h>
-#include <algorithm>
 
 #undef FAILURE
 #define FAILURE -1
+#undef SUCCES
+#define SUCCES 0
 
 int pt_mutex::lock(pthread_t thread_id)
 {
-    int			sleep_time = SLEEP_TIME;
-    const int	max_sleep = MAX_SLEEP;
-
-	if (this->_lock && this->_thread_id == thread_id)
-	{
-		ft_errno = PT_ERR_ALRDY_LOCKED;
-		this->set_error(PT_ERR_ALRDY_LOCKED);
-		return (FAILURE);
-	}
-	ft_errno = ER_SUCCESS;
-	this->set_error(ER_SUCCESS);
-    while (true)
+    (void)thread_id;
+    ft_errno = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
+    size_t spins = 0;
+    while (this->_flag.test_and_set(std::memory_order_acquire))
     {
-        if (this->_wait_queue_start == this->_wait_queue_end && !this->_lock)
+        if (++spins < 100)
         {
-            if (__sync_bool_compare_and_swap(&this->_lock, false, true))
-            {
-                this->_thread_id = thread_id;
-                this->_lock_released = false;
-                return (SUCCES);
-            }
+#if defined(__x86_64__) || defined(__i386) || defined(_M_X64) || defined(_M_IX86)
+            __asm__ __volatile__("pause");
+#endif
         }
-        bool already_waiting = false;
-        int start = this->_wait_queue_start;
-        int end = this->_wait_queue_end;
-        while (start != end)
+        else
         {
-            if (this->_wait_queue[start] == thread_id)
-            {
-                already_waiting = true;
-                break ;
-            }
-            start = (start + 1) % 128;
-        }
-        if (!already_waiting)
-        {
-            int next_end = (this->_wait_queue_end + 1) % 128;
-            if (next_end == this->_wait_queue_start)
-            {
-				ft_errno = PT_ERR_QUEUE_FULL;
-                this->set_error(PT_ERR_QUEUE_FULL);
-                return (FAILURE);
-            }
-            this->_wait_queue[this->_wait_queue_end] = thread_id;
-            this->_wait_queue_end = next_end;
-        }
-        usleep(sleep_time);
-        sleep_time = std::min(sleep_time * 2, max_sleep);
-        if (this->_lock_released && this->_wait_queue[this->_wait_queue_start] == thread_id)
-        {
-            int next_start = (this->_wait_queue_start + 1) % 128;
-            this->_wait_queue_start = next_start;
-            if (__sync_bool_compare_and_swap(&this->_lock, false, true))
-            {
-                this->_thread_id = thread_id;
-                this->_lock_released = false;
-                return (SUCCES);
-            }
+            pt_thread_yield();
+            spins = 0;
         }
     }
+    this->_lock = true;
+    return (SUCCES);
 }

--- a/PThread/mutex.cpp
+++ b/PThread/mutex.cpp
@@ -4,34 +4,23 @@
 
 pt_mutex::pt_mutex()
 {
-	int index = 0;
-
-	this->_lock = false;
-	this->_thread_id = 0;
-	while (index < MAX_QUEUE)
-	{
-		this->_wait_queue[index] = 0;
-		index++;
-	}
-	this->_wait_queue_start = 0;
-	this->_wait_queue_end = 0;
-	this->_lock_released = false;
-	return ;
+    this->_flag.clear();
+    this->_lock = false;
+    this->_error = ER_SUCCESS;
 }
 
 pt_mutex::~pt_mutex()
 {
-	return ;
+    return ;
 }
 
-void	pt_mutex::set_error(int	error)
+void    pt_mutex::set_error(int error)
 {
-	this->_error = error;
-	ft_errno = error;
-	return ;
+    this->_error = error;
+    ft_errno = error;
 }
 
-const volatile bool	&pt_mutex::lockState() const
+const volatile bool &pt_mutex::lockState() const
 {
     return (this->_lock);
 }

--- a/PThread/mutex.hpp
+++ b/PThread/mutex.hpp
@@ -2,35 +2,31 @@
 # define MUTEX_HPP
 
 #include "PThread.hpp"
-#include <pthread.h>
+#include <atomic>
 
 class pt_mutex
 {
-	private:
-		volatile bool		_lock;
-		volatile pthread_t	_thread_id;
-		pthread_t			_wait_queue[MAX_QUEUE];
-		int					_wait_queue_start;
-		int					_wait_queue_end;
-		int					_error;
-		volatile bool		_lock_released;
+private:
+        alignas(64) std::atomic_flag _flag;
+        volatile bool                _lock;
+        int                         _error;
 
-		void		set_error(int error);
+        void    set_error(int error);
 
-		pt_mutex(const pt_mutex&) = delete;
-		pt_mutex& operator=(const pt_mutex&) = delete;
-    	pt_mutex(pt_mutex&&) = delete;
-    	pt_mutex& operator=(pt_mutex&&) = delete;
+        pt_mutex(const pt_mutex&) = delete;
+        pt_mutex& operator=(const pt_mutex&) = delete;
+        pt_mutex(pt_mutex&&) = delete;
+        pt_mutex& operator=(pt_mutex&&) = delete;
 
-	public:
-		pt_mutex();
-		~pt_mutex();
+public:
+        pt_mutex();
+        ~pt_mutex();
 
-		const volatile bool	&lockState() const;
+        const volatile bool &lockState() const;
 
-		int			lock(pthread_t thread_id);
-		int			unlock(pthread_t thread_id);
-		int			try_lock(pthread_t thread_id);
+        int     lock(pthread_t thread_id);
+        int     unlock(pthread_t thread_id);
+        int     try_lock(pthread_t thread_id);
 };
 
 #endif

--- a/PThread/try_lock_mutex.cpp
+++ b/PThread/try_lock_mutex.cpp
@@ -6,19 +6,14 @@
 
 int pt_mutex::try_lock(pthread_t thread_id)
 {
+    (void)thread_id;
     this->set_error(ER_SUCCESS);
-	if (this->_lock && this->_thread_id == thread_id)
-	{
-		ft_errno = PT_ERR_ALRDY_LOCKED;
-		this->set_error(PT_ERR_ALRDY_LOCKED);
-		return (FAILURE);
-	}
-    if (__sync_bool_compare_and_swap(&this->_lock, false, true))
+    if (this->_flag.test_and_set(std::memory_order_acquire))
     {
-                ft_errno = SUCCES;
-        this->_thread_id = thread_id;
-        this->_lock_released = false;
-        return (SUCCES);
+        this->set_error(PT_ALREADDY_LOCKED);
+        ft_errno = PT_ALREADDY_LOCKED;
+        return (PT_ALREADDY_LOCKED);
     }
-    return (PT_ALREADDY_LOCKED);
+    this->_lock = true;
+    return (SUCCES);
 }

--- a/PThread/unlock_mutex.cpp
+++ b/PThread/unlock_mutex.cpp
@@ -5,15 +5,9 @@ thread_local int ft_errno = 0;
 
 int pt_mutex::unlock(pthread_t thread_id)
 {
+    (void)thread_id;
     this->set_error(ER_SUCCESS);
-    if (this->_thread_id != thread_id)
-    {
-		ft_errno = PT_ERR_MUTEX_OWNER;
-        this->set_error(PT_ERR_MUTEX_OWNER);
-        return (-1);
-    }
-    this->_thread_id = 0;
+    this->_flag.clear(std::memory_order_release);
     this->_lock = false;
-    this->_lock_released = true;
-    return (0); 
+    return (0);
 }


### PR DESCRIPTION
## Summary
- Add a lightweight spin-based `pt_mutex` using an `atomic_flag` with adaptive yielding
- Implement custom `ft_memchr`, `ft_memmove`, `ft_strchr`, and `ft_strncmp` without delegating to the C standard library

## Testing
- `make -C Test OPT_LEVEL=0`
- ⚠️ `./Test/libft_tests` (interactive prompt)


------
https://chatgpt.com/codex/tasks/task_e_68aa2f28bc3883319d6ddc23ab742994