### PR TITLE
refactor: replace mutex with ticket algorithm

### DIFF
--- a/PThread/mutex.cpp
+++ b/PThread/mutex.cpp
@@ -3,35 +3,25 @@
 #include "../Errno/errno.hpp"
 
 pt_mutex::pt_mutex()
+    : _next(0), _serving(0), _owner(0), _lock(false), _error(ER_SUCCESS)
 {
-	int index = 0;
-
-	this->_lock = false;
-	this->_thread_id = 0;
-	while (index < MAX_QUEUE)
-	{
-		this->_wait_queue[index] = 0;
-		index++;
-	}
-	this->_wait_queue_start = 0;
-	this->_wait_queue_end = 0;
-	this->_lock_released = false;
-	return ;
+    return ;
 }
 
 pt_mutex::~pt_mutex()
 {
-	return ;
+    return ;
 }
 
-void	pt_mutex::set_error(int	error)
+void    pt_mutex::set_error(int error)
 {
-	this->_error = error;
-	ft_errno = error;
-	return ;
+    _error = error;
+    ft_errno = error;
+    return ;
 }
 
-const volatile bool	&pt_mutex::lockState() const
+const volatile bool &pt_mutex::lockState() const
 {
-    return (this->_lock);
+    return (_lock);
 }
+

--- a/PThread/mutex.hpp
+++ b/PThread/mutex.hpp
@@ -3,34 +3,34 @@
 
 #include "PThread.hpp"
 #include <pthread.h>
+#include <atomic>
 
 class pt_mutex
 {
-	private:
-		volatile bool		_lock;
-		volatile pthread_t	_thread_id;
-		pthread_t			_wait_queue[MAX_QUEUE];
-		int					_wait_queue_start;
-		int					_wait_queue_end;
-		int					_error;
-		volatile bool		_lock_released;
+    private:
+        std::atomic<uint32_t>   _next;
+        std::atomic<uint32_t>   _serving;
+        std::atomic<pthread_t>  _owner;
+        volatile bool           _lock;
+        int                     _error;
 
-		void		set_error(int error);
+        void    set_error(int error);
 
-		pt_mutex(const pt_mutex&) = delete;
-		pt_mutex& operator=(const pt_mutex&) = delete;
-    	pt_mutex(pt_mutex&&) = delete;
-    	pt_mutex& operator=(pt_mutex&&) = delete;
+        pt_mutex(const pt_mutex&) = delete;
+        pt_mutex& operator=(const pt_mutex&) = delete;
+        pt_mutex(pt_mutex&&) = delete;
+        pt_mutex& operator=(pt_mutex&&) = delete;
 
-	public:
-		pt_mutex();
-		~pt_mutex();
+    public:
+        pt_mutex();
+        ~pt_mutex();
 
-		const volatile bool	&lockState() const;
+        const volatile bool &lockState() const;
 
-		int			lock(pthread_t thread_id);
-		int			unlock(pthread_t thread_id);
-		int			try_lock(pthread_t thread_id);
+        int     lock(pthread_t thread_id);
+        int     unlock(pthread_t thread_id);
+        int     try_lock(pthread_t thread_id);
 };
 
 #endif
+

--- a/PThread/unlock_mutex.cpp
+++ b/PThread/unlock_mutex.cpp
@@ -1,19 +1,21 @@
 #include "mutex.hpp"
 #include "../Errno/errno.hpp"
+#include "../Libft/libft.hpp"
 
 thread_local int ft_errno = 0;
 
 int pt_mutex::unlock(pthread_t thread_id)
 {
-    this->set_error(ER_SUCCESS);
-    if (this->_thread_id != thread_id)
+    set_error(ER_SUCCESS);
+    if (_owner.load(std::memory_order_relaxed) != thread_id)
     {
-		ft_errno = PT_ERR_MUTEX_OWNER;
-        this->set_error(PT_ERR_MUTEX_OWNER);
+        ft_errno = PT_ERR_MUTEX_OWNER;
+        set_error(PT_ERR_MUTEX_OWNER);
         return (-1);
     }
-    this->_thread_id = 0;
-    this->_lock = false;
-    this->_lock_released = true;
-    return (0); 
+    _owner.store(0, std::memory_order_relaxed);
+    _lock = false;
+    _serving.fetch_add(1, std::memory_order_release);
+    return (SUCCES);
 }
+


### PR DESCRIPTION
## Summary
- refactor `pt_mutex` to use a ticket-based locking scheme with atomics
- add adaptive spinning with `pt_thread_yield` for heavy contention
- streamline unlock and try-lock paths using atomic counters
- normalize return statement style with parenthesized values and spaced void returns

## Testing
- `make -C PThread`


------
https://chatgpt.com/codex/tasks/task_e_68ab77dadf2c8331bfe375ac8a8b8a34