### PR TITLE
Fix tabs in Libft Makefiles

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -77,22 +77,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -103,10 +103,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Makefile
+++ b/Makefile
@@ -91,93 +91,93 @@ cd temp_objs && $(AR) x ../$1 && cd ..
 endef
 
 $(TARGET): $(LIBS)
-    @echo "Linking libraries into $(TARGET)..."
-    $(RM) $@
-    $(MKDIR) temp_objs
-    $(call EXTRACT,CMA/CustomMemoryAllocator.a)
-    $(call EXTRACT,GetNextLine/GetNextLine.a)
-    $(call EXTRACT,Libft/LibFT.a)
-    $(call EXTRACT,Printf/Printf.a)
-    $(call EXTRACT,ReadLine/ReadLine.a)
-    $(call EXTRACT,PThread/PThread.a)
-    $(call EXTRACT,CPP_class/CPP_class.a)
-    $(call EXTRACT,Errno/errno.a)
-    $(call EXTRACT,Networking/networking.a)
-    $(OS_EXTRACT)
-    $(call EXTRACT,encryption/encryption.a)
-    $(call EXTRACT,RNG/RNG.a)
-    $(call EXTRACT,JSon/JSon.a)
-    $(call EXTRACT,file/file.a)
-    $(call EXTRACT,HTML/HTMLParser.a)
-    $(call EXTRACT,Game/Game.a)
-    $(AR) $(ARFLAGS) $@ temp_objs/*.o
-    $(RMDIR) temp_objs
+	@echo "Linking libraries into $(TARGET)..."
+	$(RM) $@
+	$(MKDIR) temp_objs
+	$(call EXTRACT,CMA/CustomMemoryAllocator.a)
+	$(call EXTRACT,GetNextLine/GetNextLine.a)
+	$(call EXTRACT,Libft/LibFT.a)
+	$(call EXTRACT,Printf/Printf.a)
+	$(call EXTRACT,ReadLine/ReadLine.a)
+	$(call EXTRACT,PThread/PThread.a)
+	$(call EXTRACT,CPP_class/CPP_class.a)
+	$(call EXTRACT,Errno/errno.a)
+	$(call EXTRACT,Networking/networking.a)
+	$(OS_EXTRACT)
+	$(call EXTRACT,encryption/encryption.a)
+	$(call EXTRACT,RNG/RNG.a)
+	$(call EXTRACT,JSon/JSon.a)
+	$(call EXTRACT,file/file.a)
+	$(call EXTRACT,HTML/HTMLParser.a)
+	$(call EXTRACT,Game/Game.a)
+	$(AR) $(ARFLAGS) $@ temp_objs/*.o
+	$(RMDIR) temp_objs
 
 $(DEBUG_TARGET): $(DEBUG_LIBS)
-    @echo "Linking libraries into $(DEBUG_TARGET)..."
-    $(RM) $@
-    $(MKDIR) temp_objs
-    $(call EXTRACT,CMA/CustomMemoryAllocator_debug.a)
-    $(call EXTRACT,GetNextLine/GetNextLine_debug.a)
-    $(call EXTRACT,Libft/LibFT_debug.a)
-    $(call EXTRACT,Printf/Printf_debug.a)
-    $(call EXTRACT,ReadLine/ReadLine_debug.a)
-    $(call EXTRACT,PThread/PThread_debug.a)
-    $(call EXTRACT,CPP_class/CPP_class_debug.a)
-    $(call EXTRACT,Errno/errno_debug.a)
-    $(call EXTRACT,Networking/networking_debug.a)
-    $(DEBUG_OS_EXTRACT)
-    $(call EXTRACT,encryption/encryption_debug.a)
-    $(call EXTRACT,RNG/RNG_debug.a)
-    $(call EXTRACT,JSon/JSon_debug.a)
-    $(call EXTRACT,file/file_debug.a)
-    $(call EXTRACT,HTML/HTMLParser_debug.a)
-    $(call EXTRACT,Game/Game_debug.a)
-    $(AR) $(ARFLAGS) $@ temp_objs/*.o
-    $(RMDIR) temp_objs
+	@echo "Linking libraries into $(DEBUG_TARGET)..."
+	$(RM) $@
+	$(MKDIR) temp_objs
+	$(call EXTRACT,CMA/CustomMemoryAllocator_debug.a)
+	$(call EXTRACT,GetNextLine/GetNextLine_debug.a)
+	$(call EXTRACT,Libft/LibFT_debug.a)
+	$(call EXTRACT,Printf/Printf_debug.a)
+	$(call EXTRACT,ReadLine/ReadLine_debug.a)
+	$(call EXTRACT,PThread/PThread_debug.a)
+	$(call EXTRACT,CPP_class/CPP_class_debug.a)
+	$(call EXTRACT,Errno/errno_debug.a)
+	$(call EXTRACT,Networking/networking_debug.a)
+	$(DEBUG_OS_EXTRACT)
+	$(call EXTRACT,encryption/encryption_debug.a)
+	$(call EXTRACT,RNG/RNG_debug.a)
+	$(call EXTRACT,JSon/JSon_debug.a)
+	$(call EXTRACT,file/file_debug.a)
+	$(call EXTRACT,HTML/HTMLParser_debug.a)
+	$(call EXTRACT,Game/Game_debug.a)
+	$(AR) $(ARFLAGS) $@ temp_objs/*.o
+	$(RMDIR) temp_objs
 
 %.a:
-    $(MAKE) -C $(dir $@)
+	$(MAKE) -C $(dir $@)
 
 %_debug.a:
-    $(MAKE) -C $(dir $@) debug
+	$(MAKE) -C $(dir $@) debug
 
 clean:
-    $(MAKE) -C CMA clean
-    $(MAKE) -C GetNextLine clean
-    $(MAKE) -C Libft clean
-    $(MAKE) -C Printf clean
-    $(MAKE) -C ReadLine clean
-    $(MAKE) -C PThread clean
-    $(MAKE) -C CPP_class clean
-    $(MAKE) -C Errno clean
-    $(MAKE) -C Networking clean
-    $(OS_CLEAN)
-    $(MAKE) -C encryption clean
-    $(MAKE) -C RNG clean
-    $(MAKE) -C JSon clean
-    $(MAKE) -C file clean
-    $(MAKE) -C HTML clean
-    $(MAKE) -C Game clean
-    $(RM) $(TARGET) $(DEBUG_TARGET)
+	$(MAKE) -C CMA clean
+	$(MAKE) -C GetNextLine clean
+	$(MAKE) -C Libft clean
+	$(MAKE) -C Printf clean
+	$(MAKE) -C ReadLine clean
+	$(MAKE) -C PThread clean
+	$(MAKE) -C CPP_class clean
+	$(MAKE) -C Errno clean
+	$(MAKE) -C Networking clean
+	$(OS_CLEAN)
+	$(MAKE) -C encryption clean
+	$(MAKE) -C RNG clean
+	$(MAKE) -C JSon clean
+	$(MAKE) -C file clean
+	$(MAKE) -C HTML clean
+	$(MAKE) -C Game clean
+	$(RM) $(TARGET) $(DEBUG_TARGET)
 
 fclean: clean
-    $(MAKE) -C CMA fclean
-    $(MAKE) -C GetNextLine fclean
-    $(MAKE) -C Libft fclean
-    $(MAKE) -C Printf fclean
-    $(MAKE) -C ReadLine fclean
-    $(MAKE) -C PThread fclean
-    $(MAKE) -C CPP_class fclean
-    $(MAKE) -C Errno fclean
-    $(MAKE) -C Networking fclean
-    $(OS_FCLEAN)
-    $(MAKE) -C encryption fclean
-    $(MAKE) -C RNG fclean
-    $(MAKE) -C JSon fclean
-    $(MAKE) -C file fclean
-    $(MAKE) -C HTML fclean
-    $(MAKE) -C Game fclean
-    $(RM) $(TARGET) $(DEBUG_TARGET)
+	$(MAKE) -C CMA fclean
+	$(MAKE) -C GetNextLine fclean
+	$(MAKE) -C Libft fclean
+	$(MAKE) -C Printf fclean
+	$(MAKE) -C ReadLine fclean
+	$(MAKE) -C PThread fclean
+	$(MAKE) -C CPP_class fclean
+	$(MAKE) -C Errno fclean
+	$(MAKE) -C Networking fclean
+	$(OS_FCLEAN)
+	$(MAKE) -C encryption fclean
+	$(MAKE) -C RNG fclean
+	$(MAKE) -C JSon fclean
+	$(MAKE) -C file fclean
+	$(MAKE) -C HTML fclean
+	$(MAKE) -C Game fclean
+	$(RM) $(TARGET) $(DEBUG_TARGET)
     
 .PHONY: all debug both re clean fclean


### PR DESCRIPTION
## Summary
- Replace spaces with tabs in root Makefile recipes
- Use proper tab prefixes for Libft library build, clean, and helper rules

## Testing
- `make -n` *(fails: Makefile:53: missing separator in CMA/Makefile)*
- `cd Libft && make -n`

------
https://chatgpt.com/codex/tasks/task_e_68add9e94c6c8331b1adb8412476ee6b