### PR TITLE
Fix tabs in Libft Makefiles

### DIFF
--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -50,22 +50,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -76,10 +76,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/CPP_class/Makefile
+++ b/CPP_class/Makefile
@@ -39,22 +39,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -65,10 +65,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Errno/Makefile
+++ b/Errno/Makefile
@@ -34,22 +34,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -60,10 +60,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Game/Makefile
+++ b/Game/Makefile
@@ -36,22 +36,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -62,10 +62,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/GetNextLine/Makefile
+++ b/GetNextLine/Makefile
@@ -33,22 +33,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -59,10 +59,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/HTML/Makefile
+++ b/HTML/Makefile
@@ -32,22 +32,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -58,10 +58,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/JSon/Makefile
+++ b/JSon/Makefile
@@ -35,22 +35,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -61,10 +61,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -77,22 +77,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -103,10 +103,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -39,22 +39,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -65,10 +65,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Logger/Makefile
+++ b/Logger/Makefile
@@ -32,22 +32,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -58,10 +58,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Makefile
+++ b/Makefile
@@ -91,93 +91,93 @@ cd temp_objs && $(AR) x ../$1 && cd ..
 endef
 
 $(TARGET): $(LIBS)
-    @echo "Linking libraries into $(TARGET)..."
-    $(RM) $@
-    $(MKDIR) temp_objs
-    $(call EXTRACT,CMA/CustomMemoryAllocator.a)
-    $(call EXTRACT,GetNextLine/GetNextLine.a)
-    $(call EXTRACT,Libft/LibFT.a)
-    $(call EXTRACT,Printf/Printf.a)
-    $(call EXTRACT,ReadLine/ReadLine.a)
-    $(call EXTRACT,PThread/PThread.a)
-    $(call EXTRACT,CPP_class/CPP_class.a)
-    $(call EXTRACT,Errno/errno.a)
-    $(call EXTRACT,Networking/networking.a)
-    $(OS_EXTRACT)
-    $(call EXTRACT,encryption/encryption.a)
-    $(call EXTRACT,RNG/RNG.a)
-    $(call EXTRACT,JSon/JSon.a)
-    $(call EXTRACT,file/file.a)
-    $(call EXTRACT,HTML/HTMLParser.a)
-    $(call EXTRACT,Game/Game.a)
-    $(AR) $(ARFLAGS) $@ temp_objs/*.o
-    $(RMDIR) temp_objs
+	@echo "Linking libraries into $(TARGET)..."
+	$(RM) $@
+	$(MKDIR) temp_objs
+	$(call EXTRACT,CMA/CustomMemoryAllocator.a)
+	$(call EXTRACT,GetNextLine/GetNextLine.a)
+	$(call EXTRACT,Libft/LibFT.a)
+	$(call EXTRACT,Printf/Printf.a)
+	$(call EXTRACT,ReadLine/ReadLine.a)
+	$(call EXTRACT,PThread/PThread.a)
+	$(call EXTRACT,CPP_class/CPP_class.a)
+	$(call EXTRACT,Errno/errno.a)
+	$(call EXTRACT,Networking/networking.a)
+	$(OS_EXTRACT)
+	$(call EXTRACT,encryption/encryption.a)
+	$(call EXTRACT,RNG/RNG.a)
+	$(call EXTRACT,JSon/JSon.a)
+	$(call EXTRACT,file/file.a)
+	$(call EXTRACT,HTML/HTMLParser.a)
+	$(call EXTRACT,Game/Game.a)
+	$(AR) $(ARFLAGS) $@ temp_objs/*.o
+	$(RMDIR) temp_objs
 
 $(DEBUG_TARGET): $(DEBUG_LIBS)
-    @echo "Linking libraries into $(DEBUG_TARGET)..."
-    $(RM) $@
-    $(MKDIR) temp_objs
-    $(call EXTRACT,CMA/CustomMemoryAllocator_debug.a)
-    $(call EXTRACT,GetNextLine/GetNextLine_debug.a)
-    $(call EXTRACT,Libft/LibFT_debug.a)
-    $(call EXTRACT,Printf/Printf_debug.a)
-    $(call EXTRACT,ReadLine/ReadLine_debug.a)
-    $(call EXTRACT,PThread/PThread_debug.a)
-    $(call EXTRACT,CPP_class/CPP_class_debug.a)
-    $(call EXTRACT,Errno/errno_debug.a)
-    $(call EXTRACT,Networking/networking_debug.a)
-    $(DEBUG_OS_EXTRACT)
-    $(call EXTRACT,encryption/encryption_debug.a)
-    $(call EXTRACT,RNG/RNG_debug.a)
-    $(call EXTRACT,JSon/JSon_debug.a)
-    $(call EXTRACT,file/file_debug.a)
-    $(call EXTRACT,HTML/HTMLParser_debug.a)
-    $(call EXTRACT,Game/Game_debug.a)
-    $(AR) $(ARFLAGS) $@ temp_objs/*.o
-    $(RMDIR) temp_objs
+	@echo "Linking libraries into $(DEBUG_TARGET)..."
+	$(RM) $@
+	$(MKDIR) temp_objs
+	$(call EXTRACT,CMA/CustomMemoryAllocator_debug.a)
+	$(call EXTRACT,GetNextLine/GetNextLine_debug.a)
+	$(call EXTRACT,Libft/LibFT_debug.a)
+	$(call EXTRACT,Printf/Printf_debug.a)
+	$(call EXTRACT,ReadLine/ReadLine_debug.a)
+	$(call EXTRACT,PThread/PThread_debug.a)
+	$(call EXTRACT,CPP_class/CPP_class_debug.a)
+	$(call EXTRACT,Errno/errno_debug.a)
+	$(call EXTRACT,Networking/networking_debug.a)
+	$(DEBUG_OS_EXTRACT)
+	$(call EXTRACT,encryption/encryption_debug.a)
+	$(call EXTRACT,RNG/RNG_debug.a)
+	$(call EXTRACT,JSon/JSon_debug.a)
+	$(call EXTRACT,file/file_debug.a)
+	$(call EXTRACT,HTML/HTMLParser_debug.a)
+	$(call EXTRACT,Game/Game_debug.a)
+	$(AR) $(ARFLAGS) $@ temp_objs/*.o
+	$(RMDIR) temp_objs
 
 %.a:
-    $(MAKE) -C $(dir $@)
+	$(MAKE) -C $(dir $@)
 
 %_debug.a:
-    $(MAKE) -C $(dir $@) debug
+	$(MAKE) -C $(dir $@) debug
 
 clean:
-    $(MAKE) -C CMA clean
-    $(MAKE) -C GetNextLine clean
-    $(MAKE) -C Libft clean
-    $(MAKE) -C Printf clean
-    $(MAKE) -C ReadLine clean
-    $(MAKE) -C PThread clean
-    $(MAKE) -C CPP_class clean
-    $(MAKE) -C Errno clean
-    $(MAKE) -C Networking clean
-    $(OS_CLEAN)
-    $(MAKE) -C encryption clean
-    $(MAKE) -C RNG clean
-    $(MAKE) -C JSon clean
-    $(MAKE) -C file clean
-    $(MAKE) -C HTML clean
-    $(MAKE) -C Game clean
-    $(RM) $(TARGET) $(DEBUG_TARGET)
+	$(MAKE) -C CMA clean
+	$(MAKE) -C GetNextLine clean
+	$(MAKE) -C Libft clean
+	$(MAKE) -C Printf clean
+	$(MAKE) -C ReadLine clean
+	$(MAKE) -C PThread clean
+	$(MAKE) -C CPP_class clean
+	$(MAKE) -C Errno clean
+	$(MAKE) -C Networking clean
+	$(OS_CLEAN)
+	$(MAKE) -C encryption clean
+	$(MAKE) -C RNG clean
+	$(MAKE) -C JSon clean
+	$(MAKE) -C file clean
+	$(MAKE) -C HTML clean
+	$(MAKE) -C Game clean
+	$(RM) $(TARGET) $(DEBUG_TARGET)
 
 fclean: clean
-    $(MAKE) -C CMA fclean
-    $(MAKE) -C GetNextLine fclean
-    $(MAKE) -C Libft fclean
-    $(MAKE) -C Printf fclean
-    $(MAKE) -C ReadLine fclean
-    $(MAKE) -C PThread fclean
-    $(MAKE) -C CPP_class fclean
-    $(MAKE) -C Errno fclean
-    $(MAKE) -C Networking fclean
-    $(OS_FCLEAN)
-    $(MAKE) -C encryption fclean
-    $(MAKE) -C RNG fclean
-    $(MAKE) -C JSon fclean
-    $(MAKE) -C file fclean
-    $(MAKE) -C HTML fclean
-    $(MAKE) -C Game fclean
-    $(RM) $(TARGET) $(DEBUG_TARGET)
+	$(MAKE) -C CMA fclean
+	$(MAKE) -C GetNextLine fclean
+	$(MAKE) -C Libft fclean
+	$(MAKE) -C Printf fclean
+	$(MAKE) -C ReadLine fclean
+	$(MAKE) -C PThread fclean
+	$(MAKE) -C CPP_class fclean
+	$(MAKE) -C Errno fclean
+	$(MAKE) -C Networking fclean
+	$(OS_FCLEAN)
+	$(MAKE) -C encryption fclean
+	$(MAKE) -C RNG fclean
+	$(MAKE) -C JSon fclean
+	$(MAKE) -C file fclean
+	$(MAKE) -C HTML fclean
+	$(MAKE) -C Game fclean
+	$(RM) $(TARGET) $(DEBUG_TARGET)
     
 .PHONY: all debug both re clean fclean

--- a/Networking/Makefile
+++ b/Networking/Makefile
@@ -37,22 +37,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -63,10 +63,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/PThread/Makefile
+++ b/PThread/Makefile
@@ -43,22 +43,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -69,10 +69,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Printf/Makefile
+++ b/Printf/Makefile
@@ -36,22 +36,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -62,10 +62,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -32,22 +32,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -58,10 +58,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/ReadLine/Makefile
+++ b/ReadLine/Makefile
@@ -42,22 +42,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -68,10 +68,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -43,16 +43,16 @@ ifeq ($(OPT_LEVEL),0)
 OPT_FLAGS = -O0 -g
 else ifeq ($(OPT_LEVEL),1)
 OPT_FLAGS = -O1 -flto -s -ffunction-sections -fdata-sections -Wl,--gc-sections \
-            -fno-builtin -fno-builtin-memcpy -fno-builtin-memmove -fno-builtin-memset \
-            -fno-builtin-strlen -fno-builtin-strcmp -fno-builtin-isdigit
+	-fno-builtin -fno-builtin-memcpy -fno-builtin-memmove -fno-builtin-memset \
+	-fno-builtin-strlen -fno-builtin-strcmp -fno-builtin-isdigit
 else ifeq ($(OPT_LEVEL),2)
 OPT_FLAGS = -O2 -flto -s -ffunction-sections -fdata-sections -Wl,--gc-sections \
-            -fno-builtin -fno-builtin-memcpy -fno-builtin-memmove -fno-builtin-memset \
-            -fno-builtin-strlen -fno-builtin-strcmp -fno-builtin-isdigit
+	-fno-builtin -fno-builtin-memcpy -fno-builtin-memmove -fno-builtin-memset \
+	-fno-builtin-strlen -fno-builtin-strcmp -fno-builtin-isdigit
 else ifeq ($(OPT_LEVEL),3)
 OPT_FLAGS = -O3 -flto -s -ffunction-sections -fdata-sections -Wl,--gc-sections \
-            -fno-builtin -fno-builtin-memcpy -fno-builtin-memmove -fno-builtin-memset \
-            -fno-builtin-strlen -fno-builtin-strcmp -fno-builtin-isdigit
+	-fno-builtin -fno-builtin-memcpy -fno-builtin-memmove -fno-builtin-memset \
+	-fno-builtin-strlen -fno-builtin-strcmp -fno-builtin-isdigit
 else
 $(error Unsupported OPT_LEVEL=$(OPT_LEVEL))
 endif
@@ -73,27 +73,27 @@ DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
 all: $(TARGET)
 
 $(TARGET): $(OBJS) ../Full_Libft.a
-    $(CXX) $(CFLAGS) -o $@ $^
+	$(CXX) $(CFLAGS) -o $@ $^
 
 $(OBJDIR)/%.o: %.cpp
-    $(MKDIR) $(dir $@)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(MKDIR) $(dir $@)
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS) ../Full_Libft_debug.a
-    $(CXX) $(CFLAGS) -o $@ $^
+	$(CXX) $(CFLAGS) -o $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp
-    $(MKDIR) $(dir $@)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(MKDIR) $(dir $@)
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 ../Full_Libft.a:
-    $(MAKE) -C .. COMPILE_FLAGS="$(COMPILE_FLAGS)"
+	$(MAKE) -C .. COMPILE_FLAGS="$(COMPILE_FLAGS)"
 
 ../Full_Libft_debug.a:
-    $(MAKE) -C .. debug COMPILE_FLAGS="$(COMPILE_FLAGS)"
+	$(MAKE) -C .. debug COMPILE_FLAGS="$(COMPILE_FLAGS)"
 
 CLEAN_OBJS := $(shell find $(OBJDIR) $(DEBUG_OBJDIR) -type f -name '*.o' 2>/dev/null)
 
@@ -104,13 +104,13 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
-    $(MAKE) -C .. clean COMPILE_FLAGS="$(COMPILE_FLAGS)"
+	-$(RM) $(CLEAN_FILES)
+	$(MAKE) -C .. clean COMPILE_FLAGS="$(COMPILE_FLAGS)"
 
 fclean:
-    -$(RM) $(CLEAN_FILES)
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
-    $(MAKE) -C .. fclean COMPILE_FLAGS="$(COMPILE_FLAGS)"
+	-$(RM) $(CLEAN_FILES)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+	$(MAKE) -C .. fclean COMPILE_FLAGS="$(COMPILE_FLAGS)"
 
 re: fclean all
 

--- a/Windows/Makefile
+++ b/Windows/Makefile
@@ -32,22 +32,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -58,10 +58,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/encryption/Makefile
+++ b/encryption/Makefile
@@ -33,22 +33,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -59,10 +59,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 

--- a/file/Makefile
+++ b/file/Makefile
@@ -34,22 +34,22 @@ CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS)
-    $(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 $(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
-    $(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR) $(DEBUG_OBJDIR):
-    $(MKDIR) $@
+	$(MKDIR) $@
 
 CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
 
@@ -60,10 +60,10 @@ else
 endif
 
 clean:
-    -$(RM) $(CLEAN_FILES)
+	-$(RM) $(CLEAN_FILES)
 
 fclean: clean
-    -$(RM) $(TARGET) $(DEBUG_TARGET)
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
 
 re: fclean all
 


### PR DESCRIPTION
## Summary
- Replace space-indented command lines with tabs across all submodule Makefiles

## Testing
- `make -n`
- `cd Libft && make -n`


------
https://chatgpt.com/codex/tasks/task_e_68add9e94c6c8331b1adb8412476ee6b