### PR TITLE
Add API wrapper module using custom JSON

### DIFF
--- a/API/Makefile
+++ b/API/Makefile
@@ -1,0 +1,70 @@
+TARGET         := API.a
+DEBUG_TARGET   := API_debug.a
+
+SRCS := api_wrapper.cpp
+
+HEADERS := api_wrapper.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
+clean:
+	-$(RM) $(CLEAN_FILES)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/API/api_wrapper.hpp
+++ b/API/api_wrapper.hpp
@@ -1,0 +1,12 @@
+#ifndef API_WRAPPER_HPP
+#define API_WRAPPER_HPP
+
+#include "../JSon/json.hpp"
+#include <cstdint>
+
+json_group *api_request_json(const char *ip, uint16_t port,
+                             const char *method, const char *path,
+                             json_group *payload);
+json_group *api_get_json(const char *ip, uint16_t port, const char *path);
+
+#endif

--- a/API/compile_commands.json
+++ b/API/compile_commands.json
@@ -1,0 +1,20 @@
+[
+  {
+    "arguments": [
+      "/usr/bin/g++",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g",
+      "-O0",
+      "-std=c++17",
+      "-c",
+      "-o",
+      "objs/api_wrapper.o",
+      "api_wrapper.cpp"
+    ],
+    "directory": "/workspace/Libft/API",
+    "file": "/workspace/Libft/API/api_wrapper.cpp",
+    "output": "/workspace/Libft/API/objs/api_wrapper.o"
+  }
+]

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ SUBDIRS :=  CMA \
             PThread \
             CPP_class \
             Errno \
-            Networking
+            Networking \
+            API
 
 ifeq ($(OS),Windows_NT)
 SUBDIRS += Windows
@@ -29,12 +30,7 @@ else
 SUBDIRS += Linux
 endif
 
-SUBDIRS += encryption \
-            RNG \
-            JSon \
-            file \
-            HTML \
-            Game
+SUBDIRS += encryption RNG JSon file HTML Game
 
 LIB_BASES := \
   CMA/CustomMemoryAllocator \
@@ -45,7 +41,8 @@ LIB_BASES := \
   PThread/PThread \
   CPP_class/CPP_class \
   Errno/errno \
-  Networking/networking
+    Networking/networking \
+    API/API
 
 ifeq ($(OS),Windows_NT)
 LIB_BASES += Windows/Windows
@@ -103,6 +100,7 @@ $(TARGET): $(LIBS)
 	$(call EXTRACT,CPP_class/CPP_class.a)
 	$(call EXTRACT,Errno/errno.a)
 	$(call EXTRACT,Networking/networking.a)
+	$(call EXTRACT,API/API.a)
 	$(OS_EXTRACT)
 	$(call EXTRACT,encryption/encryption.a)
 	$(call EXTRACT,RNG/RNG.a)
@@ -126,6 +124,7 @@ $(DEBUG_TARGET): $(DEBUG_LIBS)
 	$(call EXTRACT,CPP_class/CPP_class_debug.a)
 	$(call EXTRACT,Errno/errno_debug.a)
 	$(call EXTRACT,Networking/networking_debug.a)
+	$(call EXTRACT,API/API_debug.a)
 	$(DEBUG_OS_EXTRACT)
 	$(call EXTRACT,encryption/encryption_debug.a)
 	$(call EXTRACT,RNG/RNG_debug.a)
@@ -152,6 +151,7 @@ clean:
 	$(MAKE) -C CPP_class clean
 	$(MAKE) -C Errno clean
 	$(MAKE) -C Networking clean
+	$(MAKE) -C API clean
 	$(OS_CLEAN)
 	$(MAKE) -C encryption clean
 	$(MAKE) -C RNG clean
@@ -171,6 +171,7 @@ fclean: clean
 	$(MAKE) -C CPP_class fclean
 	$(MAKE) -C Errno fclean
 	$(MAKE) -C Networking fclean
+	$(MAKE) -C API fclean
 	$(OS_FCLEAN)
 	$(MAKE) -C encryption fclean
 	$(MAKE) -C RNG fclean


### PR DESCRIPTION
## Summary
- Introduce flexible `api_request_json` to perform HTTP requests with optional JSON payload and parse responses
- Expose simplified `api_get_json` helper for GET requests

## Testing
- `make API/API.a`
- `make Full_Libft.a`


------
https://chatgpt.com/codex/tasks/task_e_68ade333997c8331a4aee9ff613e1048