### PR TITLE
feat(api): expose response status

### DIFF
--- a/API/Makefile
+++ b/API/Makefile
@@ -1,9 +1,9 @@
 TARGET         := API.a
 DEBUG_TARGET   := API_debug.a
 
-SRCS := api_request.cpp
+SRCS := api_request.cpp api_promise.cpp
 
-HEADERS := api.hpp
+HEADERS := api.hpp api_promise.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/API/api.hpp
+++ b/API/api.hpp
@@ -3,8 +3,10 @@
 
 #include "../JSon/json.hpp"
 #include <cstdint>
+#include <cstddef>
 
 json_group *api_request_json(const char *ip, uint16_t port,
-        const char *method, const char *path, json_group *payload);
+        const char *method, const char *path, json_group *payload = NULL,
+        const char *headers = NULL, int *status = NULL);
 
 #endif

--- a/API/api_promise.cpp
+++ b/API/api_promise.cpp
@@ -1,0 +1,14 @@
+#include "api_promise.hpp"
+
+bool api_promise::request(const char *ip, uint16_t port,
+                          const char *method, const char *path,
+                          json_group *payload,
+                          const char *headers, int *status)
+{
+    json_group *resp = api_request_json(ip, port, method, path, payload,
+                                        headers, status);
+    if (!resp)
+        return (false);
+    set_value(resp);
+    return (true);
+}

--- a/API/api_promise.hpp
+++ b/API/api_promise.hpp
@@ -1,0 +1,16 @@
+#ifndef API_PROMISE_HPP
+#define API_PROMISE_HPP
+
+#include "../Template/promise.hpp"
+#include "api.hpp"
+
+class api_promise : public ft_promise<json_group*>
+{
+public:
+    bool request(const char *ip, uint16_t port,
+                 const char *method, const char *path,
+                 json_group *payload = NULL,
+                 const char *headers = NULL, int *status = NULL);
+};
+
+#endif

--- a/API/api_request.cpp
+++ b/API/api_request.cpp
@@ -2,10 +2,12 @@
 #include "../Networking/socket_class.hpp"
 #include "../CPP_class/string_class.hpp"
 #include "../CMA/CMA.hpp"
+#include "../Libft/libft.hpp"
 #include <cstring>
 
 json_group *api_request_json(const char *ip, uint16_t port,
-    const char *method, const char *path, json_group *payload)
+    const char *method, const char *path, json_group *payload,
+    const char *headers, int *status)
 {
     SocketConfig config;
     config.type = SocketType::CLIENT;
@@ -21,6 +23,11 @@ json_group *api_request_json(const char *ip, uint16_t port,
     request += path;
     request += " HTTP/1.1\r\nHost: ";
     request += ip;
+    if (headers && headers[0])
+    {
+        request += "\r\n";
+        request += headers;
+    }
 
     ft_string body_string;
     if (payload)
@@ -53,6 +60,13 @@ json_group *api_request_json(const char *ip, uint16_t port,
     {
         buffer[bytes] = '\0';
         response += buffer;
+    }
+    if (status)
+    {
+        *status = -1;
+        const char *space = strchr(response.c_str(), ' ');
+        if (space)
+            *status = ft_atoi(space + 1);
     }
     const char *body = strstr(response.c_str(), "\r\n\r\n");
     if (!body)

--- a/API/compile_commands.json
+++ b/API/compile_commands.json
@@ -10,11 +10,29 @@
       "-std=c++17",
       "-c",
       "-o",
-      "objs/api_wrapper.o",
-      "api_wrapper.cpp"
+      "objs/api_request.o",
+      "api_request.cpp"
     ],
     "directory": "/workspace/Libft/API",
-    "file": "/workspace/Libft/API/api_wrapper.cpp",
-    "output": "/workspace/Libft/API/objs/api_wrapper.o"
+    "file": "/workspace/Libft/API/api_request.cpp",
+    "output": "/workspace/Libft/API/objs/api_request.o"
+  },
+  {
+    "arguments": [
+      "/usr/bin/g++",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g",
+      "-O0",
+      "-std=c++17",
+      "-c",
+      "-o",
+      "objs/api_promise.o",
+      "api_promise.cpp"
+    ],
+    "directory": "/workspace/Libft/API",
+    "file": "/workspace/Libft/API/api_promise.cpp",
+    "output": "/workspace/Libft/API/objs/api_promise.o"
   }
 ]

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -1,6 +1,8 @@
 #ifndef FULL_LIBFT_HPP
 # define FULL_LIBFT_HPP
 
+#include "API/api.hpp"
+#include "API/api_promise.hpp"
 #include "CMA/CMA.hpp"
 #include "CMA/CMA_internal.hpp"
 #include "CPP_class/data_buffer.hpp"

--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ const char *get_error_str() const;
 * **File** – directory handling wrappers such as `ft_opendir` and `ft_readdir`,
   and cross-platform file helpers (`ft_open`, `ft_read`, `ft_write`,
   `ft_close`, `ft_initialize_standard_file_descriptors`).
+* **API** – simple HTTP client that sends requests and parses JSON responses
+  via `api_request_json`. Custom headers can be supplied via an optional
+  argument, and the HTTP status code can be retrieved through an optional
+  output parameter. The module also provides `api_promise`, a
+  `ft_promise<json_group*>` derivative with a `request` helper that fulfills
+  the promise with the response JSON.
 * **HTML** – minimal HTML node creation and searching utilities.
 * **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_event`, `ft_upgrade`, `ft_item`, and `ft_reputation` also expose adders, and now each of these classes provides matching subtract helpers. `ft_inventory` manages stacked items and can query item counts with `has_item` and `count_item`. `ft_character` keeps track of coins and a `valor` attribute with helpers to add or subtract these values. The character's current level can be retrieved with `get_level()` which relies on an internal experience table.
 `ft_quest` objects can report completion with `is_complete()` and progress phases via `advance_phase()`.


### PR DESCRIPTION
## Summary
- extend api_request_json with an optional status-code out parameter
- parse HTTP status from responses and document the new capability
- wrap ft_promise<json_group*> in api_promise with a request helper for asynchronous JSON responses

## Testing
- `make -C API`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68adf035383c8331863a22e8480ecf94