### PR TITLE
Add raw string API request helper with configurable timeout

### DIFF
--- a/API/api.hpp
+++ b/API/api.hpp
@@ -5,8 +5,14 @@
 #include <cstdint>
 #include <cstddef>
 
+char    *api_request_string(const char *ip, uint16_t port,
+        const char *method, const char *path, json_group *payload = NULL,
+        const char *headers = NULL, int *status = NULL,
+        int timeout = 60000);
+
 json_group *api_request_json(const char *ip, uint16_t port,
         const char *method, const char *path, json_group *payload = NULL,
-        const char *headers = NULL, int *status = NULL);
+        const char *headers = NULL, int *status = NULL,
+        int timeout = 60000);
 
 #endif

--- a/API/api_promise.cpp
+++ b/API/api_promise.cpp
@@ -3,10 +3,25 @@
 bool api_promise::request(const char *ip, uint16_t port,
                           const char *method, const char *path,
                           json_group *payload,
-                          const char *headers, int *status)
+                          const char *headers, int *status,
+                          int timeout)
 {
     json_group *resp = api_request_json(ip, port, method, path, payload,
-                                        headers, status);
+                                        headers, status, timeout);
+    if (!resp)
+        return (false);
+    set_value(resp);
+    return (true);
+}
+
+bool api_string_promise::request(const char *ip, uint16_t port,
+                                 const char *method, const char *path,
+                                 json_group *payload,
+                                 const char *headers, int *status,
+                                 int timeout)
+{
+    char *resp = api_request_string(ip, port, method, path, payload,
+                                    headers, status, timeout);
     if (!resp)
         return (false);
     set_value(resp);

--- a/API/api_promise.hpp
+++ b/API/api_promise.hpp
@@ -10,7 +10,18 @@ public:
     bool request(const char *ip, uint16_t port,
                  const char *method, const char *path,
                  json_group *payload = NULL,
-                 const char *headers = NULL, int *status = NULL);
+                 const char *headers = NULL, int *status = NULL,
+                 int timeout = 60000);
+};
+
+class api_string_promise : public ft_promise<char*>
+{
+public:
+    bool request(const char *ip, uint16_t port,
+                 const char *method, const char *path,
+                 json_group *payload = NULL,
+                 const char *headers = NULL, int *status = NULL,
+                 int timeout = 60000);
 };
 
 #endif

--- a/API/api_request.cpp
+++ b/API/api_request.cpp
@@ -5,14 +5,16 @@
 #include "../Libft/libft.hpp"
 #include <cstring>
 
-json_group *api_request_json(const char *ip, uint16_t port,
+char *api_request_string(const char *ip, uint16_t port,
     const char *method, const char *path, json_group *payload,
-    const char *headers, int *status)
+    const char *headers, int *status, int timeout)
 {
     SocketConfig config;
     config.type = SocketType::CLIENT;
     config.ip = ip;
     config.port = port;
+    config.recv_timeout = timeout;
+    config.send_timeout = timeout;
 
     ft_socket sock(config);
     if (sock.get_error())
@@ -72,5 +74,18 @@ json_group *api_request_json(const char *ip, uint16_t port,
     if (!body)
         return (NULL);
     body += 4;
-    return (json_read_from_string(body));
+    return (cma_strdup(body));
+}
+
+json_group *api_request_json(const char *ip, uint16_t port,
+    const char *method, const char *path, json_group *payload,
+    const char *headers, int *status, int timeout)
+{
+    char *body = api_request_string(ip, port, method, path, payload,
+                                   headers, status, timeout);
+    if (!body)
+        return (NULL);
+    json_group *result = json_read_from_string(body);
+    cma_free(body);
+    return (result);
 }

--- a/README.md
+++ b/README.md
@@ -308,9 +308,15 @@ const char *get_error_str() const;
 * **API** – simple HTTP client that sends requests and parses JSON responses
   via `api_request_json`. Custom headers can be supplied via an optional
   argument, and the HTTP status code can be retrieved through an optional
-  output parameter. The module also provides `api_promise`, a
-  `ft_promise<json_group*>` derivative with a `request` helper that fulfills
-  the promise with the response JSON.
+  output parameter. Both `api_request_json` and `api_request_string` accept an
+  optional timeout (in milliseconds) that controls send and receive timeouts,
+  defaulting to 1 minute (60,000 ms). When the raw response body is needed,
+  `api_request_string` performs the same request and returns the text content.
+  The module also provides `api_promise`, a `ft_promise<json_group*>`
+  derivative with a `request` helper that fulfills the promise with the
+  response JSON, and `api_string_promise`, which wraps `api_request_string` and
+  fulfills the promise with the raw body. Both promise helpers support the same
+  timeout parameter.
 * **HTML** – minimal HTML node creation and searching utilities.
 * **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_event`, `ft_upgrade`, `ft_item`, and `ft_reputation` also expose adders, and now each of these classes provides matching subtract helpers. `ft_inventory` manages stacked items and can query item counts with `has_item` and `count_item`. `ft_character` keeps track of coins and a `valor` attribute with helpers to add or subtract these values. The character's current level can be retrieved with `get_level()` which relies on an internal experience table.
 `ft_quest` objects can report completion with `is_complete()` and progress phases via `advance_phase()`.


### PR DESCRIPTION
## Summary
- add `api_request_string` for retrieving raw HTTP response bodies
- refactor existing `api_request_json` to use new helper
- document raw string requests and promise interface
- introduce `api_string_promise` for asynchronous raw body requests
- allow configuring request timeouts across API helpers and promises
- default timeouts to 1 minute when no value is provided

## Testing
- `cd API && make clean >/tmp/api_make_clean.log && cat /tmp/api_make_clean.log`
- `make >/tmp/api_make.log && cat /tmp/api_make.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae00f31a1c8331898a5a733fed7d5d