### PR TITLE
Add TLS JSON request utilities and printf benchmark

### DIFF
--- a/API/api.hpp
+++ b/API/api.hpp
@@ -20,4 +20,9 @@ json_group *api_request_json(const char *ip, uint16_t port,
         const char *headers = NULL, int *status = NULL,
         int timeout = 60000);
 
+json_group *api_request_json_tls(const char *host, uint16_t port,
+        const char *method, const char *path, json_group *payload = NULL,
+        const char *headers = NULL, int *status = NULL,
+        int timeout = 60000);
+
 #endif

--- a/API/api_request_tls.cpp
+++ b/API/api_request_tls.cpp
@@ -163,3 +163,16 @@ cleanup:
         freeaddrinfo(res);
     return (ret);
 }
+
+json_group *api_request_json_tls(const char *host, uint16_t port,
+    const char *method, const char *path, json_group *payload,
+    const char *headers, int *status, int timeout)
+{
+    char *body = api_request_string_tls(host, port, method, path, payload,
+                                        headers, status, timeout);
+    if (!body)
+        return (NULL);
+    json_group *result = json_read_from_string(body);
+    cma_free(body);
+    return (result);
+}

--- a/API/api_tls_client.cpp
+++ b/API/api_tls_client.cpp
@@ -190,3 +190,15 @@ char *api_tls_client::request(const char *method, const char *path, json_group *
     return (cma_strdup(body.c_str()));
 }
 
+json_group *api_tls_client::request_json(const char *method, const char *path,
+                                         json_group *payload,
+                                         const char *headers, int *status)
+{
+    char *body = request(method, path, payload, headers, status);
+    if (!body)
+        return (NULL);
+    json_group *result = json_read_from_string(body);
+    cma_free(body);
+    return (result);
+}
+

--- a/API/api_tls_client.hpp
+++ b/API/api_tls_client.hpp
@@ -26,6 +26,10 @@ public:
 
     char *request(const char *method, const char *path, json_group *payload = NULL,
                   const char *headers = NULL, int *status = NULL);
+
+    json_group *request_json(const char *method, const char *path,
+                             json_group *payload = NULL,
+                             const char *headers = NULL, int *status = NULL);
 };
 
 #endif

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -21,7 +21,7 @@ EFF_SRCS := efficiency/efficiency_strlen.cpp efficiency/efficiency_memcpy.cpp \
             efficiency/efficiency_clamp.cpp \
             efficiency/efficiency_atoi.cpp efficiency/efficiency_atol.cpp \
             efficiency/efficiency_pool.cpp efficiency/efficiency_swap.cpp \
-            efficiency/efficiency_mutex.cpp
+            efficiency/efficiency_mutex.cpp efficiency/efficiency_printf.cpp
 
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp test_strlen.cpp \
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \

--- a/Test/efficiency/efficiency_printf.cpp
+++ b/Test/efficiency/efficiency_printf.cpp
@@ -1,0 +1,43 @@
+#include "../../Printf/printf.hpp"
+#include "efficiency_utils.hpp"
+
+#include <cstdio>
+#include <string>
+
+int test_efficiency_printf(void) {
+  const size_t iterations = 1000; // fewer iterations due to I/O cost
+  const char *fmt = "Hello %s %d %x";
+  const char *str = "world";
+  int num = 42;
+  unsigned hex = 0x2a;
+  volatile int sink = 0;
+
+  FILE *devnull = std::fopen("/dev/null", "w");
+  if (!devnull)
+    return (0);
+
+  auto start_std = clock_type::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    prevent_optimization((void *)fmt);
+    prevent_optimization((void *)str);
+    sink += std::fprintf(devnull, fmt, str, num, hex);
+    prevent_optimization((void *)&sink);
+  }
+  std::fflush(devnull);
+  auto end_std = clock_type::now();
+
+  auto start_ft = clock_type::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    prevent_optimization((void *)fmt);
+    prevent_optimization((void *)str);
+    sink += ft_fprintf(devnull, fmt, str, num, hex);
+    prevent_optimization((void *)&sink);
+  }
+  std::fflush(devnull);
+  auto end_ft = clock_type::now();
+
+  std::fclose(devnull);
+  print_comparison("printf", elapsed_us(start_std, end_std),
+                   elapsed_us(start_ft, end_ft));
+  return (1);
+}


### PR DESCRIPTION
## Summary
- add `api_request_json_tls` helper for JSON responses over TLS
- extend `api_tls_client` with `request_json` method
- add efficiency test comparing standard `fprintf` and custom `ft_fprintf`

## Testing
- `cd API && make clean >/tmp/make_clean.log && tail -n 20 /tmp/make_clean.log`
- `cd API && make >/tmp/make.log && tail -n 20 /tmp/make.log`
- `cd API && make fclean >/tmp/make_fclean.log && tail -n 20 /tmp/make_fclean.log`
- `cd Test && make clean >/tmp/test_make_clean.log && tail -n 20 /tmp/test_make_clean.log`
- `cd Test && make >/tmp/test_make.log && tail -n 20 /tmp/test_make.log`
- `cd Test && make fclean >/tmp/test_make_fclean.log && tail -n 20 /tmp/test_make_fclean.log`


------
https://chatgpt.com/codex/tasks/task_e_68af2d98ff388331b41795894609a944