### PR TITLE
Add TLS promise wrappers to API

### DIFF
--- a/API/api_promise.cpp
+++ b/API/api_promise.cpp
@@ -27,3 +27,31 @@ bool api_string_promise::request(const char *ip, uint16_t port,
     set_value(resp);
     return (true);
 }
+
+bool api_tls_promise::request(const char *host, uint16_t port,
+                              const char *method, const char *path,
+                              json_group *payload,
+                              const char *headers, int *status,
+                              int timeout)
+{
+    json_group *resp = api_request_json_tls(host, port, method, path, payload,
+                                            headers, status, timeout);
+    if (!resp)
+        return (false);
+    set_value(resp);
+    return (true);
+}
+
+bool api_tls_string_promise::request(const char *host, uint16_t port,
+                                     const char *method, const char *path,
+                                     json_group *payload,
+                                     const char *headers, int *status,
+                                     int timeout)
+{
+    char *resp = api_request_string_tls(host, port, method, path, payload,
+                                        headers, status, timeout);
+    if (!resp)
+        return (false);
+    set_value(resp);
+    return (true);
+}

--- a/API/api_promise.hpp
+++ b/API/api_promise.hpp
@@ -24,4 +24,24 @@ public:
                  int timeout = 60000);
 };
 
+class api_tls_promise : public ft_promise<json_group*>
+{
+public:
+    bool request(const char *host, uint16_t port,
+                 const char *method, const char *path,
+                 json_group *payload = NULL,
+                 const char *headers = NULL, int *status = NULL,
+                 int timeout = 60000);
+};
+
+class api_tls_string_promise : public ft_promise<char*>
+{
+public:
+    bool request(const char *host, uint16_t port,
+                 const char *method, const char *path,
+                 json_group *payload = NULL,
+                 const char *headers = NULL, int *status = NULL,
+                 int timeout = 60000);
+};
+
 #endif


### PR DESCRIPTION
## Summary
- add `api_tls_promise` and `api_tls_string_promise` to support asynchronous TLS requests
- implement TLS promise request methods calling `api_request_json_tls` and `api_request_string_tls`

## Testing
- `make -C API`


------
https://chatgpt.com/codex/tasks/task_e_68af49eb70bc8331be6558eadced57ba