### PR TITLE
feat(api): add hostname request helpers

### DIFF
--- a/API/api.hpp
+++ b/API/api.hpp
@@ -15,12 +15,22 @@ char    *api_request_string_tls(const char *host, uint16_t port,
         const char *headers = NULL, int *status = NULL,
         int timeout = 60000);
 
+char    *api_request_string_host(const char *host, uint16_t port,
+        const char *method, const char *path, json_group *payload = NULL,
+        const char *headers = NULL, int *status = NULL,
+        int timeout = 60000);
+
 json_group *api_request_json(const char *ip, uint16_t port,
         const char *method, const char *path, json_group *payload = NULL,
         const char *headers = NULL, int *status = NULL,
         int timeout = 60000);
 
 json_group *api_request_json_tls(const char *host, uint16_t port,
+        const char *method, const char *path, json_group *payload = NULL,
+        const char *headers = NULL, int *status = NULL,
+        int timeout = 60000);
+
+json_group *api_request_json_host(const char *host, uint16_t port,
         const char *method, const char *path, json_group *payload = NULL,
         const char *headers = NULL, int *status = NULL,
         int timeout = 60000);

--- a/API/api_request.cpp
+++ b/API/api_request.cpp
@@ -4,6 +4,17 @@
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
 #include <cstring>
+#include <cstdio>
+#ifdef _WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
+#else
+# include <netdb.h>
+# include <arpa/inet.h>
+# include <sys/socket.h>
+# include <sys/time.h>
+# include <unistd.h>
+#endif
 
 char *api_request_string(const char *ip, uint16_t port,
     const char *method, const char *path, json_group *payload,
@@ -83,6 +94,126 @@ json_group *api_request_json(const char *ip, uint16_t port,
 {
     char *body = api_request_string(ip, port, method, path, payload,
                                    headers, status, timeout);
+    if (!body)
+        return (NULL);
+    json_group *result = json_read_from_string(body);
+    cma_free(body);
+    return (result);
+}
+
+char *api_request_string_host(const char *host, uint16_t port,
+    const char *method, const char *path, json_group *payload,
+    const char *headers, int *status, int timeout)
+{
+    struct addrinfo hints;
+    struct addrinfo *res = NULL;
+    struct addrinfo *p;
+    int sock = -1;
+    ft_string request;
+    ft_string body_string;
+    ft_string response;
+    char *ret = NULL;
+    char buffer[1024];
+    ssize_t bytes;
+    const char *body = NULL;
+    char port_str[6];
+
+    if (!host || !method || !path)
+        return (NULL);
+    ft_bzero(&hints, sizeof(hints));
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_family = AF_UNSPEC;
+    std::snprintf(port_str, sizeof(port_str), "%u", port);
+    if (getaddrinfo(host, port_str, &hints, &res) != 0)
+        goto cleanup;
+
+    for (p = res; p != NULL; p = p->ai_next)
+    {
+        sock = nw_socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+        if (sock < 0)
+            continue;
+        if (timeout > 0)
+        {
+            struct timeval tv;
+            tv.tv_sec = timeout / 1000;
+            tv.tv_usec = (timeout % 1000) * 1000;
+            setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+            setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+        }
+        if (nw_connect(sock, p->ai_addr, static_cast<socklen_t>(p->ai_addrlen)) == 0)
+            break;
+        FT_CLOSE_SOCKET(sock);
+        sock = -1;
+    }
+    freeaddrinfo(res);
+    res = NULL;
+    if (sock < 0)
+        goto cleanup;
+
+    request = method;
+    request += " ";
+    request += path;
+    request += " HTTP/1.1\r\nHost: ";
+    request += host;
+    if (headers && headers[0])
+    {
+        request += "\r\n";
+        request += headers;
+    }
+    if (payload)
+    {
+        char *tmp = json_write_to_string(payload);
+        if (!tmp)
+            goto cleanup;
+        body_string = tmp;
+        cma_free(tmp);
+        request += "\r\nContent-Type: application/json";
+        char *len = cma_itoa(static_cast<int>(body_string.size()));
+        if (!len)
+            goto cleanup;
+        request += "\r\nContent-Length: ";
+        request += len;
+        cma_free(len);
+    }
+    request += "\r\nConnection: close\r\n\r\n";
+    if (payload)
+        request += body_string.c_str();
+
+    if (nw_send(sock, request.c_str(), request.size(), 0) < 0)
+        goto cleanup;
+
+    while ((bytes = nw_recv(sock, buffer, sizeof(buffer) - 1, 0)) > 0)
+    {
+        buffer[bytes] = '\0';
+        response += buffer;
+    }
+    if (status)
+    {
+        *status = -1;
+        const char *space = strchr(response.c_str(), ' ');
+        if (space)
+            *status = ft_atoi(space + 1);
+    }
+    body = strstr(response.c_str(), "\r\n\r\n");
+    if (!body)
+        goto cleanup;
+    body += 4;
+    ret = cma_strdup(body);
+
+cleanup:
+    if (sock >= 0)
+        FT_CLOSE_SOCKET(sock);
+    if (res)
+        freeaddrinfo(res);
+    return (ret);
+}
+
+json_group *api_request_json_host(const char *host, uint16_t port,
+    const char *method, const char *path, json_group *payload,
+    const char *headers, int *status, int timeout)
+{
+    char *body = api_request_string_host(host, port, method, path, payload,
+                                        headers, status, timeout);
     if (!body)
         return (NULL);
     json_group *result = json_read_from_string(body);

--- a/README.md
+++ b/README.md
@@ -312,11 +312,12 @@ const char *get_error_str() const;
   optional timeout (in milliseconds) that controls send and receive timeouts,
   defaulting to 1 minute (60,000 ms). When the raw response body is needed,
   `api_request_string` performs the same request and returns the text content.
-  The module also provides `api_promise`, a `ft_promise<json_group*>`
-  derivative with a `request` helper that fulfills the promise with the
-  response JSON, and `api_string_promise`, which wraps `api_request_string` and
-  fulfills the promise with the raw body. Both promise helpers support the same
-  timeout parameter.
+  The module also provides `api_request_string_host` and
+  `api_request_json_host` variants that resolve a hostname before issuing the
+  request, allowing non-TLS queries to be made using domain names instead of
+  raw IP addresses. Asynchronous helpers `api_promise` and
+  `api_string_promise` wrap the string and JSON request functions and both
+  support the same timeout parameter.
 * **HTML** – minimal HTML node creation and searching utilities.
 * **Game** – basic game related classes (`ft_character`, `ft_item`, `ft_inventory`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`, `ft_buff`, `ft_debuff`). `ft_buff` and `ft_debuff` each store four independent modifiers and expose getters, setters, and adders (including for duration). `ft_event`, `ft_upgrade`, `ft_item`, and `ft_reputation` also expose adders, and now each of these classes provides matching subtract helpers. `ft_inventory` manages stacked items and can query item counts with `has_item` and `count_item`. `ft_character` keeps track of coins and a `valor` attribute with helpers to add or subtract these values. The character's current level can be retrieved with `get_level()` which relies on an internal experience table.
 `ft_quest` objects can report completion with `is_complete()` and progress phases via `advance_phase()`.


### PR DESCRIPTION
## Summary
- add `api_request_string_host` and `api_request_json_host` for hostname-based HTTP requests
- document API hostname helpers in README

## Testing
- `cd API && make && make clean && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68af4af4bc708331abdae2c6541bcebf