### PR TITLE
Add INI configuration parser

### DIFF
--- a/Config/Makefile
+++ b/Config/Makefile
@@ -1,0 +1,70 @@
+TARGET := config.a
+DEBUG_TARGET := config_debug.a
+
+SRCS :=         config_parse.cpp
+
+HEADERS := config.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
+clean:
+	-$(RM) $(CLEAN_FILES)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/Config/config.hpp
+++ b/Config/config.hpp
@@ -1,0 +1,23 @@
+#ifndef CONFIG_HPP
+#define CONFIG_HPP
+
+#include "../CPP_class/nullptr.hpp"
+#include <cstddef>
+
+struct ft_config_entry
+{
+    char    *section;
+    char    *key;
+    char    *value;
+};
+
+struct ft_config
+{
+    ft_config_entry *entries;
+    size_t           entry_count;
+};
+
+ft_config   *ft_config_parse(const char *filename);
+void        ft_config_free(ft_config *config);
+
+#endif

--- a/Config/config_parse.cpp
+++ b/Config/config_parse.cpp
@@ -1,0 +1,167 @@
+#include "config.hpp"
+#include "../Errno/errno.hpp"
+#include "../CMA/CMA.hpp"
+#include "../Libft/libft.hpp"
+#include <cstdio>
+#include <cstring>
+#include <cctype>
+
+static char *trim_whitespace(char *str)
+{
+    if (!str)
+        return str;
+    while (*str && std::isspace(static_cast<unsigned char>(*str)))
+        str++;
+    char *end = str + std::strlen(str);
+    while (end > str && std::isspace(static_cast<unsigned char>(end[-1])))
+        end--;
+    *end = '\0';
+    return str;
+}
+
+void ft_config_free(ft_config *config)
+{
+    if (!config)
+        return ;
+    for (size_t i = 0; i < config->entry_count; ++i)
+    {
+        cma_free(config->entries[i].section);
+        cma_free(config->entries[i].key);
+        cma_free(config->entries[i].value);
+    }
+    cma_free(config->entries);
+    cma_free(config);
+    return ;
+}
+
+ft_config *ft_config_parse(const char *filename)
+{
+    if (!filename)
+        return ft_nullptr;
+    FILE *file = ft_fopen(filename, "r");
+    if (!file)
+        return ft_nullptr;
+    ft_config *config = static_cast<ft_config*>(cma_calloc(1, sizeof(ft_config)));
+    if (!config)
+    {
+        ft_errno = FT_EALLOC;
+        ft_fclose(file);
+        return ft_nullptr;
+    }
+    char buffer[512];
+    char *current_section = ft_nullptr;
+    while (std::fgets(buffer, sizeof(buffer), file))
+    {
+        char *line = trim_whitespace(buffer);
+        if (*line == '\0' || *line == ';' || *line == '#')
+            continue ;
+        if (*line == '[')
+        {
+            char *close = std::strchr(line, ']');
+            if (close)
+            {
+                *close = '\0';
+                cma_free(current_section);
+                current_section = cma_strdup(line + 1);
+                if (!current_section)
+                {
+                    ft_errno = FT_EALLOC;
+                    ft_config_free(config);
+                    ft_fclose(file);
+                    return ft_nullptr;
+                }
+            }
+            continue ;
+        }
+        char *eq = std::strchr(line, '=');
+        char *key = ft_nullptr;
+        char *value = ft_nullptr;
+        if (eq)
+        {
+            *eq = '\0';
+            char *k = trim_whitespace(line);
+            char *v = trim_whitespace(eq + 1);
+            if (*k)
+            {
+                key = cma_strdup(k);
+                if (!key)
+                {
+                    ft_errno = FT_EALLOC;
+                    cma_free(value);
+                    ft_config_free(config);
+                    if (current_section)
+                        cma_free(current_section);
+                    ft_fclose(file);
+                    return ft_nullptr;
+                }
+            }
+            if (*v)
+            {
+                value = cma_strdup(v);
+                if (!value)
+                {
+                    ft_errno = FT_EALLOC;
+                    cma_free(key);
+                    ft_config_free(config);
+                    if (current_section)
+                        cma_free(current_section);
+                    ft_fclose(file);
+                    return ft_nullptr;
+                }
+            }
+        }
+        else
+        {
+            char *k = trim_whitespace(line);
+            if (*k)
+            {
+                key = cma_strdup(k);
+                if (!key)
+                {
+                    ft_errno = FT_EALLOC;
+                    ft_config_free(config);
+                    if (current_section)
+                        cma_free(current_section);
+                    ft_fclose(file);
+                    return ft_nullptr;
+                }
+            }
+        }
+        ft_config_entry entry;
+        entry.section = current_section ? cma_strdup(current_section) : ft_nullptr;
+        entry.key = key;
+        entry.value = value;
+        if (current_section && !entry.section)
+        {
+            ft_errno = FT_EALLOC;
+            cma_free(key);
+            cma_free(value);
+            ft_config_free(config);
+            if (current_section)
+                cma_free(current_section);
+            ft_fclose(file);
+            return ft_nullptr;
+        }
+        ft_config_entry *new_entries = static_cast<ft_config_entry*>(cma_realloc(config->entries, sizeof(ft_config_entry) * (config->entry_count + 1)));
+        if (!new_entries)
+        {
+            ft_errno = FT_EALLOC;
+            cma_free(entry.section);
+            cma_free(entry.key);
+            cma_free(entry.value);
+            ft_config_free(config);
+            if (current_section)
+                cma_free(current_section);
+            ft_fclose(file);
+            return ft_nullptr;
+        }
+        config->entries = new_entries;
+        config->entries[config->entry_count] = entry;
+        config->entry_count++;
+    }
+    if (current_section)
+        cma_free(current_section);
+    ft_fclose(file);
+    return config;
+}
+

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -10,6 +10,7 @@
 #include "CPP_class/nullptr.hpp"
 #include "CPP_class/string_class.hpp"
 #include "Errno/errno.hpp"
+#include "Config/config.hpp"
 #include "GetNextLine/get_next_line.hpp"
 #include "HTML/html_parser.hpp"
 #include "JSon/json.hpp"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SUBDIRS :=  CMA \
             PThread \
             CPP_class \
             Errno \
+            Config \
             Networking \
             API
 
@@ -41,8 +42,9 @@ LIB_BASES := \
   PThread/PThread \
   CPP_class/CPP_class \
   Errno/errno \
-    Networking/networking \
-    API/API
+  Config/config \
+  Networking/networking \
+  API/API
 
 ifeq ($(OS),Windows_NT)
 LIB_BASES += Windows/Windows
@@ -99,6 +101,7 @@ $(TARGET): $(LIBS)
 	$(call EXTRACT,PThread/PThread.a)
 	$(call EXTRACT,CPP_class/CPP_class.a)
 	$(call EXTRACT,Errno/errno.a)
+	$(call EXTRACT,Config/config.a)
 	$(call EXTRACT,Networking/networking.a)
 	$(call EXTRACT,API/API.a)
 	$(OS_EXTRACT)
@@ -123,6 +126,7 @@ $(DEBUG_TARGET): $(DEBUG_LIBS)
 	$(call EXTRACT,PThread/PThread_debug.a)
 	$(call EXTRACT,CPP_class/CPP_class_debug.a)
 	$(call EXTRACT,Errno/errno_debug.a)
+	$(call EXTRACT,Config/config_debug.a)
 	$(call EXTRACT,Networking/networking_debug.a)
 	$(call EXTRACT,API/API_debug.a)
 	$(DEBUG_OS_EXTRACT)
@@ -150,6 +154,7 @@ clean:
 	$(MAKE) -C PThread clean
 	$(MAKE) -C CPP_class clean
 	$(MAKE) -C Errno clean
+	$(MAKE) -C Config clean
 	$(MAKE) -C Networking clean
 	$(MAKE) -C API clean
 	$(OS_CLEAN)
@@ -170,6 +175,7 @@ fclean: clean
 	$(MAKE) -C PThread fclean
 	$(MAKE) -C CPP_class fclean
 	$(MAKE) -C Errno fclean
+	$(MAKE) -C Config fclean
 	$(MAKE) -C Networking fclean
 	$(MAKE) -C API fclean
 	$(OS_FCLEAN)

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -27,7 +27,7 @@ SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp 
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \
        test_cpp_class.cpp test_template.cpp test_printf.cpp test_get_next_line.cpp \
        test_cma.cpp test_game.cpp test_queue.cpp test_queue_class.cpp \
-       test_promise.cpp $(EFF_SRCS)
+       test_promise.cpp test_config.cpp $(EFF_SRCS)
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -164,6 +164,8 @@ int test_queue_basic(void);
 int test_ft_queue_class_basic(void);
 int test_ft_promise_set_get(void);
 int test_ft_promise_not_ready(void);
+int test_config_basic(void);
+int test_config_missing_value(void);
 int test_pt_async_basic(void);
 
 int test_efficiency_strlen(void);
@@ -369,6 +371,8 @@ int main(int argc, char **argv)
         { test_ft_queue_class_basic, "queue class basic" },
         { test_ft_promise_set_get, "ft_promise set/get" },
         { test_ft_promise_not_ready, "ft_promise not ready" },
+        { test_config_basic, "config basic" },
+        { test_config_missing_value, "config missing value" },
         { test_pt_async_basic, "pt_async basic" }
     };
 

--- a/Test/test_config.cpp
+++ b/Test/test_config.cpp
@@ -1,0 +1,44 @@
+#include "../Config/config.hpp"
+#include "../CPP_class/nullptr.hpp"
+#include <cstdio>
+#include <cstring>
+
+int test_config_basic(void)
+{
+    const char *filename = "test_config.ini";
+    FILE *file = std::fopen(filename, "w");
+    if (!file)
+        return 0;
+    std::fprintf(file, "[section]\nkey=value\n");
+    std::fclose(file);
+    ft_config *cfg = ft_config_parse(filename);
+    int ok = cfg && cfg->entry_count == 1 &&
+             cfg->entries[0].section && std::strcmp(cfg->entries[0].section, "section") == 0 &&
+             cfg->entries[0].key && std::strcmp(cfg->entries[0].key, "key") == 0 &&
+             cfg->entries[0].value && std::strcmp(cfg->entries[0].value, "value") == 0;
+    if (cfg)
+        ft_config_free(cfg);
+    std::remove(filename);
+    return ok;
+}
+
+int test_config_missing_value(void)
+{
+    const char *filename = "test_config_missing.ini";
+    FILE *file = std::fopen(filename, "w");
+    if (!file)
+        return 0;
+    std::fprintf(file, "key_without_value=\n=value_without_key\n");
+    std::fclose(file);
+    ft_config *cfg = ft_config_parse(filename);
+    int ok = cfg && cfg->entry_count == 2 &&
+             cfg->entries[0].key && std::strcmp(cfg->entries[0].key, "key_without_value") == 0 &&
+             cfg->entries[0].value == ft_nullptr &&
+             cfg->entries[1].key == ft_nullptr &&
+             cfg->entries[1].value && std::strcmp(cfg->entries[1].value, "value_without_key") == 0;
+    if (cfg)
+        ft_config_free(cfg);
+    std::remove(filename);
+    return ok;
+}
+


### PR DESCRIPTION
## Summary
- implement `ft_config_parse` and `ft_config_free` for reading INI files into a structured result
- integrate config module into build and export through `FullLibft.hpp`
- add tests covering basic parsing and missing value cases

## Testing
- `make -C Test`
- `./Test/libft_tests --all`


------
https://chatgpt.com/codex/tasks/task_e_68b1d88810408331bf3fa5870b7e778d