### PR TITLE
Prefix class members with underscores

### DIFF
--- a/API/api_request.cpp
+++ b/API/api_request.cpp
@@ -21,11 +21,11 @@ char *api_request_string(const char *ip, uint16_t port,
     const char *headers, int *status, int timeout)
 {
     SocketConfig config;
-    config.type = SocketType::CLIENT;
-    config.ip = ip;
-    config.port = port;
-    config.recv_timeout = timeout;
-    config.send_timeout = timeout;
+    config._type = SocketType::CLIENT;
+    config._ip = ip;
+    config._port = port;
+    config._recv_timeout = timeout;
+    config._send_timeout = timeout;
 
     ft_socket sock(config);
     if (sock.get_error())

--- a/API/api_tls_client.hpp
+++ b/API/api_tls_client.hpp
@@ -9,11 +9,11 @@
 class api_tls_client
 {
 private:
-    SSL_CTX *ctx;
-    SSL *ssl;
-    int sock;
-    ft_string host;
-    int timeout;
+    SSL_CTX *_ctx;
+    SSL *_ssl;
+    int _sock;
+    ft_string _host;
+    int _timeout;
 
 public:
     api_tls_client(const char *host, uint16_t port, int timeout = 60000);

--- a/Networking/networking.cpp
+++ b/Networking/networking.cpp
@@ -10,49 +10,49 @@
 #endif
 
 SocketConfig::SocketConfig()
-    : type(SocketType::SERVER),
-      ip("127.0.0.1"),
-      port(8080),
-      backlog(10),
-      protocol(IPPROTO_TCP),
-      address_family(AF_INET),
-      reuse_address(true),
-      non_blocking(false),
-      recv_timeout(5000),
-      send_timeout(5000),
-      multicast_group(""),
-      multicast_interface("")
+    : _type(SocketType::SERVER),
+      _ip("127.0.0.1"),
+      _port(8080),
+      _backlog(10),
+      _protocol(IPPROTO_TCP),
+      _address_family(AF_INET),
+      _reuse_address(true),
+      _non_blocking(false),
+      _recv_timeout(5000),
+      _send_timeout(5000),
+      _multicast_group(""),
+      _multicast_interface("")
 {
-    if (!_error && ip.get_error())
-        _error = ip.get_error();
-    if (!_error && multicast_group.get_error())
-        _error = multicast_group.get_error();
-    if (!_error && multicast_interface.get_error())
-        _error = multicast_interface.get_error();
+    if (!_error && _ip.get_error())
+        _error = _ip.get_error();
+    if (!_error && _multicast_group.get_error())
+        _error = _multicast_group.get_error();
+    if (!_error && _multicast_interface.get_error())
+        _error = _multicast_interface.get_error();
     return ;
 }
 
 SocketConfig::SocketConfig(const SocketConfig& other) noexcept
     : _error(other._error),
-      type(other.type),
-      ip(other.ip),
-      port(other.port),
-      backlog(other.backlog),
-      protocol(other.protocol),
-      address_family(other.address_family),
-      reuse_address(other.reuse_address),
-      non_blocking(other.non_blocking),
-      recv_timeout(other.recv_timeout),
-      send_timeout(other.send_timeout),
-      multicast_group(other.multicast_group),
-      multicast_interface(other.multicast_interface)
+      _type(other._type),
+      _ip(other._ip),
+      _port(other._port),
+      _backlog(other._backlog),
+      _protocol(other._protocol),
+      _address_family(other._address_family),
+      _reuse_address(other._reuse_address),
+      _non_blocking(other._non_blocking),
+      _recv_timeout(other._recv_timeout),
+      _send_timeout(other._send_timeout),
+      _multicast_group(other._multicast_group),
+      _multicast_interface(other._multicast_interface)
 {
-    if (!_error && ip.get_error())
-        _error = ip.get_error();
-    if (!_error && multicast_group.get_error())
-        _error = multicast_group.get_error();
-    if (!_error && multicast_interface.get_error())
-        _error = multicast_interface.get_error();
+    if (!_error && _ip.get_error())
+        _error = _ip.get_error();
+    if (!_error && _multicast_group.get_error())
+        _error = _multicast_group.get_error();
+    if (!_error && _multicast_interface.get_error())
+        _error = _multicast_interface.get_error();
     return ;
 }
 
@@ -61,61 +61,61 @@ SocketConfig& SocketConfig::operator=(const SocketConfig& other) noexcept
     if (this != &other)
     {
         _error = other._error;
-        type = other.type;
-        ip = other.ip;
-        port = other.port;
-        backlog = other.backlog;
-        protocol = other.protocol;
-        address_family = other.address_family;
-        reuse_address = other.reuse_address;
-        non_blocking = other.non_blocking;
-        recv_timeout = other.recv_timeout;
-        send_timeout = other.send_timeout;
-        multicast_group = other.multicast_group;
-        multicast_interface = other.multicast_interface;
+        _type = other._type;
+        _ip = other._ip;
+        _port = other._port;
+        _backlog = other._backlog;
+        _protocol = other._protocol;
+        _address_family = other._address_family;
+        _reuse_address = other._reuse_address;
+        _non_blocking = other._non_blocking;
+        _recv_timeout = other._recv_timeout;
+        _send_timeout = other._send_timeout;
+        _multicast_group = other._multicast_group;
+        _multicast_interface = other._multicast_interface;
     }
-    if (!_error && ip.get_error())
-        _error = ip.get_error();
-    if (!_error && multicast_group.get_error())
-        _error = multicast_group.get_error();
-    if (!_error && multicast_interface.get_error())
-        _error = multicast_interface.get_error();
+    if (!_error && _ip.get_error())
+        _error = _ip.get_error();
+    if (!_error && _multicast_group.get_error())
+        _error = _multicast_group.get_error();
+    if (!_error && _multicast_interface.get_error())
+        _error = _multicast_interface.get_error();
     return (*this);
 }
 
 SocketConfig::SocketConfig(SocketConfig&& other) noexcept
     : _error(other._error),
-      type(other.type),
-      ip(other.ip),
-      port(other.port),
-      backlog(other.backlog),
-      protocol(other.protocol),
-      address_family(other.address_family),
-      reuse_address(other.reuse_address),
-      non_blocking(other.non_blocking),
-      recv_timeout(other.recv_timeout),
-      send_timeout(other.send_timeout),
-      multicast_group(other.multicast_group),
-      multicast_interface(other.multicast_interface)
+      _type(other._type),
+      _ip(other._ip),
+      _port(other._port),
+      _backlog(other._backlog),
+      _protocol(other._protocol),
+      _address_family(other._address_family),
+      _reuse_address(other._reuse_address),
+      _non_blocking(other._non_blocking),
+      _recv_timeout(other._recv_timeout),
+      _send_timeout(other._send_timeout),
+      _multicast_group(other._multicast_group),
+      _multicast_interface(other._multicast_interface)
 {
     other._error = 0;
-    other.type = SocketType::CLIENT;
-    other.port = 0;
-    other.backlog = 0;
-    other.protocol = 0;
-    other.address_family = 0;
-    other.reuse_address = false;
-    other.non_blocking = false;
-    other.recv_timeout = 0;
-    other.send_timeout = 0;
-    other.multicast_group.clear();
-    other.multicast_interface.clear();
-    if (!_error && ip.get_error())
-        _error = ip.get_error();
-    if (!_error && multicast_group.get_error())
-        _error = multicast_group.get_error();
-    if (!_error && multicast_interface.get_error())
-        _error = multicast_interface.get_error();
+    other._type = SocketType::CLIENT;
+    other._port = 0;
+    other._backlog = 0;
+    other._protocol = 0;
+    other._address_family = 0;
+    other._reuse_address = false;
+    other._non_blocking = false;
+    other._recv_timeout = 0;
+    other._send_timeout = 0;
+    other._multicast_group.clear();
+    other._multicast_interface.clear();
+    if (!_error && _ip.get_error())
+        _error = _ip.get_error();
+    if (!_error && _multicast_group.get_error())
+        _error = _multicast_group.get_error();
+    if (!_error && _multicast_interface.get_error())
+        _error = _multicast_interface.get_error();
     return ;
 }
 
@@ -124,37 +124,37 @@ SocketConfig& SocketConfig::operator=(SocketConfig&& other) noexcept
     if (this != &other)
     {
         _error = other._error;
-        type = other.type;
-        other.ip = this->ip;
-        port = other.port;
-        backlog = other.backlog;
-        protocol = other.protocol;
-        address_family = other.address_family;
-        reuse_address = other.reuse_address;
-        non_blocking = other.non_blocking;
-        recv_timeout = other.recv_timeout;
-        send_timeout = other.send_timeout;
-        other.multicast_group = this->multicast_group;
-        other.multicast_interface = this->multicast_interface;
+        _type = other._type;
+        other._ip = this->_ip;
+        _port = other._port;
+        _backlog = other._backlog;
+        _protocol = other._protocol;
+        _address_family = other._address_family;
+        _reuse_address = other._reuse_address;
+        _non_blocking = other._non_blocking;
+        _recv_timeout = other._recv_timeout;
+        _send_timeout = other._send_timeout;
+        other._multicast_group = this->_multicast_group;
+        other._multicast_interface = this->_multicast_interface;
         other._error = 0;
-        other.type = SocketType::CLIENT;
-        other.port = 0;
-        other.backlog = 0;
-        other.protocol = 0;
-        other.address_family = 0;
-        other.reuse_address = false;
-        other.non_blocking = false;
-        other.recv_timeout = 0;
-        other.send_timeout = 0;
-        other.multicast_group.clear();
-        other.multicast_interface.clear();
+        other._type = SocketType::CLIENT;
+        other._port = 0;
+        other._backlog = 0;
+        other._protocol = 0;
+        other._address_family = 0;
+        other._reuse_address = false;
+        other._non_blocking = false;
+        other._recv_timeout = 0;
+        other._send_timeout = 0;
+        other._multicast_group.clear();
+        other._multicast_interface.clear();
     }
-    if (!_error && ip.get_error())
-        _error = ip.get_error();
-    if (!_error && multicast_group.get_error())
-        _error = multicast_group.get_error();
-    if (!_error && multicast_interface.get_error())
-        _error = multicast_interface.get_error();
+    if (!_error && _ip.get_error())
+        _error = _ip.get_error();
+    if (!_error && _multicast_group.get_error())
+        _error = _multicast_group.get_error();
+    if (!_error && _multicast_interface.get_error())
+        _error = _multicast_interface.get_error();
     return (*this);
 }
 

--- a/Networking/networking.hpp
+++ b/Networking/networking.hpp
@@ -29,18 +29,18 @@ class SocketConfig
         int _error;
 
     public:
-        SocketType type;
-        ft_string ip;
-        uint16_t port;
-        int backlog;
-        int protocol;
-        int address_family;
-        bool reuse_address;
-        bool non_blocking;
-        int recv_timeout;
-        int send_timeout;
-        ft_string multicast_group;
-        ft_string multicast_interface;
+        SocketType _type;
+        ft_string _ip;
+        uint16_t _port;
+        int _backlog;
+        int _protocol;
+        int _address_family;
+        bool _reuse_address;
+        bool _non_blocking;
+        int _recv_timeout;
+        int _send_timeout;
+        ft_string _multicast_group;
+        ft_string _multicast_interface;
 
         SocketConfig();
         ~SocketConfig();

--- a/Networking/setup_client.cpp
+++ b/Networking/setup_client.cpp
@@ -18,18 +18,18 @@ int ft_socket::setup_client(const SocketConfig &config)
 {
     if (create_socket(config) != ER_SUCCESS)
         return (this->_error);
-    if (config.non_blocking)
+    if (config._non_blocking)
         if (set_non_blocking(config) != ER_SUCCESS)
             return (this->_error);
-    if (config.recv_timeout > 0 || config.send_timeout > 0)
+    if (config._recv_timeout > 0 || config._send_timeout > 0)
         if (set_timeouts(config) != ER_SUCCESS)
             return (this->_error);
     if (configure_address(config) != ER_SUCCESS)
         return (this->_error);
     socklen_t addr_len;
-    if (config.address_family == AF_INET)
+    if (config._address_family == AF_INET)
         addr_len = sizeof(struct sockaddr_in);
-    else if (config.address_family == AF_INET6)
+    else if (config._address_family == AF_INET6)
         addr_len = sizeof(struct sockaddr_in6);
     else
     {
@@ -46,7 +46,7 @@ int ft_socket::setup_client(const SocketConfig &config)
         this->_socket_fd = -1;
         return (this->_error);
     }
-    if (!config.multicast_group.empty())
+    if (!config._multicast_group.empty())
         if (join_multicast_group(config) != ER_SUCCESS)
             return (this->_error);
     this->_error = ER_SUCCESS;

--- a/Networking/socket_class.cpp
+++ b/Networking/socket_class.cpp
@@ -188,9 +188,9 @@ ft_socket::ft_socket(int fd, const sockaddr_storage &addr) : _address(addr), _so
 
 ft_socket::ft_socket(const SocketConfig &config) : _socket_fd(-1), _error(ER_SUCCESS)
 {
-    if (config.type == SocketType::SERVER)
+    if (config._type == SocketType::SERVER)
         setup_server(config);
-    else if (config.type == SocketType::CLIENT)
+    else if (config._type == SocketType::CLIENT)
         setup_client(config);
     else
     {
@@ -333,9 +333,9 @@ int ft_socket::initialize(const SocketConfig &config)
         ft_errno = SOCKET_ALRDY_INITIALIZED;
         return (1);
     }
-    if (config.type == SocketType::SERVER)
+    if (config._type == SocketType::SERVER)
         setup_server(config);
-    else if (config.type == SocketType::CLIENT)
+    else if (config._type == SocketType::CLIENT)
         setup_client(config);
     else
     {

--- a/Template/deque.hpp
+++ b/Template/deque.hpp
@@ -16,9 +16,9 @@ class ft_deque
     private:
         struct DequeNode
         {
-            ElementType data;
-            DequeNode* prev;
-            DequeNode* next;
+            ElementType _data;
+            DequeNode* _prev;
+            DequeNode* _next;
         };
 
         DequeNode*   _front;
@@ -135,13 +135,13 @@ void ft_deque<ElementType>::push_front(const ElementType& value)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&node->data, value);
-    node->prev = ft_nullptr;
-    node->next = this->_front;
+    construct_at(&node->_data, value);
+    node->_prev = ft_nullptr;
+    node->_next = this->_front;
     if (this->_front == ft_nullptr)
         this->_back = node;
     else
-        this->_front->prev = node;
+        this->_front->_prev = node;
     this->_front = node;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -163,13 +163,13 @@ void ft_deque<ElementType>::push_front(ElementType&& value)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&node->data, std::move(value));
-    node->prev = ft_nullptr;
-    node->next = this->_front;
+    construct_at(&node->_data, std::move(value));
+    node->_prev = ft_nullptr;
+    node->_next = this->_front;
     if (this->_front == ft_nullptr)
         this->_back = node;
     else
-        this->_front->prev = node;
+        this->_front->_prev = node;
     this->_front = node;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -191,13 +191,13 @@ void ft_deque<ElementType>::push_back(const ElementType& value)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&node->data, value);
-    node->next = ft_nullptr;
-    node->prev = this->_back;
+    construct_at(&node->_data, value);
+    node->_next = ft_nullptr;
+    node->_prev = this->_back;
     if (this->_back == ft_nullptr)
         this->_front = node;
     else
-        this->_back->next = node;
+        this->_back->_next = node;
     this->_back = node;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -219,13 +219,13 @@ void ft_deque<ElementType>::push_back(ElementType&& value)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&node->data, std::move(value));
-    node->next = ft_nullptr;
-    node->prev = this->_back;
+    construct_at(&node->_data, std::move(value));
+    node->_next = ft_nullptr;
+    node->_prev = this->_back;
     if (this->_back == ft_nullptr)
         this->_front = node;
     else
-        this->_back->next = node;
+        this->_back->_next = node;
     this->_back = node;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -247,13 +247,13 @@ ElementType ft_deque<ElementType>::pop_front()
         return (ElementType());
     }
     DequeNode* node = this->_front;
-    this->_front = node->next;
+    this->_front = node->_next;
     if (this->_front == ft_nullptr)
         this->_back = ft_nullptr;
     else
-        this->_front->prev = ft_nullptr;
-    ElementType value = std::move(node->data);
-    destroy_at(&node->data);
+        this->_front->_prev = ft_nullptr;
+    ElementType value = std::move(node->_data);
+    destroy_at(&node->_data);
     cma_free(node);
     --this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -275,13 +275,13 @@ ElementType ft_deque<ElementType>::pop_back()
         return (ElementType());
     }
     DequeNode* node = this->_back;
-    this->_back = node->prev;
+    this->_back = node->_prev;
     if (this->_back == ft_nullptr)
         this->_front = ft_nullptr;
     else
-        this->_back->next = ft_nullptr;
-    ElementType value = std::move(node->data);
-    destroy_at(&node->data);
+        this->_back->_next = ft_nullptr;
+    ElementType value = std::move(node->_data);
+    destroy_at(&node->_data);
     cma_free(node);
     --this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -303,7 +303,7 @@ ElementType& ft_deque<ElementType>::front()
         this->_mutex.unlock(THREAD_ID);
         return (errorElement);
     }
-    ElementType& ref = this->_front->data;
+    ElementType& ref = this->_front->_data;
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -323,7 +323,7 @@ const ElementType& ft_deque<ElementType>::front() const
         this->_mutex.unlock(THREAD_ID);
         return (errorElement);
     }
-    ElementType& ref = this->_front->data;
+    ElementType& ref = this->_front->_data;
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -343,7 +343,7 @@ ElementType& ft_deque<ElementType>::back()
         this->_mutex.unlock(THREAD_ID);
         return (errorElement);
     }
-    ElementType& ref = this->_back->data;
+    ElementType& ref = this->_back->_data;
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -363,7 +363,7 @@ const ElementType& ft_deque<ElementType>::back() const
         this->_mutex.unlock(THREAD_ID);
         return (errorElement);
     }
-    ElementType& ref = this->_back->data;
+    ElementType& ref = this->_back->_data;
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -416,8 +416,8 @@ void ft_deque<ElementType>::clear()
     while (this->_front != ft_nullptr)
     {
         DequeNode* node = this->_front;
-        this->_front = this->_front->next;
-        destroy_at(&node->data);
+        this->_front = this->_front->_next;
+        destroy_at(&node->_data);
         cma_free(node);
     }
     this->_back = ft_nullptr;

--- a/Template/event_emitter.hpp
+++ b/Template/event_emitter.hpp
@@ -22,8 +22,8 @@ class ft_event_emitter
     private:
         struct Listener
         {
-            EventType event;
-            void (*callback)(Args...);
+            EventType _event;
+            void (*_callback)(Args...);
         };
 
         Listener*   _listeners;
@@ -181,10 +181,10 @@ void ft_event_emitter<EventType, Args...>::emit(const EventType& event, Args... 
     size_t i = 0;
     while (i < this->_size)
     {
-        if (this->_listeners[i].event == event)
+        if (this->_listeners[i]._event == event)
         {
             found = true;
-            this->_listeners[i].callback(args...);
+            this->_listeners[i]._callback(args...);
         }
         ++i;
     }
@@ -202,7 +202,7 @@ void ft_event_emitter<EventType, Args...>::remove_listener(const EventType& even
     size_t i = 0;
     while (i < this->_size)
     {
-        if (this->_listeners[i].event == event && this->_listeners[i].callback == cb)
+        if (this->_listeners[i]._event == event && this->_listeners[i]._callback == cb)
         {
             destroy_at(&this->_listeners[i]);
             size_t j = i;

--- a/Template/graph.hpp
+++ b/Template/graph.hpp
@@ -23,10 +23,10 @@ class ft_graph
     private:
         struct GraphNode
         {
-            VertexType  value;
-            size_t*     edges;
-            size_t      degree;
-            size_t      capacity;
+            VertexType  _value;
+            size_t*     _edges;
+            size_t      _degree;
+            size_t      _capacity;
         };
 
         GraphNode*   _nodes;
@@ -89,9 +89,9 @@ ft_graph<VertexType>::~ft_graph()
         size_t i = 0;
         while (i < this->_size)
         {
-            destroy_at(&this->_nodes[i].value);
-            if (this->_nodes[i].edges != ft_nullptr)
-                cma_free(this->_nodes[i].edges);
+            destroy_at(&this->_nodes[i]._value);
+            if (this->_nodes[i]._edges != ft_nullptr)
+                cma_free(this->_nodes[i]._edges);
             ++i;
         }
         cma_free(this->_nodes);
@@ -164,11 +164,11 @@ bool ft_graph<VertexType>::ensure_node_capacity(size_t desired)
     size_t i = 0;
     while (i < this->_size)
     {
-        construct_at(&newNodes[i].value, std::move(this->_nodes[i].value));
-        newNodes[i].edges = this->_nodes[i].edges;
-        newNodes[i].degree = this->_nodes[i].degree;
-        newNodes[i].capacity = this->_nodes[i].capacity;
-        destroy_at(&this->_nodes[i].value);
+        construct_at(&newNodes[i]._value, std::move(this->_nodes[i]._value));
+        newNodes[i]._edges = this->_nodes[i]._edges;
+        newNodes[i]._degree = this->_nodes[i]._degree;
+        newNodes[i]._capacity = this->_nodes[i]._capacity;
+        destroy_at(&this->_nodes[i]._value);
         ++i;
     }
     if (this->_nodes != ft_nullptr)
@@ -181,9 +181,9 @@ bool ft_graph<VertexType>::ensure_node_capacity(size_t desired)
 template <typename VertexType>
 bool ft_graph<VertexType>::ensure_edge_capacity(GraphNode& node, size_t desired)
 {
-    if (desired <= node.capacity)
+    if (desired <= node._capacity)
         return (true);
-    size_t newCap = (node.capacity == 0) ? 1 : node.capacity * 2;
+    size_t newCap = (node._capacity == 0) ? 1 : node._capacity * 2;
     while (newCap < desired)
         newCap *= 2;
     size_t* newEdges = static_cast<size_t*>(cma_malloc(sizeof(size_t) * newCap));
@@ -193,15 +193,15 @@ bool ft_graph<VertexType>::ensure_edge_capacity(GraphNode& node, size_t desired)
         return (false);
     }
     size_t i = 0;
-    while (i < node.degree)
+    while (i < node._degree)
     {
-        newEdges[i] = node.edges[i];
+        newEdges[i] = node._edges[i];
         ++i;
     }
-    if (node.edges != ft_nullptr)
-        cma_free(node.edges);
-    node.edges = newEdges;
-    node.capacity = newCap;
+    if (node._edges != ft_nullptr)
+        cma_free(node._edges);
+    node._edges = newEdges;
+    node._capacity = newCap;
     return (true);
 }
 
@@ -218,10 +218,10 @@ size_t ft_graph<VertexType>::add_vertex(const VertexType& value)
         this->_mutex.unlock(THREAD_ID);
         return (this->_size);
     }
-    construct_at(&this->_nodes[this->_size].value, value);
-    this->_nodes[this->_size].edges = ft_nullptr;
-    this->_nodes[this->_size].degree = 0;
-    this->_nodes[this->_size].capacity = 0;
+    construct_at(&this->_nodes[this->_size]._value, value);
+    this->_nodes[this->_size]._edges = ft_nullptr;
+    this->_nodes[this->_size]._degree = 0;
+    this->_nodes[this->_size]._capacity = 0;
     size_t idx = this->_size;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -241,10 +241,10 @@ size_t ft_graph<VertexType>::add_vertex(VertexType&& value)
         this->_mutex.unlock(THREAD_ID);
         return (this->_size);
     }
-    construct_at(&this->_nodes[this->_size].value, std::move(value));
-    this->_nodes[this->_size].edges = ft_nullptr;
-    this->_nodes[this->_size].degree = 0;
-    this->_nodes[this->_size].capacity = 0;
+    construct_at(&this->_nodes[this->_size]._value, std::move(value));
+    this->_nodes[this->_size]._edges = ft_nullptr;
+    this->_nodes[this->_size]._degree = 0;
+    this->_nodes[this->_size]._capacity = 0;
     size_t idx = this->_size;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -266,13 +266,13 @@ void ft_graph<VertexType>::add_edge(size_t from, size_t to)
         return ;
     }
     GraphNode& node = this->_nodes[from];
-    if (!ensure_edge_capacity(node, node.degree + 1))
+    if (!ensure_edge_capacity(node, node._degree + 1))
     {
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    node.edges[node.degree] = to;
-    ++node.degree;
+    node._edges[node._degree] = to;
+    ++node._degree;
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -311,11 +311,11 @@ void ft_graph<VertexType>::bfs(size_t start, Func visit)
     while (!q.empty())
     {
         size_t v = q.dequeue();
-        visit(this->_nodes[v].value);
+        visit(this->_nodes[v]._value);
         size_t j = 0;
-        while (j < this->_nodes[v].degree)
+        while (j < this->_nodes[v]._degree)
         {
-            size_t w = this->_nodes[v].edges[j];
+            size_t w = this->_nodes[v]._edges[j];
             if (!visited[w])
             {
                 visited[w] = true;
@@ -365,12 +365,12 @@ void ft_graph<VertexType>::dfs(size_t start, Func visit)
         if (visited[v])
             continue ;
         visited[v] = true;
-        visit(this->_nodes[v].value);
-        size_t j = this->_nodes[v].degree;
+        visit(this->_nodes[v]._value);
+        size_t j = this->_nodes[v]._degree;
         while (j > 0)
         {
             --j;
-            size_t w = this->_nodes[v].edges[j];
+            size_t w = this->_nodes[v]._edges[j];
             if (!visited[w])
                 st.push(w);
         }
@@ -428,13 +428,13 @@ void ft_graph<VertexType>::clear()
     size_t i = 0;
     while (i < this->_size)
     {
-        destroy_at(&this->_nodes[i].value);
-        if (this->_nodes[i].edges != ft_nullptr)
+        destroy_at(&this->_nodes[i]._value);
+        if (this->_nodes[i]._edges != ft_nullptr)
         {
-            cma_free(this->_nodes[i].edges);
-            this->_nodes[i].edges = ft_nullptr;
-            this->_nodes[i].degree = 0;
-            this->_nodes[i].capacity = 0;
+            cma_free(this->_nodes[i]._edges);
+            this->_nodes[i]._edges = ft_nullptr;
+            this->_nodes[i]._degree = 0;
+            this->_nodes[i]._capacity = 0;
         }
         ++i;
     }

--- a/Template/iterator.hpp
+++ b/Template/iterator.hpp
@@ -18,17 +18,17 @@ class Iterator
         ValueType& operator*() const;
 
     private:
-        ValueType* m_ptr;
+        ValueType* _ptr;
 };
 
 template <typename ValueType>
-Iterator<ValueType>::Iterator(ValueType* ptr) : m_ptr(ptr)
+Iterator<ValueType>::Iterator(ValueType* ptr) : _ptr(ptr)
 {
     return ;
 }
 
 template <typename ValueType>
-Iterator<ValueType>::Iterator(const Iterator& other) : m_ptr(other.m_ptr)
+Iterator<ValueType>::Iterator(const Iterator& other) : _ptr(other._ptr)
 {
     return ;
 }
@@ -37,14 +37,14 @@ template <typename ValueType>
 Iterator<ValueType>& Iterator<ValueType>::operator=(const Iterator& other)
 {
     if (this != &other)
-        m_ptr = other.m_ptr;
+        _ptr = other._ptr;
     return (*this);
 }
 
 template <typename ValueType>
-Iterator<ValueType>::Iterator(Iterator&& other) noexcept : m_ptr(other.m_ptr)
+Iterator<ValueType>::Iterator(Iterator&& other) noexcept : _ptr(other._ptr)
 {
-    other.m_ptr = ft_nullptr;
+    other._ptr = ft_nullptr;
         return ;
 }
 
@@ -53,8 +53,8 @@ Iterator<ValueType>& Iterator<ValueType>::operator=(Iterator&& other) noexcept
 {
     if (this != &other)
     {
-        m_ptr = other.m_ptr;
-        other.m_ptr = ft_nullptr;
+        _ptr = other._ptr;
+        other._ptr = ft_nullptr;
     }
     return (*this);
 }
@@ -62,20 +62,20 @@ Iterator<ValueType>& Iterator<ValueType>::operator=(Iterator&& other) noexcept
 template <typename ValueType>
 Iterator<ValueType> Iterator<ValueType>::operator++()
 {
-    ++m_ptr;
+    ++_ptr;
     return (*this);
 }
 
 template <typename ValueType>
 bool Iterator<ValueType>::operator!=(const Iterator& other) const
 {
-    return (m_ptr != other.m_ptr);
+    return (_ptr != other._ptr);
 }
 
 template <typename ValueType>
 ValueType& Iterator<ValueType>::operator*() const
 {
-    return (*m_ptr);
+    return (*_ptr);
 }
 
 #endif

--- a/Template/queue.hpp
+++ b/Template/queue.hpp
@@ -16,8 +16,8 @@ class ft_queue
     private:
         struct QueueNode
         {
-            ElementType data;
-            QueueNode* next;
+            ElementType _data;
+            QueueNode* _next;
         };
 
         QueueNode*  _front;
@@ -129,8 +129,8 @@ void ft_queue<ElementType>::enqueue(const ElementType& value)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&node->data, value);
-    node->next = ft_nullptr;
+    construct_at(&node->_data, value);
+    node->_next = ft_nullptr;
     if (this->_rear == ft_nullptr)
     {
         this->_front = node;
@@ -138,7 +138,7 @@ void ft_queue<ElementType>::enqueue(const ElementType& value)
     }
     else
     {
-        this->_rear->next = node;
+        this->_rear->_next = node;
         this->_rear = node;
     }
     ++this->_size;
@@ -161,8 +161,8 @@ void ft_queue<ElementType>::enqueue(ElementType&& value)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&node->data, std::move(value));
-    node->next = ft_nullptr;
+    construct_at(&node->_data, std::move(value));
+    node->_next = ft_nullptr;
     if (this->_rear == ft_nullptr)
     {
         this->_front = node;
@@ -170,7 +170,7 @@ void ft_queue<ElementType>::enqueue(ElementType&& value)
     }
     else
     {
-        this->_rear->next = node;
+        this->_rear->_next = node;
         this->_rear = node;
     }
     ++this->_size;
@@ -193,11 +193,11 @@ ElementType ft_queue<ElementType>::dequeue()
         return (ElementType());
     }
     QueueNode* node = this->_front;
-    this->_front = node->next;
+    this->_front = node->_next;
     if (this->_front == ft_nullptr)
         this->_rear = ft_nullptr;
-    ElementType value = std::move(node->data);
-    destroy_at(&node->data);
+    ElementType value = std::move(node->_data);
+    destroy_at(&node->_data);
     cma_free(node);
     --this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -219,7 +219,7 @@ ElementType& ft_queue<ElementType>::front()
         this->_mutex.unlock(THREAD_ID);
         return (errorElement);
     }
-    ElementType& ref = this->_front->data;
+    ElementType& ref = this->_front->_data;
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -239,7 +239,7 @@ const ElementType& ft_queue<ElementType>::front() const
         this->_mutex.unlock(THREAD_ID);
         return (errorElement);
     }
-    ElementType& ref = this->_front->data;
+    ElementType& ref = this->_front->_data;
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -292,8 +292,8 @@ void ft_queue<ElementType>::clear()
     while (this->_front != ft_nullptr)
     {
         QueueNode* node = this->_front;
-        this->_front = this->_front->next;
-        destroy_at(&node->data);
+        this->_front = this->_front->_next;
+        destroy_at(&node->_data);
         cma_free(node);
     }
     this->_rear = ft_nullptr;

--- a/Template/stack.hpp
+++ b/Template/stack.hpp
@@ -16,10 +16,10 @@ class ft_stack
     private:
         struct StackNode
         {
-            ElementType data;
-            StackNode* next;
+            ElementType _data;
+            StackNode* _next;
         };
-    
+
             StackNode*  _top;
             size_t      _size;
             mutable int _errorCode;
@@ -125,8 +125,8 @@ void ft_stack<ElementType>::push(const ElementType& value)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&newNode->data, value);
-    newNode->next = this->_top;
+    construct_at(&newNode->_data, value);
+    newNode->_next = this->_top;
     this->_top = newNode;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -148,8 +148,8 @@ void ft_stack<ElementType>::push(ElementType&& value)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&newNode->data, std::move(value));
-    newNode->next = this->_top;
+    construct_at(&newNode->_data, std::move(value));
+    newNode->_next = this->_top;
     this->_top = newNode;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -171,9 +171,9 @@ ElementType ft_stack<ElementType>::pop()
         return (ElementType());
     }
     StackNode* node = this->_top;
-    this->_top = node->next;
-    ElementType value = std::move(node->data);
-    destroy_at(&node->data);
+    this->_top = node->_next;
+    ElementType value = std::move(node->_data);
+    destroy_at(&node->_data);
     cma_free(node);
     --this->_size;
     this->_mutex.unlock(THREAD_ID);
@@ -195,7 +195,7 @@ ElementType& ft_stack<ElementType>::top()
         this->_mutex.unlock(THREAD_ID);
         return (errorElement);
     }
-    ElementType& ref = this->_top->data;
+    ElementType& ref = this->_top->_data;
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -215,7 +215,7 @@ const ElementType& ft_stack<ElementType>::top() const
         this->_mutex.unlock(THREAD_ID);
         return (errorElement);
     }
-    ElementType& ref = this->_top->data;
+    ElementType& ref = this->_top->_data;
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -268,8 +268,8 @@ void ft_stack<ElementType>::clear()
     while (this->_top != ft_nullptr)
     {
         StackNode* node = this->_top;
-        this->_top = this->_top->next;
-        destroy_at(&node->data);
+        this->_top = this->_top->_next;
+        destroy_at(&node->_data);
         cma_free(node);
     }
     this->_size = 0;

--- a/Test/test_networking.cpp
+++ b/Test/test_networking.cpp
@@ -6,15 +6,15 @@
 int test_network_send_receive(void)
 {
     SocketConfig server_conf;
-    server_conf.port = 54321;
-    server_conf.type = SocketType::SERVER;
+    server_conf._port = 54321;
+    server_conf._type = SocketType::SERVER;
     ft_socket server(server_conf);
     if (server.get_error() != ER_SUCCESS)
         return 0;
 
     SocketConfig client_conf;
-    client_conf.port = 54321;
-    client_conf.type = SocketType::CLIENT;
+    client_conf._port = 54321;
+    client_conf._type = SocketType::CLIENT;
     ft_socket client(client_conf);
     if (client.get_error() != ER_SUCCESS)
         return 0;
@@ -39,9 +39,9 @@ int test_network_send_receive(void)
 int test_network_invalid_ip(void)
 {
     SocketConfig conf;
-    conf.type = SocketType::SERVER;
-    conf.port = 54324;
-    conf.ip = "256.0.0.1";
+    conf._type = SocketType::SERVER;
+    conf._port = 54324;
+    conf._ip = "256.0.0.1";
     ft_socket server(conf);
     return (server.get_error() == SOCKET_INVALID_CONFIGURATION);
 }


### PR DESCRIPTION
## Summary
- Prefix member fields in core containers and utilities with `_`
- Align networking `SocketConfig` and TLS client structures to underscore convention
- Update tests and networking code to use new member names

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68b3fbc5e370833183bfd2440fbad2ea