### PR TITLE
Add authentication helpers to API requests and CLI flag parser

### DIFF
--- a/API/api.hpp
+++ b/API/api.hpp
@@ -2,37 +2,98 @@
 #define API_WRAPPER_HPP
 
 #include "../JSon/json.hpp"
+#include "../CPP_class/nullptr.hpp"
 #include <cstdint>
 #include <cstddef>
 
 char    *api_request_string(const char *ip, uint16_t port,
-        const char *method, const char *path, json_group *payload = NULL,
-        const char *headers = NULL, int *status = NULL,
+        const char *method, const char *path, json_group *payload = ft_nullptr,
+        const char *headers = ft_nullptr, int *status = ft_nullptr,
         int timeout = 60000);
 
+char    *api_request_string_bearer(const char *ip, uint16_t port,
+        const char *method, const char *path, const char *token,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+char    *api_request_string_basic(const char *ip, uint16_t port,
+        const char *method, const char *path, const char *credentials,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
 char    *api_request_string_tls(const char *host, uint16_t port,
-        const char *method, const char *path, json_group *payload = NULL,
-        const char *headers = NULL, int *status = NULL,
+        const char *method, const char *path, json_group *payload = ft_nullptr,
+        const char *headers = ft_nullptr, int *status = ft_nullptr,
         int timeout = 60000);
 
 char    *api_request_string_host(const char *host, uint16_t port,
-        const char *method, const char *path, json_group *payload = NULL,
-        const char *headers = NULL, int *status = NULL,
+        const char *method, const char *path, json_group *payload = ft_nullptr,
+        const char *headers = ft_nullptr, int *status = ft_nullptr,
         int timeout = 60000);
+
+char    *api_request_string_host_bearer(const char *host, uint16_t port,
+        const char *method, const char *path, const char *token,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+char    *api_request_string_host_basic(const char *host, uint16_t port,
+        const char *method, const char *path, const char *credentials,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
 
 json_group *api_request_json(const char *ip, uint16_t port,
-        const char *method, const char *path, json_group *payload = NULL,
-        const char *headers = NULL, int *status = NULL,
+        const char *method, const char *path, json_group *payload = ft_nullptr,
+        const char *headers = ft_nullptr, int *status = ft_nullptr,
         int timeout = 60000);
 
+json_group *api_request_json_bearer(const char *ip, uint16_t port,
+        const char *method, const char *path, const char *token,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+json_group *api_request_json_basic(const char *ip, uint16_t port,
+        const char *method, const char *path, const char *credentials,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
 json_group *api_request_json_tls(const char *host, uint16_t port,
-        const char *method, const char *path, json_group *payload = NULL,
-        const char *headers = NULL, int *status = NULL,
+        const char *method, const char *path, json_group *payload = ft_nullptr,
+        const char *headers = ft_nullptr, int *status = ft_nullptr,
         int timeout = 60000);
 
 json_group *api_request_json_host(const char *host, uint16_t port,
-        const char *method, const char *path, json_group *payload = NULL,
-        const char *headers = NULL, int *status = NULL,
+        const char *method, const char *path, json_group *payload = ft_nullptr,
+        const char *headers = ft_nullptr, int *status = ft_nullptr,
         int timeout = 60000);
+
+json_group *api_request_json_host_bearer(const char *host, uint16_t port,
+        const char *method, const char *path, const char *token,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+json_group *api_request_json_host_basic(const char *host, uint16_t port,
+        const char *method, const char *path, const char *credentials,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+char    *api_request_string_tls_bearer(const char *host, uint16_t port,
+        const char *method, const char *path, const char *token,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+json_group *api_request_json_tls_bearer(const char *host, uint16_t port,
+        const char *method, const char *path, const char *token,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+char    *api_request_string_tls_basic(const char *host, uint16_t port,
+        const char *method, const char *path, const char *credentials,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+json_group *api_request_json_tls_basic(const char *host, uint16_t port,
+        const char *method, const char *path, const char *credentials,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
 
 #endif

--- a/API/api_promise.hpp
+++ b/API/api_promise.hpp
@@ -9,8 +9,8 @@ class api_promise : public ft_promise<json_group*>
 public:
     bool request(const char *ip, uint16_t port,
                  const char *method, const char *path,
-                 json_group *payload = NULL,
-                 const char *headers = NULL, int *status = NULL,
+                 json_group *payload = ft_nullptr,
+                 const char *headers = ft_nullptr, int *status = ft_nullptr,
                  int timeout = 60000);
 };
 
@@ -19,8 +19,8 @@ class api_string_promise : public ft_promise<char*>
 public:
     bool request(const char *ip, uint16_t port,
                  const char *method, const char *path,
-                 json_group *payload = NULL,
-                 const char *headers = NULL, int *status = NULL,
+                 json_group *payload = ft_nullptr,
+                 const char *headers = ft_nullptr, int *status = ft_nullptr,
                  int timeout = 60000);
 };
 
@@ -29,8 +29,8 @@ class api_tls_promise : public ft_promise<json_group*>
 public:
     bool request(const char *host, uint16_t port,
                  const char *method, const char *path,
-                 json_group *payload = NULL,
-                 const char *headers = NULL, int *status = NULL,
+                 json_group *payload = ft_nullptr,
+                 const char *headers = ft_nullptr, int *status = ft_nullptr,
                  int timeout = 60000);
 };
 
@@ -39,8 +39,8 @@ class api_tls_string_promise : public ft_promise<char*>
 public:
     bool request(const char *host, uint16_t port,
                  const char *method, const char *path,
-                 json_group *payload = NULL,
-                 const char *headers = NULL, int *status = NULL,
+                 json_group *payload = ft_nullptr,
+                 const char *headers = ft_nullptr, int *status = ft_nullptr,
                  int timeout = 60000);
 };
 

--- a/API/api_request.cpp
+++ b/API/api_request.cpp
@@ -27,9 +27,9 @@ char *api_request_string(const char *ip, uint16_t port,
     config._recv_timeout = timeout;
     config._send_timeout = timeout;
 
-    ft_socket sock(config);
-    if (sock.get_error())
-        return (NULL);
+    ft_socket socket_wrapper(config);
+    if (socket_wrapper.get_error())
+        return (ft_nullptr);
 
     ft_string request(method);
     request += " ";
@@ -45,33 +45,33 @@ char *api_request_string(const char *ip, uint16_t port,
     ft_string body_string;
     if (payload)
     {
-        char *tmp = json_write_to_string(payload);
-        if (!tmp)
-            return (NULL);
-        body_string = tmp;
-        cma_free(tmp);
+        char *temporary_string = json_write_to_string(payload);
+        if (!temporary_string)
+            return (ft_nullptr);
+        body_string = temporary_string;
+        cma_free(temporary_string);
         request += "\r\nContent-Type: application/json";
-        char *len = cma_itoa(static_cast<int>(body_string.size()));
-        if (!len)
-            return (NULL);
+        char *length_string = cma_itoa(static_cast<int>(body_string.size()));
+        if (!length_string)
+            return (ft_nullptr);
         request += "\r\nContent-Length: ";
-        request += len;
-        cma_free(len);
+        request += length_string;
+        cma_free(length_string);
     }
     request += "\r\nConnection: close\r\n\r\n";
     if (payload)
         request += body_string.c_str();
 
-    if (sock.send_all(request.c_str(), request.size(), 0) < 0)
-        return (NULL);
+    if (socket_wrapper.send_all(request.c_str(), request.size(), 0) < 0)
+        return (ft_nullptr);
 
     char buffer[1024];
     ft_string response;
-    ssize_t bytes;
+    ssize_t bytes_received;
 
-    while ((bytes = sock.receive_data(buffer, sizeof(buffer) - 1, 0)) > 0)
+    while ((bytes_received = socket_wrapper.receive_data(buffer, sizeof(buffer) - 1, 0)) > 0)
     {
-        buffer[bytes] = '\0';
+        buffer[bytes_received] = '\0';
         response += buffer;
     }
     if (status)
@@ -83,7 +83,7 @@ char *api_request_string(const char *ip, uint16_t port,
     }
     const char *body = strstr(response.c_str(), "\r\n\r\n");
     if (!body)
-        return (NULL);
+        return (ft_nullptr);
     body += 4;
     return (cma_strdup(body));
 }
@@ -95,7 +95,7 @@ json_group *api_request_json(const char *ip, uint16_t port,
     char *body = api_request_string(ip, port, method, path, payload,
                                    headers, status, timeout);
     if (!body)
-        return (NULL);
+        return (ft_nullptr);
     json_group *result = json_read_from_string(body);
     cma_free(body);
     return (result);
@@ -106,48 +106,51 @@ char *api_request_string_host(const char *host, uint16_t port,
     const char *headers, int *status, int timeout)
 {
     struct addrinfo hints;
-    struct addrinfo *res = NULL;
-    struct addrinfo *p;
-    int sock = -1;
+    struct addrinfo *address_results = ft_nullptr;
+    struct addrinfo *address_info;
+    int socket_fd = -1;
     ft_string request;
     ft_string body_string;
     ft_string response;
-    char *ret = NULL;
+    char *result = ft_nullptr;
     char buffer[1024];
-    ssize_t bytes;
-    const char *body = NULL;
-    char port_str[6];
+    ssize_t bytes_received;
+    const char *body = ft_nullptr;
+    char port_string[6];
 
     if (!host || !method || !path)
-        return (NULL);
+        return (ft_nullptr);
     ft_bzero(&hints, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_family = AF_UNSPEC;
-    std::snprintf(port_str, sizeof(port_str), "%u", port);
-    if (getaddrinfo(host, port_str, &hints, &res) != 0)
+    std::snprintf(port_string, sizeof(port_string), "%u", port);
+    if (getaddrinfo(host, port_string, &hints, &address_results) != 0)
         goto cleanup;
 
-    for (p = res; p != NULL; p = p->ai_next)
+    address_info = address_results;
+    while (address_info != ft_nullptr)
     {
-        sock = nw_socket(p->ai_family, p->ai_socktype, p->ai_protocol);
-        if (sock < 0)
-            continue;
-        if (timeout > 0)
+        socket_fd = nw_socket(address_info->ai_family, address_info->ai_socktype, address_info->ai_protocol);
+        if (socket_fd >= 0)
         {
-            struct timeval tv;
-            tv.tv_sec = timeout / 1000;
-            tv.tv_usec = (timeout % 1000) * 1000;
-            setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-            setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+            if (timeout > 0)
+            {
+                struct timeval tv;
+                tv.tv_sec = timeout / 1000;
+                tv.tv_usec = (timeout % 1000) * 1000;
+                setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+                setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+            }
+            if (nw_connect(socket_fd, address_info->ai_addr, static_cast<socklen_t>(address_info->ai_addrlen)) == 0)
+                break;
+            FT_CLOSE_SOCKET(socket_fd);
+            socket_fd = -1;
         }
-        if (nw_connect(sock, p->ai_addr, static_cast<socklen_t>(p->ai_addrlen)) == 0)
-            break;
-        FT_CLOSE_SOCKET(sock);
-        sock = -1;
+        address_info = address_info->ai_next;
     }
-    freeaddrinfo(res);
-    res = NULL;
-    if (sock < 0)
+    freeaddrinfo(address_results);
+    address_results = ft_nullptr;
+    if (socket_fd < 0)
         goto cleanup;
 
     request = method;
@@ -162,29 +165,29 @@ char *api_request_string_host(const char *host, uint16_t port,
     }
     if (payload)
     {
-        char *tmp = json_write_to_string(payload);
-        if (!tmp)
+        char *temporary_string = json_write_to_string(payload);
+        if (!temporary_string)
             goto cleanup;
-        body_string = tmp;
-        cma_free(tmp);
+        body_string = temporary_string;
+        cma_free(temporary_string);
         request += "\r\nContent-Type: application/json";
-        char *len = cma_itoa(static_cast<int>(body_string.size()));
-        if (!len)
+        char *length_string = cma_itoa(static_cast<int>(body_string.size()));
+        if (!length_string)
             goto cleanup;
         request += "\r\nContent-Length: ";
-        request += len;
-        cma_free(len);
+        request += length_string;
+        cma_free(length_string);
     }
     request += "\r\nConnection: close\r\n\r\n";
     if (payload)
         request += body_string.c_str();
 
-    if (nw_send(sock, request.c_str(), request.size(), 0) < 0)
+    if (nw_send(socket_fd, request.c_str(), request.size(), 0) < 0)
         goto cleanup;
 
-    while ((bytes = nw_recv(sock, buffer, sizeof(buffer) - 1, 0)) > 0)
+    while ((bytes_received = nw_recv(socket_fd, buffer, sizeof(buffer) - 1, 0)) > 0)
     {
-        buffer[bytes] = '\0';
+        buffer[bytes_received] = '\0';
         response += buffer;
     }
     if (status)
@@ -198,14 +201,14 @@ char *api_request_string_host(const char *host, uint16_t port,
     if (!body)
         goto cleanup;
     body += 4;
-    ret = cma_strdup(body);
+    result = cma_strdup(body);
 
 cleanup:
-    if (sock >= 0)
-        FT_CLOSE_SOCKET(sock);
-    if (res)
-        freeaddrinfo(res);
-    return (ret);
+    if (socket_fd >= 0)
+        FT_CLOSE_SOCKET(socket_fd);
+    if (address_results)
+        freeaddrinfo(address_results);
+    return (result);
 }
 
 json_group *api_request_json_host(const char *host, uint16_t port,
@@ -215,7 +218,136 @@ json_group *api_request_json_host(const char *host, uint16_t port,
     char *body = api_request_string_host(host, port, method, path, payload,
                                         headers, status, timeout);
     if (!body)
-        return (NULL);
+        return (ft_nullptr);
+    json_group *result = json_read_from_string(body);
+    cma_free(body);
+    return (result);
+}
+
+char *api_request_string_bearer(const char *ip, uint16_t port,
+    const char *method, const char *path, const char *token,
+    json_group *payload, const char *headers, int *status, int timeout)
+{
+    if (!token)
+        return (api_request_string(ip, port, method, path, payload,
+                                   headers, status, timeout));
+    ft_string header_string;
+    if (headers && headers[0])
+    {
+        header_string = headers;
+        header_string += "\r\n";
+    }
+    header_string += "Authorization: Bearer ";
+    header_string += token;
+    return (api_request_string(ip, port, method, path, payload,
+                               header_string.c_str(), status, timeout));
+}
+
+json_group *api_request_json_bearer(const char *ip, uint16_t port,
+    const char *method, const char *path, const char *token,
+    json_group *payload, const char *headers, int *status, int timeout)
+{
+    char *body = api_request_string_bearer(ip, port, method, path, token,
+                                           payload, headers, status, timeout);
+    if (!body)
+        return (ft_nullptr);
+    json_group *result = json_read_from_string(body);
+    cma_free(body);
+    return (result);
+}
+
+char *api_request_string_basic(const char *ip, uint16_t port,
+    const char *method, const char *path, const char *credentials,
+    json_group *payload, const char *headers, int *status, int timeout)
+{
+    if (!credentials)
+        return (api_request_string(ip, port, method, path, payload,
+                                   headers, status, timeout));
+    ft_string header_string;
+    if (headers && headers[0])
+    {
+        header_string = headers;
+        header_string += "\r\n";
+    }
+    header_string += "Authorization: Basic ";
+    header_string += credentials;
+    return (api_request_string(ip, port, method, path, payload,
+                               header_string.c_str(), status, timeout));
+}
+
+json_group *api_request_json_basic(const char *ip, uint16_t port,
+    const char *method, const char *path, const char *credentials,
+    json_group *payload, const char *headers, int *status, int timeout)
+{
+    char *body = api_request_string_basic(ip, port, method, path, credentials,
+                                          payload, headers, status, timeout);
+    if (!body)
+        return (ft_nullptr);
+    json_group *result = json_read_from_string(body);
+    cma_free(body);
+    return (result);
+}
+
+char *api_request_string_host_bearer(const char *host, uint16_t port,
+    const char *method, const char *path, const char *token,
+    json_group *payload, const char *headers, int *status, int timeout)
+{
+    if (!token)
+        return (api_request_string_host(host, port, method, path, payload,
+                                        headers, status, timeout));
+    ft_string header_string;
+    if (headers && headers[0])
+    {
+        header_string = headers;
+        header_string += "\r\n";
+    }
+    header_string += "Authorization: Bearer ";
+    header_string += token;
+    return (api_request_string_host(host, port, method, path, payload,
+                                    header_string.c_str(), status, timeout));
+}
+
+json_group *api_request_json_host_bearer(const char *host, uint16_t port,
+    const char *method, const char *path, const char *token,
+    json_group *payload, const char *headers, int *status, int timeout)
+{
+    char *body = api_request_string_host_bearer(host, port, method, path, token,
+                                                payload, headers, status, timeout);
+    if (!body)
+        return (ft_nullptr);
+    json_group *result = json_read_from_string(body);
+    cma_free(body);
+    return (result);
+}
+
+char *api_request_string_host_basic(const char *host, uint16_t port,
+    const char *method, const char *path, const char *credentials,
+    json_group *payload, const char *headers, int *status, int timeout)
+{
+    if (!credentials)
+        return (api_request_string_host(host, port, method, path, payload,
+                                        headers, status, timeout));
+    ft_string header_string;
+    if (headers && headers[0])
+    {
+        header_string = headers;
+        header_string += "\r\n";
+    }
+    header_string += "Authorization: Basic ";
+    header_string += credentials;
+    return (api_request_string_host(host, port, method, path, payload,
+                                    header_string.c_str(), status, timeout));
+}
+
+json_group *api_request_json_host_basic(const char *host, uint16_t port,
+    const char *method, const char *path, const char *credentials,
+    json_group *payload, const char *headers, int *status, int timeout)
+{
+    char *body = api_request_string_host_basic(host, port, method, path,
+                                               credentials, payload, headers,
+                                               status, timeout);
+    if (!body)
+        return (ft_nullptr);
     json_group *result = json_read_from_string(body);
     cma_free(body);
     return (result);

--- a/API/api_tls_client.cpp
+++ b/API/api_tls_client.cpp
@@ -32,11 +32,11 @@ static ssize_t ssl_send_all(SSL *ssl, const void *data, size_t size)
 }
 
 api_tls_client::api_tls_client(const char *host_c, uint16_t port, int timeout_ms)
-: _ctx(NULL), _ssl(NULL), _sock(-1), _host(host_c ? host_c : ""), _timeout(timeout_ms)
+: _ctx(ft_nullptr), _ssl(ft_nullptr), _sock(-1), _host(host_c ? host_c : ""), _timeout(timeout_ms)
 {
     if (!host_c)
         return;
-    if (!OPENSSL_init_ssl(0, NULL))
+    if (!OPENSSL_init_ssl(0, ft_nullptr))
         return;
 
     _ctx = SSL_CTX_new(TLS_client_method());
@@ -44,36 +44,39 @@ api_tls_client::api_tls_client(const char *host_c, uint16_t port, int timeout_ms
         return;
 
     struct addrinfo hints;
-    struct addrinfo *res = NULL;
-    struct addrinfo *p;
+    struct addrinfo *address_results = ft_nullptr;
+    struct addrinfo *address_info;
     ft_bzero(&hints, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_family = AF_UNSPEC;
-    char port_str[6];
-    std::snprintf(port_str, sizeof(port_str), "%u", port);
-    if (getaddrinfo(host_c, port_str, &hints, &res) != 0)
+    char port_string[6];
+    std::snprintf(port_string, sizeof(port_string), "%u", port);
+    if (getaddrinfo(host_c, port_string, &hints, &address_results) != 0)
         return;
 
-    for (p = res; p != NULL; p = p->ai_next)
+    address_info = address_results;
+    while (address_info != ft_nullptr)
     {
-        _sock = nw_socket(p->ai_family, p->ai_socktype, p->ai_protocol);
-        if (_sock < 0)
-            continue;
-        if (timeout_ms > 0)
+        _sock = nw_socket(address_info->ai_family, address_info->ai_socktype, address_info->ai_protocol);
+        if (_sock >= 0)
         {
-            struct timeval tv;
-            tv.tv_sec = timeout_ms / 1000;
-            tv.tv_usec = (timeout_ms % 1000) * 1000;
-            setsockopt(_sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-            setsockopt(_sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+            if (timeout_ms > 0)
+            {
+                struct timeval time_value;
+                time_value.tv_sec = timeout_ms / 1000;
+                time_value.tv_usec = (timeout_ms % 1000) * 1000;
+                setsockopt(_sock, SOL_SOCKET, SO_RCVTIMEO, &time_value, sizeof(time_value));
+                setsockopt(_sock, SOL_SOCKET, SO_SNDTIMEO, &time_value, sizeof(time_value));
+            }
+            if (nw_connect(_sock, address_info->ai_addr, static_cast<socklen_t>(address_info->ai_addrlen)) == 0)
+                break;
+            FT_CLOSE_SOCKET(_sock);
+            _sock = -1;
         }
-        if (nw_connect(_sock, p->ai_addr, static_cast<socklen_t>(p->ai_addrlen)) == 0)
-            break;
-        FT_CLOSE_SOCKET(_sock);
-        _sock = -1;
+        address_info = address_info->ai_next;
     }
-    if (res)
-        freeaddrinfo(res);
+    if (address_results)
+        freeaddrinfo(address_results);
     if (_sock < 0)
         return;
 
@@ -85,7 +88,7 @@ api_tls_client::api_tls_client(const char *host_c, uint16_t port, int timeout_ms
     if (SSL_connect(_ssl) <= 0)
     {
         SSL_free(_ssl);
-        _ssl = NULL;
+        _ssl = ft_nullptr;
         return;
     }
 }
@@ -105,14 +108,14 @@ api_tls_client::~api_tls_client()
 
 bool api_tls_client::is_valid() const
 {
-    return (_ssl != NULL);
+    return (_ssl != ft_nullptr);
 }
 
 char *api_tls_client::request(const char *method, const char *path, json_group *payload,
                               const char *headers, int *status)
 {
     if (!_ssl || !method || !path)
-        return (NULL);
+        return (ft_nullptr);
 
     ft_string request(method);
     request += " ";
@@ -128,66 +131,66 @@ char *api_tls_client::request(const char *method, const char *path, json_group *
     ft_string body_string;
     if (payload)
     {
-        char *tmp = json_write_to_string(payload);
-        if (!tmp)
-            return (NULL);
-        body_string = tmp;
-        cma_free(tmp);
+        char *temporary_string = json_write_to_string(payload);
+        if (!temporary_string)
+            return (ft_nullptr);
+        body_string = temporary_string;
+        cma_free(temporary_string);
         request += "\r\nContent-Type: application/json";
-        char *len = cma_itoa(static_cast<int>(body_string.size()));
-        if (!len)
-            return (NULL);
+        char *length_string = cma_itoa(static_cast<int>(body_string.size()));
+        if (!length_string)
+            return (ft_nullptr);
         request += "\r\nContent-Length: ";
-        request += len;
-        cma_free(len);
+        request += length_string;
+        cma_free(length_string);
     }
     request += "\r\nConnection: keep-alive\r\n\r\n";
     if (payload)
         request += body_string.c_str();
 
     if (ssl_send_all(_ssl, request.c_str(), request.size()) < 0)
-        return (NULL);
+        return (ft_nullptr);
 
-    ft_string resp;
+    ft_string response;
     char buffer[1024];
-    ssize_t bytes;
-    const char *header_end_ptr = NULL;
+    ssize_t bytes_received;
+    const char *header_end_ptr = ft_nullptr;
 
     while (!header_end_ptr)
     {
-        bytes = nw_ssl_read(_ssl, buffer, sizeof(buffer) - 1);
-        if (bytes <= 0)
-            return (NULL);
-        buffer[bytes] = '\0';
-        resp += buffer;
-        header_end_ptr = strstr(resp.c_str(), "\r\n\r\n");
+        bytes_received = nw_ssl_read(_ssl, buffer, sizeof(buffer) - 1);
+        if (bytes_received <= 0)
+            return (ft_nullptr);
+        buffer[bytes_received] = '\0';
+        response += buffer;
+        header_end_ptr = strstr(response.c_str(), "\r\n\r\n");
     }
 
     if (status)
     {
         *status = -1;
-        const char *space = strchr(resp.c_str(), ' ');
+        const char *space = strchr(response.c_str(), ' ');
         if (space)
             *status = ft_atoi(space + 1);
     }
 
-    size_t header_len = static_cast<size_t>(header_end_ptr - resp.c_str()) + 4;
+    size_t header_len = static_cast<size_t>(header_end_ptr - response.c_str()) + 4;
     size_t content_length = 0;
-    const char *cl = strstr(resp.c_str(), "Content-Length:");
-    if (cl)
+    const char *content_length_ptr = strstr(response.c_str(), "Content-Length:");
+    if (content_length_ptr)
     {
-        cl += strlen("Content-Length:");
-        while (*cl == ' ') cl++;
-        content_length = static_cast<size_t>(ft_atoi(cl));
+        content_length_ptr += strlen("Content-Length:");
+        while (*content_length_ptr == ' ') content_length_ptr++;
+        content_length = static_cast<size_t>(ft_atoi(content_length_ptr));
     }
 
-    ft_string body(resp.c_str() + header_len);
+    ft_string body(response.c_str() + header_len);
     while (body.size() < content_length)
     {
-        bytes = nw_ssl_read(_ssl, buffer, sizeof(buffer) - 1);
-        if (bytes <= 0)
-            return (NULL);
-        buffer[bytes] = '\0';
+        bytes_received = nw_ssl_read(_ssl, buffer, sizeof(buffer) - 1);
+        if (bytes_received <= 0)
+            return (ft_nullptr);
+        buffer[bytes_received] = '\0';
         body += buffer;
     }
 
@@ -200,7 +203,7 @@ json_group *api_tls_client::request_json(const char *method, const char *path,
 {
     char *body = request(method, path, payload, headers, status);
     if (!body)
-        return (NULL);
+        return (ft_nullptr);
     json_group *result = json_read_from_string(body);
     cma_free(body);
     return (result);

--- a/API/api_tls_client.hpp
+++ b/API/api_tls_client.hpp
@@ -3,6 +3,7 @@
 
 #include "../JSon/json.hpp"
 #include "../CPP_class/string_class.hpp"
+#include "../CPP_class/nullptr.hpp"
 #include <openssl/ssl.h>
 #include <cstdint>
 
@@ -20,12 +21,12 @@ public:
     ~api_tls_client();
     bool is_valid() const;
 
-    char *request(const char *method, const char *path, json_group *payload = NULL,
-                  const char *headers = NULL, int *status = NULL);
+    char *request(const char *method, const char *path, json_group *payload = ft_nullptr,
+                  const char *headers = ft_nullptr, int *status = ft_nullptr);
 
     json_group *request_json(const char *method, const char *path,
-                             json_group *payload = NULL,
-                             const char *headers = NULL, int *status = NULL);
+                             json_group *payload = ft_nullptr,
+                             const char *headers = ft_nullptr, int *status = ft_nullptr);
 };
 
 #endif

--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -10,16 +10,16 @@ char    *cma_strdup(const char *string) __attribute__ ((warn_unused_result));
 void    *cma_memdup(const void *source, size_t size) __attribute__ ((warn_unused_result));
 void    *cma_calloc(std::size_t, std::size_t size) __attribute__ ((warn_unused_result));
 void    *cma_realloc(void* ptr, std::size_t new_size) __attribute__ ((warn_unused_result));
-char    **cma_split(char const *s, char c) __attribute__ ((warn_unused_result));
-char    *cma_itoa(int n) __attribute__ ((warn_unused_result));
-char    *cma_itoa_base(int n, int base) __attribute__ ((warn_unused_result));
+char    **cma_split(char const *string, char delimiter) __attribute__ ((warn_unused_result));
+char    *cma_itoa(int number) __attribute__ ((warn_unused_result));
+char    *cma_itoa_base(int number, int base) __attribute__ ((warn_unused_result));
 char    *cma_strjoin(char const *string_1, char const *string_2)
             __attribute__ ((warn_unused_result));
 char    *cma_strjoin_multiple(int count, ...)
             __attribute__ ((warn_unused_result));
-char    *cma_substr(const char *s, unsigned int start, size_t len)
+char    *cma_substr(const char *source, unsigned int start, size_t length)
             __attribute__ ((warn_unused_result));
-char    *cma_strtrim(const char *s1, const char *set)
+char    *cma_strtrim(const char *string, const char *set)
             __attribute__ ((warn_unused_result));
 void    cma_free_double(char **content);
 void    cma_cleanup();

--- a/CMA/cma_calloc.cpp
+++ b/CMA/cma_calloc.cpp
@@ -1,5 +1,6 @@
 #include <cstddef>
 #include <stdbool.h>
+#include "../CPP_class/nullptr.hpp"
 #include "CMA.hpp"
 
 void    *cma_calloc(std::size_t count, std::size_t size)
@@ -9,11 +10,11 @@ void    *cma_calloc(std::size_t count, std::size_t size)
     char            *char_ptr;
 
     if (count <= 0 || size <= 0)
-        return (NULL);
+        return (ft_nullptr);
     total_size = count * size;
     ptr = cma_malloc(total_size);
     if (!ptr)
-        return (NULL);
+        return (ft_nullptr);
     char_ptr = static_cast<char*>(ptr);
     std::size_t index = 0;
     while (index < total_size)

--- a/CMA/cma_free_double.cpp
+++ b/CMA/cma_free_double.cpp
@@ -2,15 +2,15 @@
 
 void    cma_free_double(char **content)
 {
-    int    i;
+    int    index;
 
-    i = 0;
+    index = 0;
     if (content)
     {
-        while (content[i])
+        while (content[index])
         {
-            cma_free(content[i]);
-            i++;
+            cma_free(content[index]);
+            index++;
         }
         cma_free(content);
     }

--- a/CMA/cma_itoa.cpp
+++ b/CMA/cma_itoa.cpp
@@ -1,67 +1,67 @@
 #include "CMA.hpp"
 #include "../CPP_class/nullptr.hpp"
 
-static int    itoa_len(int n)
+static int    itoa_length(int number)
 {
-    int        i;
+    int        length;
 
-    i = 0;
-    if (n == 0)
+    length = 0;
+    if (number == 0)
         return (1);
-    while (n)
+    while (number)
     {
-        n /= 10;
-        i++;
+        number /= 10;
+        length++;
     }
-    return (i);
+    return (length);
 }
 
-static char *fill_digits(char *c, unsigned int num, int start_index)
+static char *fill_digits(char *characters, unsigned int number, int start_index)
 {
     while (start_index >= 0)
     {
-        c[start_index] = static_cast<char>((num % 10) + '0');
-        num /= 10;
+        characters[start_index] = static_cast<char>((number % 10) + '0');
+        number /= 10;
         start_index--;
     }
-    return (c);
+    return (characters);
 }
 
-static char    *convert_int(int n, int is_negative)
+static char    *convert_int(int number, int is_negative)
 {
-    int                i;
-    char            *c;
-    unsigned int    num;
+    int                length;
+    char            *result;
+    unsigned int    absolute_value;
 
-    i = itoa_len(n);
-    c = static_cast<char *>(cma_malloc(i + 1 + is_negative));
-    if (!c)
+    length = itoa_length(number);
+    result = static_cast<char *>(cma_malloc(length + 1 + is_negative));
+    if (!result)
         return (ft_nullptr);
-    if (n < 0)
-        num = -n;
+    if (number < 0)
+        absolute_value = -number;
     else
-        num = n;
-    c[i + is_negative] = '\0';
+        absolute_value = number;
+    result[length + is_negative] = '\0';
     if (is_negative == 0)
-        c = fill_digits(c, num, i - 1);
+        result = fill_digits(result, absolute_value, length - 1);
     else
-        c = fill_digits(c, num, i);
+        result = fill_digits(result, absolute_value, length);
     if (is_negative == 1)
-        c[0] = '-';
-    return (c);
+        result[0] = '-';
+    return (result);
 }
 
-char    *cma_itoa(int n)
+char    *cma_itoa(int number)
 {
     int    is_negative;
 
-    if (n > 0)
+    if (number > 0)
         is_negative = 0;
-    else if (n == -2147483648)
+    else if (number == -2147483648)
         return (cma_strdup("-2147483648"));
-    else if (n == 0)
+    else if (number == 0)
         return (cma_strdup("0"));
     else
         is_negative = 1;
-    return (convert_int(n, is_negative));
+    return (convert_int(number, is_negative));
 }

--- a/CMA/cma_itoa_base.cpp
+++ b/CMA/cma_itoa_base.cpp
@@ -1,45 +1,45 @@
 #include "CMA.hpp"
 #include "../CPP_class/nullptr.hpp"
 
-static int    calculate_length(int n, int base)
+static int    calculate_length(int number, int base)
 {
-    int len = 0;
-    unsigned int num = (n < 0) ? -n : n;
-    if (num == 0)
+    int length = 0;
+    unsigned int absolute_value = (number < 0) ? -number : number;
+    if (absolute_value == 0)
         return (1);
-    while (num)
+    while (absolute_value)
     {
-        num /= base;
-        len++;
+        absolute_value /= base;
+        length++;
     }
-    return (len);
+    return (length);
 }
 
-char    *cma_itoa_base(int n, int base)
+char    *cma_itoa_base(int number, int base)
 {
     const char digits[] = "0123456789ABCDEF";
-    int negative = 0;
-    int len;
-    char *str;
-    unsigned int num;
+    int is_negative = 0;
+    int length;
+    char *result_string;
+    unsigned int absolute_value;
 
     if (base < 2 || base > 16)
         return (ft_nullptr);
-    if (n < 0 && base == 10)
-        negative = 1;
-    num = (n < 0) ? -n : n;
-    len = calculate_length(n, base);
-    str = static_cast<char*>(cma_malloc(len + negative + 1));
-    if (!str)
+    if (number < 0 && base == 10)
+        is_negative = 1;
+    absolute_value = (number < 0) ? -number : number;
+    length = calculate_length(number, base);
+    result_string = static_cast<char*>(cma_malloc(length + is_negative + 1));
+    if (!result_string)
         return (ft_nullptr);
-    str[len + negative] = '\0';
-    while (len > 0)
+    result_string[length + is_negative] = '\0';
+    while (length > 0)
     {
-        str[len + negative - 1] = digits[num % base];
-        num /= base;
-        len--;
+        result_string[length + is_negative - 1] = digits[absolute_value % base];
+        absolute_value /= base;
+        length--;
     }
-    if (negative)
-        str[0] = '-';
-    return (str);
+    if (is_negative)
+        result_string[0] = '-';
+    return (result_string);
 }

--- a/CMA/cma_split.cpp
+++ b/CMA/cma_split.cpp
@@ -1,115 +1,115 @@
 #include "CMA.hpp"
 #include "../CPP_class/nullptr.hpp"
 
-static int    ft_count_words(const char *s, char c)
+static int    ft_count_words(const char *string, char delimiter)
 {
-    int    words;
-    int    i;
+    int    word_count;
+    int    index;
 
-    words = 0;
-    i = 0;
-    while (s[i])
+    word_count = 0;
+    index = 0;
+    while (string[index])
     {
-        if (i == 0 && s[i] != c)
-            words++;
-        if (i > 0 && s[i] != c && s[i - 1] == c)
-            words++;
-        i++;
+        if (index == 0 && string[index] != delimiter)
+            word_count++;
+        if (index > 0 && string[index] != delimiter && string[index - 1] == delimiter)
+            word_count++;
+        index++;
     }
-    return (words);
+    return (word_count);
 }
 
-static char    **ft_malloc_strs(char **strs, const char *s, char c)
+static char    **ft_malloc_strings(char **strings, const char *string, char delimiter)
 {
-    int    count;
-    int    i;
-    int    x;
+    int    char_count;
+    int    index;
+    int    array_index;
 
-    count = 0;
-    i = 0;
-    x = 0;
-    while (s[i])
+    char_count = 0;
+    index = 0;
+    array_index = 0;
+    while (string[index])
     {
-        if (s[i] != c)
-            count++;
-        if ((s[i] == c && i > 0 && s[i - 1] != c)
-            || (s[i] != c && s[i + 1] == '\0'))
+        if (string[index] != delimiter)
+            char_count++;
+        if ((string[index] == delimiter && index > 0 && string[index - 1] != delimiter)
+            || (string[index] != delimiter && string[index + 1] == '\0'))
         {
-            strs[x] = static_cast<char *>(cma_malloc(sizeof(char) * (count + 1)));
-            if (!strs[x])
+            strings[array_index] = static_cast<char *>(cma_malloc(sizeof(char) * (char_count + 1)));
+            if (!strings[array_index])
                 return (ft_nullptr);
-            count = 0;
-            x++;
+            char_count = 0;
+            array_index++;
         }
-        i++;
+        index++;
     }
-    return (strs);
+    return (strings);
 }
 
-static char    **ft_cpy_strs(char **strs, const char *s, char c)
+static char    **ft_copy_strings(char **strings, const char *string, char delimiter)
 {
-    int    i;
-    int    x;
-    int    y;
+    int    index;
+    int    array_index;
+    int    string_index;
 
-    i = 0;
-    x = 0;
-    y = 0;
-    while (s[i])
+    index = 0;
+    array_index = 0;
+    string_index = 0;
+    while (string[index])
     {
-        if (s[i] != c)
-            strs[x][y++] = s[i];
-        if (s[i] != c && s[i + 1] == '\0')
-            strs[x][y] = '\0';
-        if (s[i] == c && i > 0 && s[i - 1] != c)
+        if (string[index] != delimiter)
+            strings[array_index][string_index++] = string[index];
+        if (string[index] != delimiter && string[index + 1] == '\0')
+            strings[array_index][string_index] = '\0';
+        if (string[index] == delimiter && index > 0 && string[index - 1] != delimiter)
         {
-            strs[x][y] = '\0';
-            x++;
-            y = 0;
+            strings[array_index][string_index] = '\0';
+            array_index++;
+            string_index = 0;
         }
-        i++;
+        index++;
     }
-    return (strs);
+    return (strings);
 }
 
-static char    **ft_merror(char **strs)
+static char    **ft_memory_error(char **strings)
 {
-    int    i;
+    int    index;
 
-    i = 0;
-    while (strs[i])
+    index = 0;
+    while (strings[index])
     {
-        cma_free(strs[i]);
-        strs[i] = ft_nullptr;
-        i++;
+        cma_free(strings[index]);
+        strings[index] = ft_nullptr;
+        index++;
     }
-    cma_free(strs);
+    cma_free(strings);
     return (ft_nullptr);
 }
 
-char    **cma_split(char const *s, char c)
+char    **cma_split(char const *string, char delimiter)
 {
-    char    **strs;
-    int        wordcount;
+    char    **strings;
+    int        word_count;
 
-    if (!s)
+    if (!string)
     {
-        strs = static_cast<char **>(cma_malloc(sizeof(char) * 1));
-        if (!strs)
+        strings = static_cast<char **>(cma_malloc(sizeof(char) * 1));
+        if (!strings)
             return (ft_nullptr);
-        *strs = ft_nullptr;
-        return (strs);
+        *strings = ft_nullptr;
+        return (strings);
     }
-    wordcount = ft_count_words(s, c);
-    strs = static_cast<char **>(cma_malloc(sizeof(*strs) * (wordcount + 1)));
-    if (!strs)
+    word_count = ft_count_words(string, delimiter);
+    strings = static_cast<char **>(cma_malloc(sizeof(*strings) * (word_count + 1)));
+    if (!strings)
         return (ft_nullptr);
-    if (ft_malloc_strs(strs, s, c))
+    if (ft_malloc_strings(strings, string, delimiter))
     {
-        ft_cpy_strs(strs, s, c);
-        strs[wordcount] = ft_nullptr;
+        ft_copy_strings(strings, string, delimiter);
+        strings[word_count] = ft_nullptr;
     }
     else
-        strs = ft_merror(strs);
-    return (strs);
+        strings = ft_memory_error(strings);
+    return (strings);
 }

--- a/CMA/cma_strdup.cpp
+++ b/CMA/cma_strdup.cpp
@@ -1,27 +1,28 @@
 #include <stddef.h>
 #include <stdbool.h>
+#include "../CPP_class/nullptr.hpp"
 #include "CMA.hpp"
 
 char    *cma_strdup(const char *string)
 {
-    int        len;
+    int        length;
     char    *new_string;
-    int        i;
+    int        index;
 
     if (!string)
-        return (NULL);
-    len = 0;
-    while (string[len])
-        len++;
-    len++;
-    new_string = static_cast<char *>(cma_malloc(len));
+        return (ft_nullptr);
+    length = 0;
+    while (string[length])
+        length++;
+    length++;
+    new_string = static_cast<char *>(cma_malloc(length));
     if (!new_string)
-        return (NULL);
-    i = 0;
-    while (i < len)
+        return (ft_nullptr);
+    index = 0;
+    while (index < length)
     {
-        new_string[i] = string[i];
-        i++;
+        new_string[index] = string[index];
+        index++;
     }
     return (new_string);
 }

--- a/CMA/cma_strjoin.cpp
+++ b/CMA/cma_strjoin.cpp
@@ -4,37 +4,37 @@
 
 static char    *allocate_new_string(const char *string_1, const char *string_2)
 {
-    int        total_len;
-    char    *new_str;
+    int        total_length;
+    char    *new_string;
 
-    total_len = 0;
+    total_length = 0;
     if (string_1)
-        total_len += ft_strlen(string_1);
+        total_length += ft_strlen(string_1);
     if (string_2)
-        total_len += ft_strlen(string_2);
-    new_str = static_cast<char *>(cma_malloc(total_len + 1));
-    if (!new_str)
+        total_length += ft_strlen(string_2);
+    new_string = static_cast<char *>(cma_malloc(total_length + 1));
+    if (!new_string)
         return (ft_nullptr);
-    return (new_str);
+    return (new_string);
 }
 
 char    *cma_strjoin(char const *string_1, char const *string_2)
 {
     char    *result;
-    int        i;
+    int        index;
 
     if (!string_1 && !string_2)
         return (ft_nullptr);
     result = allocate_new_string(string_1, string_2);
     if (!result)
         return (ft_nullptr);
-    i = 0;
+    index = 0;
     if (string_1)
         while (string_1[0])
-            result[i++] = *string_1++;
+            result[index++] = *string_1++;
     if (string_2)
         while (string_2[0])
-            result[i++] = *string_2++;
-    result[i] = '\0';
+            result[index++] = *string_2++;
+    result[index] = '\0';
     return (result);
 }

--- a/CMA/cma_strjoin_multiple.cpp
+++ b/CMA/cma_strjoin_multiple.cpp
@@ -9,30 +9,34 @@ char    *cma_strjoin_multiple(int count, ...)
         return (ft_nullptr);
     va_list args;
     va_start(args, count);
-    size_t total_len = 0;
-    for (int i = 0; i < count; ++i)
+    size_t total_length = 0;
+    int argument_index = 0;
+    while (argument_index < count)
     {
-        const char *str = va_arg(args, const char *);
-        if (str)
-            total_len += ft_strlen(str);
+        const char *current_string = va_arg(args, const char *);
+        if (current_string)
+            total_length += ft_strlen(current_string);
+        ++argument_index;
     }
     va_end(args);
-    char *result = static_cast<char*>(cma_malloc(total_len + 1));
+    char *result = static_cast<char*>(cma_malloc(total_length + 1));
     if (!result)
         return (ft_nullptr);
     va_start(args, count);
-    size_t index = 0;
-    for (int i = 0; i < count; ++i)
+    size_t result_index = 0;
+    argument_index = 0;
+    while (argument_index < count)
     {
-        const char *str = va_arg(args, const char *);
-        if (str)
+        const char *current_string = va_arg(args, const char *);
+        if (current_string)
         {
-            size_t len = ft_strlen(str);
-            ft_memcpy(result + index, str, len);
-            index += len;
+            size_t current_length = ft_strlen(current_string);
+            ft_memcpy(result + result_index, current_string, current_length);
+            result_index += current_length;
         }
+        ++argument_index;
     }
     va_end(args);
-    result[index] = '\0';
+    result[result_index] = '\0';
     return (result);
 }

--- a/CMA/cma_strtrim.cpp
+++ b/CMA/cma_strtrim.cpp
@@ -2,37 +2,37 @@
 #include "../Libft/libft.hpp"
 #include "../CPP_class/nullptr.hpp"
 
-static bool is_in_set(char c, const char *set)
+static bool is_in_set(char character, const char *set)
 {
     while (set && *set)
     {
-        if (*set == c)
+        if (*set == character)
             return (true);
         ++set;
     }
     return (false);
 }
 
-char    *cma_strtrim(const char *s1, const char *set)
+char    *cma_strtrim(const char *input_string, const char *set)
 {
-    if (!s1 || !set)
+    if (!input_string || !set)
         return (ft_nullptr);
     size_t start = 0;
-    size_t end = ft_strlen_size_t(s1);
-    while (s1[start] && is_in_set(s1[start], set))
+    size_t end = ft_strlen_size_t(input_string);
+    while (input_string[start] && is_in_set(input_string[start], set))
         ++start;
-    while (end > start && is_in_set(s1[end - 1], set))
+    while (end > start && is_in_set(input_string[end - 1], set))
         --end;
-    size_t len = end - start;
-    char *trimmed = static_cast<char *>(cma_malloc(len + 1));
+    size_t length = end - start;
+    char *trimmed = static_cast<char *>(cma_malloc(length + 1));
     if (!trimmed)
         return (ft_nullptr);
-    size_t i = 0;
-    while (i < len)
+    size_t index = 0;
+    while (index < length)
     {
-        trimmed[i] = s1[start + i];
-        ++i;
+        trimmed[index] = input_string[start + index];
+        ++index;
     }
-    trimmed[i] = '\0';
+    trimmed[index] = '\0';
     return (trimmed);
 }

--- a/CMA/cma_substr.cpp
+++ b/CMA/cma_substr.cpp
@@ -2,28 +2,28 @@
 #include "../Libft/libft.hpp"
 #include "../CPP_class/nullptr.hpp"
 
-char    *cma_substr(const char *s, unsigned int start, size_t len)
+char    *cma_substr(const char *source, unsigned int start, size_t length)
 {
-    size_t  s_len;
-    size_t  i;
-    char    *sub;
+    size_t  source_length;
+    size_t  index;
+    char    *substring;
 
-    if (!s)
+    if (!source)
         return (ft_nullptr);
-    s_len = ft_strlen(s);
-    if (start >= s_len)
+    source_length = ft_strlen(source);
+    if (start >= source_length)
         return (cma_strdup(""));
-    if (len > s_len - start)
-        len = s_len - start;
-    sub = static_cast<char *>(cma_malloc(len + 1));
-    if (!sub)
+    if (length > source_length - start)
+        length = source_length - start;
+    substring = static_cast<char *>(cma_malloc(length + 1));
+    if (!substring)
         return (ft_nullptr);
-    i = 0;
-    while (i < len && s[start + i])
+    index = 0;
+    while (index < length && source[start + index])
     {
-        sub[i] = s[start + i];
-        i++;
+        substring[index] = source[start + index];
+        index++;
     }
-    sub[i] = '\0';
-    return (sub);
+    substring[index] = '\0';
+    return (substring);
 }

--- a/CMA/cma_utils.cpp
+++ b/CMA/cma_utils.cpp
@@ -180,7 +180,7 @@ static inline void print_block_info_impl(Block *block)
 #else
     if (!block)
     {
-        pf_printf_fd(2, "Block pointer is NULL.\n");
+        pf_printf_fd(2, "Block pointer is ft_nullptr.\n");
         return ;
     }
     const char* free_status = block->free ? "Yes" : "No";

--- a/CPP_class/file.cpp
+++ b/CPP_class/file.cpp
@@ -137,7 +137,7 @@ const char *ft_file::get_error_str() const noexcept
 
 ssize_t ft_file::read(char *buffer, int count) noexcept
 {
-    if (buffer == NULL || count <= 0)
+    if (buffer == ft_nullptr || count <= 0)
     {
         this->set_error(FT_EINVAL);
         return (-1);

--- a/Config/Makefile
+++ b/Config/Makefile
@@ -1,7 +1,8 @@
 TARGET := config.a
 DEBUG_TARGET := config_debug.a
 
-SRCS :=         config_parse.cpp
+SRCS :=         config_parse.cpp \
+                config_flags.cpp
 
 HEADERS := config.hpp
 

--- a/Config/config.hpp
+++ b/Config/config.hpp
@@ -19,5 +19,7 @@ struct ft_config
 
 ft_config   *ft_config_parse(const char *filename);
 void        ft_config_free(ft_config *config);
+char       *ft_config_parse_flags(int argc, char **argv);
+char      **ft_config_parse_long_flags(int argc, char **argv);
 
 #endif

--- a/Config/config_flags.cpp
+++ b/Config/config_flags.cpp
@@ -1,0 +1,115 @@
+#include "config.hpp"
+#include "../Errno/errno.hpp"
+#include "../CMA/CMA.hpp"
+#include "../Libft/libft.hpp"
+#include <cstring>
+#include <cctype>
+
+char *ft_config_parse_flags(int argc, char **argv)
+{
+    if (argc <= 1 || !argv)
+        return ft_nullptr;
+    char   *flags = ft_nullptr;
+    size_t  length = 0;
+    int argument_index = 1;
+    while (argument_index < argc)
+    {
+        char *argument = argv[argument_index];
+        if (!argument || argument[0] != '-' || argument[1] == '-' || argument[1] == '\0')
+        {
+            ++argument_index;
+            continue;
+        }
+        int char_index = 1;
+        while (argument[char_index])
+        {
+            char current_flag = argument[char_index];
+            if (std::isalpha(static_cast<unsigned char>(current_flag)))
+            {
+                if (!flags || !std::strchr(flags, current_flag))
+                {
+                    char *new_flags = static_cast<char*>(cma_realloc(flags, length + 2));
+                    if (!new_flags)
+                    {
+                        ft_errno = FT_EALLOC;
+                        cma_free(flags);
+                        return ft_nullptr;
+                    }
+                    flags = new_flags;
+                    flags[length++] = current_flag;
+                    flags[length] = '\0';
+                }
+            }
+            ++char_index;
+        }
+        ++argument_index;
+    }
+    return flags;
+}
+
+char **ft_config_parse_long_flags(int argc, char **argv)
+{
+    if (argc <= 1 || !argv)
+        return ft_nullptr;
+    char  **flags = ft_nullptr;
+    size_t  count = 0;
+    int argument_index = 1;
+    while (argument_index < argc)
+    {
+        char *argument = argv[argument_index];
+        if (!argument || argument[0] != '-' || argument[1] != '-' || argument[2] == '\0')
+        {
+            ++argument_index;
+            continue;
+        }
+        const char *flag_string = argument + 2;
+        bool exists = false;
+        size_t flag_index = 0;
+        while (flag_index < count)
+        {
+            if (std::strcmp(flags[flag_index], flag_string) == 0)
+            {
+                exists = true;
+                break;
+            }
+            ++flag_index;
+        }
+        if (exists)
+        {
+            ++argument_index;
+            continue;
+        }
+        char **new_flags = static_cast<char**>(cma_realloc(flags, (count + 2) * sizeof(char*)));
+        if (!new_flags)
+        {
+            ft_errno = FT_EALLOC;
+            size_t free_index = 0;
+            while (free_index < count)
+            {
+                cma_free(flags[free_index]);
+                ++free_index;
+            }
+            cma_free(flags);
+            return ft_nullptr;
+        }
+        flags = new_flags;
+        flags[count] = cma_strdup(flag_string);
+        if (!flags[count])
+        {
+            ft_errno = FT_EALLOC;
+            size_t free_index = 0;
+            while (free_index < count)
+            {
+                cma_free(flags[free_index]);
+                ++free_index;
+            }
+            cma_free(flags);
+            return ft_nullptr;
+        }
+        count++;
+        flags[count] = ft_nullptr;
+        ++argument_index;
+    }
+    return flags;
+}
+

--- a/Config/config_parse.cpp
+++ b/Config/config_parse.cpp
@@ -6,28 +6,30 @@
 #include <cstring>
 #include <cctype>
 
-static char *trim_whitespace(char *str)
+static char *trim_whitespace(char *string)
 {
-    if (!str)
-        return str;
-    while (*str && std::isspace(static_cast<unsigned char>(*str)))
-        str++;
-    char *end = str + std::strlen(str);
-    while (end > str && std::isspace(static_cast<unsigned char>(end[-1])))
-        end--;
-    *end = '\0';
-    return str;
+    if (!string)
+        return string;
+    while (*string && std::isspace(static_cast<unsigned char>(*string)))
+        string++;
+    char *end_pointer = string + std::strlen(string);
+    while (end_pointer > string && std::isspace(static_cast<unsigned char>(end_pointer[-1])))
+        end_pointer--;
+    *end_pointer = '\0';
+    return string;
 }
 
 void ft_config_free(ft_config *config)
 {
     if (!config)
         return ;
-    for (size_t i = 0; i < config->entry_count; ++i)
+    size_t entry_index = 0;
+    while (entry_index < config->entry_count)
     {
-        cma_free(config->entries[i].section);
-        cma_free(config->entries[i].key);
-        cma_free(config->entries[i].value);
+        cma_free(config->entries[entry_index].section);
+        cma_free(config->entries[entry_index].key);
+        cma_free(config->entries[entry_index].value);
+        ++entry_index;
     }
     cma_free(config->entries);
     cma_free(config);
@@ -52,17 +54,17 @@ ft_config *ft_config_parse(const char *filename)
     char *current_section = ft_nullptr;
     while (std::fgets(buffer, sizeof(buffer), file))
     {
-        char *line = trim_whitespace(buffer);
-        if (*line == '\0' || *line == ';' || *line == '#')
+        char *line_string = trim_whitespace(buffer);
+        if (*line_string == '\0' || *line_string == ';' || *line_string == '#')
             continue ;
-        if (*line == '[')
+        if (*line_string == '[')
         {
-            char *close = std::strchr(line, ']');
-            if (close)
+            char *closing_bracket = std::strchr(line_string, ']');
+            if (closing_bracket)
             {
-                *close = '\0';
+                *closing_bracket = '\0';
                 cma_free(current_section);
-                current_section = cma_strdup(line + 1);
+                current_section = cma_strdup(line_string + 1);
                 if (!current_section)
                 {
                     ft_errno = FT_EALLOC;
@@ -73,17 +75,17 @@ ft_config *ft_config_parse(const char *filename)
             }
             continue ;
         }
-        char *eq = std::strchr(line, '=');
+        char *equals_sign = std::strchr(line_string, '=');
         char *key = ft_nullptr;
         char *value = ft_nullptr;
-        if (eq)
+        if (equals_sign)
         {
-            *eq = '\0';
-            char *k = trim_whitespace(line);
-            char *v = trim_whitespace(eq + 1);
-            if (*k)
+            *equals_sign = '\0';
+            char *key_start = trim_whitespace(line_string);
+            char *value_start = trim_whitespace(equals_sign + 1);
+            if (*key_start)
             {
-                key = cma_strdup(k);
+                key = cma_strdup(key_start);
                 if (!key)
                 {
                     ft_errno = FT_EALLOC;
@@ -95,9 +97,9 @@ ft_config *ft_config_parse(const char *filename)
                     return ft_nullptr;
                 }
             }
-            if (*v)
+            if (*value_start)
             {
-                value = cma_strdup(v);
+                value = cma_strdup(value_start);
                 if (!value)
                 {
                     ft_errno = FT_EALLOC;
@@ -112,10 +114,10 @@ ft_config *ft_config_parse(const char *filename)
         }
         else
         {
-            char *k = trim_whitespace(line);
-            if (*k)
+            char *key_start = trim_whitespace(line_string);
+            if (*key_start)
             {
-                key = cma_strdup(k);
+                key = cma_strdup(key_start);
                 if (!key)
                 {
                     ft_errno = FT_EALLOC;

--- a/Game/experience_table.cpp
+++ b/Game/experience_table.cpp
@@ -40,10 +40,12 @@ bool ft_experience_table::is_valid(int count, const int *array) const noexcept
 {
     if (!array || count <= 1)
         return (true);
-    for (int i = 1; i < count; i++)
+    int index = 1;
+    while (index < count)
     {
-        if (array[i] <= array[i - 1])
+        if (array[index] <= array[index - 1])
             return (false);
+        ++index;
     }
     return (true);
 }
@@ -74,8 +76,12 @@ int ft_experience_table::resize(int new_count) noexcept
     }
     if (new_count > old_count)
     {
-        for (int i = old_count; i < new_count; i++)
-            new_levels[i] = 0;
+        int index = old_count;
+        while (index < new_count)
+        {
+            new_levels[index] = 0;
+            ++index;
+        }
     }
     this->_levels = new_levels;
     this->_count = new_count;
@@ -89,10 +95,10 @@ int ft_experience_table::get_level(int experience) const noexcept
 {
     if (!this->_levels || this->_count == 0)
         return (0);
-    int lvl = 0;
-    while (lvl < this->_count && experience >= this->_levels[lvl])
-        ++lvl;
-    return (lvl);
+    int level = 0;
+    while (level < this->_count && experience >= this->_levels[level])
+        ++level;
+    return (level);
 }
 
 int ft_experience_table::get_value(int index) const noexcept
@@ -125,8 +131,12 @@ int ft_experience_table::set_levels(const int *levels, int count) noexcept
         return (this->resize(0));
     if (this->resize(count) != ER_SUCCESS)
         return (this->_error);
-    for (int i = 0; i < count; ++i)
-        this->_levels[i] = levels[i];
+    int level_index = 0;
+    while (level_index < count)
+    {
+        this->_levels[level_index] = levels[level_index];
+        ++level_index;
+    }
     if (!this->is_valid(this->_count, this->_levels))
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
     return (this->_error);
@@ -141,10 +151,12 @@ int ft_experience_table::generate_levels_total(int count, int base,
     if (this->resize(count) != ER_SUCCESS)
         return (this->_error);
     double value = static_cast<double>(base);
-    for (int i = 0; i < count; ++i)
+    int level_index = 0;
+    while (level_index < count)
     {
-        this->_levels[i] = static_cast<int>(value);
+        this->_levels[level_index] = static_cast<int>(value);
         value *= multiplier;
+        ++level_index;
     }
     if (!this->is_valid(this->_count, this->_levels))
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
@@ -162,11 +174,13 @@ int ft_experience_table::generate_levels_scaled(int count, int base,
     double increment = static_cast<double>(base);
     double total = static_cast<double>(base);
     this->_levels[0] = static_cast<int>(total);
-    for (int i = 1; i < count; ++i)
+    int index = 1;
+    while (index < count)
     {
         increment *= multiplier;
         total += increment;
-        this->_levels[i] = static_cast<int>(total);
+        this->_levels[index] = static_cast<int>(total);
+        ++index;
     }
     if (!this->is_valid(this->_count, this->_levels))
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
@@ -177,14 +191,16 @@ int ft_experience_table::check_for_error() const noexcept
 {
     if (!this->_levels)
         return (0);
-    for (int i = 1; i < this->_count; i++)
+    int index = 1;
+    while (index < this->_count)
     {
-        if (this->_levels[i] <= this->_levels[i - 1])
+        if (this->_levels[index] <= this->_levels[index - 1])
         {
             const_cast<ft_experience_table*>(this)->set_error
                 (CHARACTER_LEVEL_TABLE_INVALID);
-            return (this->_levels[i]);
+            return (this->_levels[index]);
         }
+        ++index;
     }
     return (0);
 }

--- a/Game/map3d.cpp
+++ b/Game/map3d.cpp
@@ -98,9 +98,14 @@ void ft_map3d::allocate(size_t width, size_t height, size_t depth, int value)
         this->set_error(MAP3D_ALLOC_FAIL);
         return ;
     }
-    for (size_t z = 0; z < depth; z++)
+    size_t z = 0;
+    while (z < depth)
+    {
         this->_data[z] = ft_nullptr;
-    for (size_t z = 0; z < depth; z++)
+        ++z;
+    }
+    z = 0;
+    while (z < depth)
     {
         this->_data[z] = static_cast<int**>(cma_malloc(sizeof(int*) * height));
         if (!this->_data[z])
@@ -109,9 +114,14 @@ void ft_map3d::allocate(size_t width, size_t height, size_t depth, int value)
             this->deallocate();
             return ;
         }
-        for (size_t y = 0; y < height; y++)
+        size_t y = 0;
+        while (y < height)
+        {
             this->_data[z][y] = ft_nullptr;
-        for (size_t y = 0; y < height; y++)
+            ++y;
+        }
+        y = 0;
+        while (y < height)
         {
             this->_data[z][y] = static_cast<int*>(cma_malloc(sizeof(int) * width));
             if (!this->_data[z][y])
@@ -120,9 +130,15 @@ void ft_map3d::allocate(size_t width, size_t height, size_t depth, int value)
                 this->deallocate();
                 return ;
             }
-            for (size_t x = 0; x < width; x++)
+            size_t x = 0;
+            while (x < width)
+            {
                 this->_data[z][y][x] = value;
+                ++x;
+            }
+            ++y;
         }
+        ++z;
     }
     return ;
 }
@@ -131,11 +147,17 @@ void ft_map3d::deallocate()
 {
     if (!this->_data)
         return ;
-    for (size_t z = 0; z < this->_depth; z++)
+    size_t z = 0;
+    while (z < this->_depth)
     {
-        for (size_t y = 0; y < this->_height; y++)
+        size_t y = 0;
+        while (y < this->_height)
+        {
             cma_free(this->_data[z][y]);
+            ++y;
+        }
         cma_free(this->_data[z]);
+        ++z;
     }
     cma_free(this->_data);
     this->_data = ft_nullptr;

--- a/GetNextLine/get_next_line.cpp
+++ b/GetNextLine/get_next_line.cpp
@@ -4,39 +4,39 @@
 #include <cstdio>
 #include "get_next_line.hpp"
 
-static char* allocate_new_string(char* string_1, char* string_2)
+static char* allocate_new_string(char* string_one, char* string_two)
 {
-    int total_len = 0;
-    char* new_str;
+    int total_length = 0;
+    char* new_string;
 
-    if (string_1)
-        total_len += ft_strlen(string_1);
-    if (string_2)
-        total_len += ft_strlen(string_2);
-    new_str = static_cast<char*>(cma_malloc(total_len + 1));
-    if (!new_str)
+    if (string_one)
+        total_length += ft_strlen(string_one);
+    if (string_two)
+        total_length += ft_strlen(string_two);
+    new_string = static_cast<char*>(cma_malloc(total_length + 1));
+    if (!new_string)
         return (ft_nullptr);
-    return (new_str);
+    return (new_string);
 }
 
-char* ft_strjoin_gnl(char* string_1, char* string_2)
+char* ft_strjoin_gnl(char* string_one, char* string_two)
 {
     char* result;
-    char* original_string = string_1;
+    char* original_string = string_one;
     int index;
 
-    if (!string_1 && !string_2)
+    if (!string_one && !string_two)
         return (ft_nullptr);
-    result = allocate_new_string(string_1, string_2);
+    result = allocate_new_string(string_one, string_two);
     if (!result)
         return (ft_nullptr);
     index = 0;
-    if (string_1)
-        while (*string_1)
-            result[index++] = *string_1++;
-    if (string_2)
-        while (*string_2)
-            result[index++] = *string_2++;
+    if (string_one)
+        while (*string_one)
+            result[index++] = *string_one++;
+    if (string_two)
+        while (*string_two)
+            result[index++] = *string_two++;
     result[index] = '\0';
     cma_free(original_string);
     return (result);
@@ -66,14 +66,14 @@ static char* leftovers(char* readed_string)
     return (string);
 }
 
-static char* malloc_gnl(char* readed_string, size_t i)
+static char* malloc_gnl(char* readed_string, size_t length)
 {
     char* string;
 
-    if (readed_string && readed_string[i] == '\n')
-        string = static_cast<char*>(cma_malloc(i + 2));
+    if (readed_string && readed_string[length] == '\n')
+        string = static_cast<char*>(cma_malloc(length + 2));
     else
-        string = static_cast<char*>(cma_malloc(i + 1));
+        string = static_cast<char*>(cma_malloc(length + 1));
     if (!string)
         return (ft_nullptr);
     return (string);

--- a/HTML/html_string_writer.cpp
+++ b/HTML/html_string_writer.cpp
@@ -33,8 +33,12 @@ static char *html_indent(int indent)
     char *result = static_cast<char*>(cma_calloc(spaces + 1, sizeof(char)));
     if (!result)
         return (ft_nullptr);
-    for (int index = 0; index < spaces; ++index)
+    int index = 0;
+    while (index < spaces)
+    {
         result[index] = ' ';
+        ++index;
+    }
     return (result);
 }
 

--- a/HTML/html_writer.cpp
+++ b/HTML/html_writer.cpp
@@ -14,8 +14,12 @@ static void html_write_attrs(int fd, html_attr *attribute)
 
 static void html_write_node(int fd, html_node *htmlNode, int indent)
 {
-    for (int i = 0; i < indent; ++i)
+    int indent_index = 0;
+    while (indent_index < indent)
+    {
         pf_printf_fd(fd, "  ");
+        ++indent_index;
+    }
     pf_printf_fd(fd, "<%s", htmlNode->tag);
     html_write_attrs(fd, htmlNode->attributes);
     if (!htmlNode->text && !htmlNode->children)
@@ -35,8 +39,12 @@ static void html_write_node(int fd, html_node *htmlNode, int indent)
             html_write_node(fd, childNode, indent + 1);
             childNode = childNode->next;
         }
-        for (int i = 0; i < indent; ++i)
+        int indent_index = 0;
+        while (indent_index < indent)
+        {
             pf_printf_fd(fd, "  ");
+            ++indent_index;
+        }
     }
     pf_printf_fd(fd, "</%s>\n", htmlNode->tag);
 }

--- a/JSon/json_reader.cpp
+++ b/JSon/json_reader.cpp
@@ -5,114 +5,122 @@
 #include "../CMA/CMA.hpp"
 #include "../CPP_class/nullptr.hpp"
 
-static void skip_ws(const char *s, size_t &i)
+static void skip_whitespace(const char *json_string, size_t &index)
 {
-    while (s[i] && std::isspace(static_cast<unsigned char>(s[i])))
-        i++;
+    while (json_string[index]
+        && std::isspace(static_cast<unsigned char>(json_string[index])))
+        index++;
     return ;
 }
 
-static char *parse_string(const char *s, size_t &i)
+static char *parse_string(const char *json_string, size_t &index)
 {
-    size_t len = ft_strlen_size_t(s);
-    if (i >= len || s[i] != '"')
+    size_t length = ft_strlen_size_t(json_string);
+    if (index >= length || json_string[index] != '"')
         return (ft_nullptr);
-    i++;
-    size_t start = i;
-    while (i < len && s[i] != '"')
-        i++;
-    char *result = cma_substr(s, static_cast<unsigned int>(start), i - start);
-    if (i < len && s[i] == '"')
-        i++;
+    index++;
+    size_t start_index = index;
+    while (index < length && json_string[index] != '"')
+        index++;
+    char *result = cma_substr(json_string,
+                               static_cast<unsigned int>(start_index),
+                               index - start_index);
+    if (index < length && json_string[index] == '"')
+        index++;
     return (result);
 }
 
-static char *parse_number(const char *s, size_t &i)
+static char *parse_number(const char *json_string, size_t &index)
 {
-    size_t len = ft_strlen_size_t(s);
-    size_t start = i;
-    if (i < len && (s[i] == '-' || s[i] == '+'))
-        i++;
+    size_t length = ft_strlen_size_t(json_string);
+    size_t start_index = index;
+    if (index < length && (json_string[index] == '-' || json_string[index] == '+'))
+        index++;
     bool has_digits = false;
-    while (i < len && std::isdigit(static_cast<unsigned char>(s[i])))
+    while (index < length
+        && std::isdigit(static_cast<unsigned char>(json_string[index])))
     {
-        i++;
+        index++;
         has_digits = true;
     }
-    if (i < len && s[i] == '.')
+    if (index < length && json_string[index] == '.')
     {
-        i++;
-        while (i < len && std::isdigit(static_cast<unsigned char>(s[i])))
-            i++;
+        index++;
+        while (index < length
+            && std::isdigit(static_cast<unsigned char>(json_string[index])))
+            index++;
     }
-    if (i < len && (s[i] == 'e' || s[i] == 'E'))
+    if (index < length && (json_string[index] == 'e' || json_string[index] == 'E'))
     {
-        i++;
-        if (i < len && (s[i] == '-' || s[i] == '+'))
-            i++;
-        while (i < len && std::isdigit(static_cast<unsigned char>(s[i])))
-            i++;
+        index++;
+        if (index < length && (json_string[index] == '-' || json_string[index] == '+'))
+            index++;
+        while (index < length
+            && std::isdigit(static_cast<unsigned char>(json_string[index])))
+            index++;
     }
     if (!has_digits)
         return (ft_nullptr);
-    return (cma_substr(s, static_cast<unsigned int>(start), i - start));
+    return (cma_substr(json_string, static_cast<unsigned int>(start_index),
+                       index - start_index));
 }
 
-static char *parse_value(const char *s, size_t &i)
+static char *parse_value(const char *json_string, size_t &index)
 {
-    skip_ws(s, i);
-    size_t len = ft_strlen_size_t(s);
-    if (i >= len)
+    skip_whitespace(json_string, index);
+    size_t length = ft_strlen_size_t(json_string);
+    if (index >= length)
         return (ft_nullptr);
-    if (s[i] == '"')
-        return (parse_string(s, i));
-    if (len - i >= 4 && ft_strncmp(s + i, "true", 4) == 0)
+    if (json_string[index] == '"')
+        return (parse_string(json_string, index));
+    if (length - index >= 4 && ft_strncmp(json_string + index, "true", 4) == 0)
     {
-        i += 4;
+        index += 4;
         return (cma_strdup("true"));
     }
-    if (len - i >= 5 && ft_strncmp(s + i, "false", 5) == 0)
+    if (length - index >= 5 && ft_strncmp(json_string + index, "false", 5) == 0)
     {
-        i += 5;
+        index += 5;
         return (cma_strdup("false"));
     }
-    if (std::isdigit(static_cast<unsigned char>(s[i])) || s[i] == '-' || s[i] == '+')
-        return (parse_number(s, i));
+    if (std::isdigit(static_cast<unsigned char>(json_string[index]))
+        || json_string[index] == '-' || json_string[index] == '+')
+        return (parse_number(json_string, index));
     return (ft_nullptr);
 }
 
-static json_item *parse_items(const char *s, size_t &i)
+static json_item *parse_items(const char *json_string, size_t &index)
 {
-    size_t len = ft_strlen_size_t(s);
+    size_t length = ft_strlen_size_t(json_string);
     json_item *head = ft_nullptr;
     json_item *tail = ft_nullptr;
-    skip_ws(s, i);
-    if (i >= len || s[i] != '{')
+    skip_whitespace(json_string, index);
+    if (index >= length || json_string[index] != '{')
         return (ft_nullptr);
-    i++;
-    while (i < len)
+    index++;
+    while (index < length)
     {
-        skip_ws(s, i);
-        if (i < len && s[i] == '}')
+        skip_whitespace(json_string, index);
+        if (index < length && json_string[index] == '}')
         {
-            i++;
+            index++;
             break;
         }
-        char *key = parse_string(s, i);
+        char *key = parse_string(json_string, index);
         if (!key)
         {
             json_free_items(head);
             return (ft_nullptr);
         }
-        skip_ws(s, i);
-        if (i >= len || s[i] != ':')
+        skip_whitespace(json_string, index);
+        if (index >= length || json_string[index] != ':')
         {
             cma_free(key);
             break;
         }
-        i++;
-        skip_ws(s, i);
-        char *value = parse_value(s, i);
+        index++;
+        skip_whitespace(json_string, index);
+        char *value = parse_value(json_string, index);
         if (!value)
         {
             cma_free(key);
@@ -121,12 +129,6 @@ static json_item *parse_items(const char *s, size_t &i)
         }
         json_item *item = json_create_item(key, value);
         cma_free(key);
-        cma_free(value);
-        if (!item)
-        {
-            json_free_items(head);
-            return (ft_nullptr);
-        }
         if (!head)
             head = tail = item;
         else
@@ -134,10 +136,10 @@ static json_item *parse_items(const char *s, size_t &i)
             tail->next = item;
             tail = item;
         }
-        skip_ws(s, i);
-        if (i < len && s[i] == ',')
+        skip_whitespace(json_string, index);
+        if (index < length && json_string[index] == ',')
         {
-            i++;
+            index++;
             continue;
         }
     }
@@ -152,60 +154,70 @@ json_group *json_read_from_file(const char *filename)
     char *content = cma_strdup("");
     if (!content)
     {
-        for (int idx = 0; lines[idx]; ++idx)
-            cma_free(lines[idx]);
+        int line_index = 0;
+        while (lines[line_index])
+        {
+            cma_free(lines[line_index]);
+            ++line_index;
+        }
         cma_free(lines);
         return (ft_nullptr);
     }
-    for (int idx = 0; lines[idx]; ++idx)
+    int line_index = 0;
+    while (lines[line_index])
     {
-        char *tmp = cma_strjoin(content, lines[idx]);
+        char *tmp = cma_strjoin(content, lines[line_index]);
         cma_free(content);
-        cma_free(lines[idx]);
+        cma_free(lines[line_index]);
         if (!tmp)
         {
-            for (int j = idx + 1; lines[j]; ++j)
-                cma_free(lines[j]);
+            int remaining_index = line_index + 1;
+            while (lines[remaining_index])
+            {
+                cma_free(lines[remaining_index]);
+                ++remaining_index;
+            }
             cma_free(lines);
             return (ft_nullptr);
         }
         content = tmp;
+        ++line_index;
     }
     cma_free(lines);
-    size_t i = 0;
-    skip_ws(content, i);
-    size_t len = ft_strlen_size_t(content);
-    if (i >= len || content[i] != '{')
+    size_t index = 0;
+    skip_whitespace(content, index);
+    size_t length = ft_strlen_size_t(content);
+    if (index >= length || content[index] != '{')
     {
         cma_free(content);
         return (ft_nullptr);
     }
-    i++;
+    index++;
     json_group *head = ft_nullptr;
     json_group *tail = ft_nullptr;
-    while (i < len)
+    while (index < length)
     {
-        skip_ws(content, i);
-        if (i < len && content[i] == '}')
+        skip_whitespace(content, index);
+        if (index < length && content[index] == '}')
         {
-            i++;
+            index++;
             break;
         }
-        char *group_name = parse_string(content, i);
+        char *group_name = parse_string(content, index);
         if (!group_name)
         {
             json_free_groups(head);
             cma_free(content);
             return (ft_nullptr);
         }
-        skip_ws(content, i);
-        if (i >= len || content[i] != ':')
+        skip_whitespace(content, index);
+        if (index >= length || content[index] != ':')
         {
             cma_free(group_name);
             break;
         }
-        i++;
-        json_item *items = parse_items(content, i);
+        index++;
+        json_item *items = parse_items(content, index);
         if (!items)
         {
             cma_free(group_name);
@@ -230,10 +242,10 @@ json_group *json_read_from_file(const char *filename)
             tail->next = group;
             tail = group;
         }
-        skip_ws(content, i);
-        if (i < len && content[i] == ',')
+        skip_whitespace(content, index);
+        if (index < length && content[index] == ',')
         {
-            i++;
+            index++;
             continue;
         }
     }
@@ -245,36 +257,36 @@ json_group *json_read_from_string(const char *content)
 {
     if (!content)
         return (ft_nullptr);
-    size_t i = 0;
-    skip_ws(content, i);
-    size_t len = ft_strlen_size_t(content);
-    if (i >= len || content[i] != '{')
+    size_t index = 0;
+    skip_whitespace(content, index);
+    size_t length = ft_strlen_size_t(content);
+    if (index >= length || content[index] != '{')
         return (ft_nullptr);
-    i++;
+    index++;
     json_group *head = ft_nullptr;
     json_group *tail = ft_nullptr;
-    while (i < len)
+    while (index < length)
     {
-        skip_ws(content, i);
-        if (i < len && content[i] == '}')
+        skip_whitespace(content, index);
+        if (index < length && content[index] == '}')
         {
-            i++;
+            index++;
             break;
         }
-        char *group_name = parse_string(content, i);
+        char *group_name = parse_string(content, index);
         if (!group_name)
         {
             json_free_groups(head);
             return (ft_nullptr);
         }
-        skip_ws(content, i);
-        if (i >= len || content[i] != ':')
+        skip_whitespace(content, index);
+        if (index >= length || content[index] != ':')
         {
             cma_free(group_name);
             break;
         }
-        i++;
-        json_item *items = parse_items(content, i);
+        index++;
+        json_item *items = parse_items(content, index);
         if (!items)
         {
             cma_free(group_name);
@@ -297,10 +309,10 @@ json_group *json_read_from_string(const char *content)
             tail->next = group;
             tail = group;
         }
-        skip_ws(content, i);
-        if (i < len && content[i] == ',')
+        skip_whitespace(content, index);
+        if (index < length && content[index] == ',')
         {
-            i++;
+            index++;
             continue;
         }
     }

--- a/Libft/ft_memcmp.cpp
+++ b/Libft/ft_memcmp.cpp
@@ -5,16 +5,16 @@ int    ft_memcmp(const void *pointer1, const void *pointer2, size_t size)
 {
     const unsigned char    *string1;
     const unsigned char    *string2;
-    size_t                i;
+    size_t                index;
 
-    i = 0;
+    index = 0;
     string1 = static_cast<const unsigned char *>(pointer1);
     string2 = static_cast<const unsigned char *>(pointer2);
-    while (i < size)
+    while (index < size)
     {
-        if (string1[i] != string2[i])
-            return (string1[i] - string2[i]);
-        i++;
+        if (string1[index] != string2[index])
+            return (string1[index] - string2[index]);
+        index++;
     }
     return (0);
 }

--- a/Libft/ft_memmove.cpp
+++ b/Libft/ft_memmove.cpp
@@ -3,30 +3,30 @@
 
 void *ft_memmove(void *destination, const void *source, size_t size)
 {
-    unsigned char *dest_ptr = static_cast<unsigned char *>(destination);
-    const unsigned char *src_ptr = static_cast<const unsigned char *>(source);
-    size_t i;
+    unsigned char *destination_pointer = static_cast<unsigned char *>(destination);
+    const unsigned char *source_pointer = static_cast<const unsigned char *>(source);
+    size_t index;
 
     if (size == 0 || destination == source)
         return (destination);
     if (!destination || !source)
         return (ft_nullptr);
-    if (dest_ptr < src_ptr)
+    if (destination_pointer < source_pointer)
     {
-        i = 0;
-        while (i < size)
+        index = 0;
+        while (index < size)
         {
-            dest_ptr[i] = src_ptr[i];
-            i++;
+            destination_pointer[index] = source_pointer[index];
+            index++;
         }
     }
     else
     {
-        i = size;
-        while (i > 0)
+        index = size;
+        while (index > 0)
         {
-            dest_ptr[i - 1] = src_ptr[i - 1];
-            i--;
+            destination_pointer[index - 1] = source_pointer[index - 1];
+            index--;
         }
     }
     return (destination);

--- a/Libft/ft_strjoin_multiple.cpp
+++ b/Libft/ft_strjoin_multiple.cpp
@@ -9,30 +9,34 @@ char *ft_strjoin_multiple(int count, ...)
         return (ft_nullptr);
     va_list args;
     va_start(args, count);
-    size_t total_len = 0;
-    for (int i = 0; i < count; ++i)
+    size_t total_length = 0;
+    int argument_index = 0;
+    while (argument_index < count)
     {
-        const char *str = va_arg(args, const char *);
-        if (str)
-            total_len += ft_strlen(str);
+        const char *current_string = va_arg(args, const char *);
+        if (current_string)
+            total_length += ft_strlen(current_string);
+        ++argument_index;
     }
     va_end(args);
-    char *result = static_cast<char*>(cma_malloc(total_len + 1));
+    char *result = static_cast<char*>(cma_malloc(total_length + 1));
     if (!result)
         return (ft_nullptr);
     va_start(args, count);
-    size_t index = 0;
-    for (int i = 0; i < count; ++i)
+    size_t result_index = 0;
+    argument_index = 0;
+    while (argument_index < count)
     {
-        const char *str = va_arg(args, const char *);
-        if (str)
+        const char *current_string = va_arg(args, const char *);
+        if (current_string)
         {
-            size_t len = ft_strlen(str);
-            ft_memcpy(result + index, str, len);
-            index += len;
+            size_t string_length = ft_strlen(current_string);
+            ft_memcpy(result + result_index, current_string, string_length);
+            result_index += string_length;
         }
+        ++argument_index;
     }
     va_end(args);
-    result[index] = '\0';
+    result[result_index] = '\0';
     return (result);
 }

--- a/Libft/ft_time.cpp
+++ b/Libft/ft_time.cpp
@@ -1,4 +1,5 @@
 #include "libft.hpp"
+#include "../CPP_class/nullptr.hpp"
 #include <sys/time.h>
 #include <time.h>
 
@@ -6,7 +7,7 @@ long ft_time_ms(void)
 {
     struct timeval tv;
 
-    if (gettimeofday(&tv, NULL) != 0)
+    if (gettimeofday(&tv, ft_nullptr) != 0)
         return (-1);
     return ((tv.tv_sec * 1000L + tv.tv_usec / 1000L));
 }
@@ -17,12 +18,12 @@ char *ft_time_format(char *buffer, size_t buffer_size)
     struct tm *tm_info;
 
     if (!buffer || buffer_size == 0)
-        return (NULL);
-    now = time(NULL);
+        return (ft_nullptr);
+    now = time(ft_nullptr);
     tm_info = localtime(&now);
     if (!tm_info)
-        return (NULL);
+        return (ft_nullptr);
     if (strftime(buffer, buffer_size, "%Y-%m-%d %H:%M:%S", tm_info) == 0)
-        return (NULL);
+        return (ft_nullptr);
     return (buffer);
 }

--- a/Linux/write.cpp
+++ b/Linux/write.cpp
@@ -1,4 +1,5 @@
 #include "linux_file.hpp"
+#include "../CPP_class/nullptr.hpp"
 #include <cstdio>
 #include <cerrno>
 #include <ctime>
@@ -23,7 +24,7 @@ ssize_t ft_write(int fd, const void *buffer, size_t count)
                 {
                     attempts++;
                     struct timespec delay = {0, RETRY_DELAY_MS * 1000000L};
-                    nanosleep(&delay, NULL);
+                    nanosleep(&delay, ft_nullptr);
                     continue ;
                 }
                 else

--- a/Printf/format.cpp
+++ b/Printf/format.cpp
@@ -10,68 +10,68 @@
 int pf_printf_fd_v(int fd, const char *format, va_list args)
 {
     size_t count = 0;
-    size_t i = 0;
+    size_t index = 0;
 
-    while (format[i])
+    while (format[index])
     {
-        if (format[i] == '%')
+        if (format[index] == '%')
         {
-            i++;
-            if (format[i] == '\0')
+            index++;
+            if (format[index] == '\0')
                 break ;
             LengthModifier len_mod = LEN_NONE;
-            if (format[i] == 'l')
+            if (format[index] == 'l')
             {
                 len_mod = LEN_L;
-                i++;
+                index++;
             }
-            else if (format[i] == 'z')
+            else if (format[index] == 'z')
             {
                 len_mod = LEN_Z;
-                i++;
+                index++;
             }
-            char spec = format[i];
+            char spec = format[index];
             if (spec == '\0')
                 break ;
             if (spec == 'c')
             {
-                char c = (char)va_arg(args, int);
-                ft_putchar_fd(c, fd, &count);
+                char character = (char)va_arg(args, int);
+                ft_putchar_fd(character, fd, &count);
             }
             else if (spec == 's')
             {
-                char *s = va_arg(args, char *);
-                ft_putstr_fd(s, fd, &count);
+                char *string = va_arg(args, char *);
+                ft_putstr_fd(string, fd, &count);
             }
             else if (spec == 'd' || spec == 'i')
             {
                 if (len_mod == LEN_L)
                 {
-                    long num = va_arg(args, long);
-                    ft_putnbr_fd(num, fd, &count);
+                    long number = va_arg(args, long);
+                    ft_putnbr_fd(number, fd, &count);
                 }
                 else
                 {
-                    int num = va_arg(args, int);
-                    ft_putnbr_fd(num, fd, &count);
+                    int number = va_arg(args, int);
+                    ft_putnbr_fd(number, fd, &count);
                 }
             }
             else if (spec == 'u')
             {
                 if (len_mod == LEN_L)
                 {
-                    uintmax_t num = va_arg(args, unsigned long);
-                    ft_putunsigned_fd(num, fd, &count);
+                    uintmax_t number = va_arg(args, unsigned long);
+                    ft_putunsigned_fd(number, fd, &count);
                 }
                 else if (len_mod == LEN_Z)
                 {
-                    size_t num = va_arg(args, size_t);
-                    ft_putunsigned_fd(num, fd, &count);
+                    size_t number = va_arg(args, size_t);
+                    ft_putunsigned_fd(number, fd, &count);
                 }
                 else
                 {
-                    unsigned int num = va_arg(args, unsigned int);
-                    ft_putunsigned_fd(num, fd, &count);
+                    unsigned int number = va_arg(args, unsigned int);
+                    ft_putunsigned_fd(number, fd, &count);
                 }
             }
             else if (spec == 'x' || spec == 'X')
@@ -79,29 +79,29 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
                 bool uppercase = (spec == 'X');
                 if (len_mod == LEN_L)
                 {
-                    uintmax_t num = va_arg(args, unsigned long);
-                    ft_puthex_fd(num, fd, uppercase, &count);
+                    uintmax_t number = va_arg(args, unsigned long);
+                    ft_puthex_fd(number, fd, uppercase, &count);
                 }
                 else if (len_mod == LEN_Z)
                 {
-                    size_t num = va_arg(args, size_t);
-                                        ft_puthex_fd(num, fd, uppercase, &count);
+                    size_t number = va_arg(args, size_t);
+                    ft_puthex_fd(number, fd, uppercase, &count);
                 }
                 else
                 {
-                    unsigned int num = va_arg(args, unsigned int);
-                    ft_puthex_fd(num, fd, uppercase, &count);
+                    unsigned int number = va_arg(args, unsigned int);
+                    ft_puthex_fd(number, fd, uppercase, &count);
                 }
             }
             else if (spec == 'p')
             {
-                void *ptr = va_arg(args, void *);
-                ft_putptr_fd(ptr, fd, &count);
+                void *pointer = va_arg(args, void *);
+                ft_putptr_fd(pointer, fd, &count);
             }
             else if (spec == 'b')
             {
-                int b = va_arg(args, int);
-                if (b)
+                int boolean_value = va_arg(args, int);
+                if (boolean_value)
                     ft_putstr_fd("true", fd, &count);
                 else
                     ft_putstr_fd("false", fd, &count);
@@ -115,8 +115,8 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
             }
         }
         else
-            ft_putchar_fd(format[i], fd, &count);
-        i++;
+            ft_putchar_fd(format[index], fd, &count);
+        index++;
     }
     return (static_cast<int>(count));
 }

--- a/Printf/ft_fprintf.cpp
+++ b/Printf/ft_fprintf.cpp
@@ -15,76 +15,76 @@ typedef enum
     LEN_Z
 } LengthModifier;
 
-static void ft_putchar_stream(const char c, FILE *stream, size_t *count)
+static void ft_putchar_stream(const char character, FILE *stream, size_t *count)
 {
-    fputc(c, stream);
+    fputc(character, stream);
     (*count)++;
 }
 
-static void ft_putstr_stream(const char *s, FILE *stream, size_t *count)
+static void ft_putstr_stream(const char *string, FILE *stream, size_t *count)
 {
-    if (!s)
+    if (!string)
     {
         fwrite("(null)", 1, 6, stream);
         *count += 6;
         return;
     }
-    size_t len = strlen(s);
-    fwrite(s, 1, len, stream);
-    *count += len;
+    size_t length = strlen(string);
+    fwrite(string, 1, length, stream);
+    *count += length;
 }
 
-static void ft_putnbr_stream_recursive(long n, FILE *stream, size_t *count)
+static void ft_putnbr_stream_recursive(long number, FILE *stream, size_t *count)
 {
-    if (n < 0)
+    if (number < 0)
     {
         ft_putchar_stream('-', stream, count);
-        n = -n;
+        number = -number;
     }
-    if (n >= 10)
-        ft_putnbr_stream_recursive(n / 10, stream, count);
-    ft_putchar_stream(static_cast<char>('0' + (n % 10)), stream, count);
+    if (number >= 10)
+        ft_putnbr_stream_recursive(number / 10, stream, count);
+    ft_putchar_stream(static_cast<char>('0' + (number % 10)), stream, count);
 }
 
-static void ft_putnbr_stream(long n, FILE *stream, size_t *count)
+static void ft_putnbr_stream(long number, FILE *stream, size_t *count)
 {
-    ft_putnbr_stream_recursive(n, stream, count);
+    ft_putnbr_stream_recursive(number, stream, count);
 }
 
-static void ft_putunsigned_stream_recursive(uintmax_t n, FILE *stream, size_t *count)
+static void ft_putunsigned_stream_recursive(uintmax_t number, FILE *stream, size_t *count)
 {
-    if (n >= 10)
-        ft_putunsigned_stream_recursive(n / 10, stream, count);
-    ft_putchar_stream(static_cast<char>('0' + (n % 10)), stream, count);
+    if (number >= 10)
+        ft_putunsigned_stream_recursive(number / 10, stream, count);
+    ft_putchar_stream(static_cast<char>('0' + (number % 10)), stream, count);
 }
 
-static void ft_putunsigned_stream(uintmax_t n, FILE *stream, size_t *count)
+static void ft_putunsigned_stream(uintmax_t number, FILE *stream, size_t *count)
 {
-    ft_putunsigned_stream_recursive(n, stream, count);
+    ft_putunsigned_stream_recursive(number, stream, count);
 }
 
-static void ft_puthex_stream_recursive(uintmax_t n, FILE *stream, bool uppercase, size_t *count)
+static void ft_puthex_stream_recursive(uintmax_t number, FILE *stream, bool uppercase, size_t *count)
 {
-    if (n >= 16)
-        ft_puthex_stream_recursive(n / 16, stream, uppercase, count);
-    uintmax_t digit = n % 16;
-    char c;
+    if (number >= 16)
+        ft_puthex_stream_recursive(number / 16, stream, uppercase, count);
+    uintmax_t digit = number % 16;
+    char character;
     if (digit < 10)
-        c = static_cast<char>('0' + digit);
+        character = static_cast<char>('0' + digit);
     else
-        c = static_cast<char>((uppercase ? 'A' : 'a') + (digit - 10));
-    ft_putchar_stream(c, stream, count);
+        character = static_cast<char>((uppercase ? 'A' : 'a') + (digit - 10));
+    ft_putchar_stream(character, stream, count);
 }
 
-static void ft_puthex_stream(uintmax_t n, FILE *stream, bool uppercase, size_t *count)
+static void ft_puthex_stream(uintmax_t number, FILE *stream, bool uppercase, size_t *count)
 {
-    ft_puthex_stream_recursive(n, stream, uppercase, count);
+    ft_puthex_stream_recursive(number, stream, uppercase, count);
 }
 
-static void ft_putptr_stream(void *ptr, FILE *stream, size_t *count)
+static void ft_putptr_stream(void *pointer, FILE *stream, size_t *count)
 {
     ft_putstr_stream("0x", stream, count);
-    ft_puthex_stream(reinterpret_cast<uintptr_t>(ptr), stream, false, count);
+    ft_puthex_stream(reinterpret_cast<uintptr_t>(pointer), stream, false, count);
 }
 
 int ft_vfprintf(FILE *stream, const char *format, va_list args)
@@ -92,67 +92,67 @@ int ft_vfprintf(FILE *stream, const char *format, va_list args)
     if (stream == ft_nullptr || format == ft_nullptr)
         return (0);
     size_t count = 0;
-    size_t i = 0;
-    while (format[i])
+    size_t index = 0;
+    while (format[index])
     {
-        if (format[i] == '%')
+        if (format[index] == '%')
         {
-            i++;
-            if (format[i] == '\0')
+            index++;
+            if (format[index] == '\0')
                 break;
             LengthModifier len_mod = LEN_NONE;
-            if (format[i] == 'l')
+            if (format[index] == 'l')
             {
                 len_mod = LEN_L;
-                i++;
+                index++;
             }
-            else if (format[i] == 'z')
+            else if (format[index] == 'z')
             {
                 len_mod = LEN_Z;
-                i++;
+                index++;
             }
-            char spec = format[i];
+            char spec = format[index];
             if (spec == '\0')
                 break;
             if (spec == 'c')
             {
-                char c = static_cast<char>(va_arg(args, int));
-                ft_putchar_stream(c, stream, &count);
+                char character = static_cast<char>(va_arg(args, int));
+                ft_putchar_stream(character, stream, &count);
             }
             else if (spec == 's')
             {
-                char *s = va_arg(args, char *);
-                ft_putstr_stream(s, stream, &count);
+                char *string = va_arg(args, char *);
+                ft_putstr_stream(string, stream, &count);
             }
             else if (spec == 'd' || spec == 'i')
             {
                 if (len_mod == LEN_L)
                 {
-                    long num = va_arg(args, long);
-                    ft_putnbr_stream(num, stream, &count);
+                    long number = va_arg(args, long);
+                    ft_putnbr_stream(number, stream, &count);
                 }
                 else
                 {
-                    int num = va_arg(args, int);
-                    ft_putnbr_stream(num, stream, &count);
+                    int number = va_arg(args, int);
+                    ft_putnbr_stream(number, stream, &count);
                 }
             }
             else if (spec == 'u')
             {
                 if (len_mod == LEN_L)
                 {
-                    uintmax_t num = va_arg(args, unsigned long);
-                    ft_putunsigned_stream(num, stream, &count);
+                    uintmax_t number = va_arg(args, unsigned long);
+                    ft_putunsigned_stream(number, stream, &count);
                 }
                 else if (len_mod == LEN_Z)
                 {
-                    size_t num = va_arg(args, size_t);
-                    ft_putunsigned_stream(num, stream, &count);
+                    size_t number = va_arg(args, size_t);
+                    ft_putunsigned_stream(number, stream, &count);
                 }
                 else
                 {
-                    unsigned int num = va_arg(args, unsigned int);
-                    ft_putunsigned_stream(num, stream, &count);
+                    unsigned int number = va_arg(args, unsigned int);
+                    ft_putunsigned_stream(number, stream, &count);
                 }
             }
             else if (spec == 'x' || spec == 'X')
@@ -160,29 +160,29 @@ int ft_vfprintf(FILE *stream, const char *format, va_list args)
                 bool uppercase = (spec == 'X');
                 if (len_mod == LEN_L)
                 {
-                    uintmax_t num = va_arg(args, unsigned long);
-                    ft_puthex_stream(num, stream, uppercase, &count);
+                    uintmax_t number = va_arg(args, unsigned long);
+                    ft_puthex_stream(number, stream, uppercase, &count);
                 }
                 else if (len_mod == LEN_Z)
                 {
-                    size_t num = va_arg(args, size_t);
-                    ft_puthex_stream(num, stream, uppercase, &count);
+                    size_t number = va_arg(args, size_t);
+                    ft_puthex_stream(number, stream, uppercase, &count);
                 }
                 else
                 {
-                    unsigned int num = va_arg(args, unsigned int);
-                    ft_puthex_stream(num, stream, uppercase, &count);
+                    unsigned int number = va_arg(args, unsigned int);
+                    ft_puthex_stream(number, stream, uppercase, &count);
                 }
             }
             else if (spec == 'p')
             {
-                void *ptr = va_arg(args, void *);
-                ft_putptr_stream(ptr, stream, &count);
+                void *pointer = va_arg(args, void *);
+                ft_putptr_stream(pointer, stream, &count);
             }
             else if (spec == 'b')
             {
-                int b = va_arg(args, int);
-                ft_putstr_stream(b ? "true" : "false", stream, &count);
+                int boolean_value = va_arg(args, int);
+                ft_putstr_stream(boolean_value ? "true" : "false", stream, &count);
             }
             else if (spec == '%')
             {
@@ -196,9 +196,9 @@ int ft_vfprintf(FILE *stream, const char *format, va_list args)
         }
         else
         {
-            ft_putchar_stream(format[i], stream, &count);
+            ft_putchar_stream(format[index], stream, &count);
         }
-        i++;
+        index++;
     }
     return (static_cast<int>(count));
 }

--- a/Printf/print_args.cpp
+++ b/Printf/print_args.cpp
@@ -8,115 +8,115 @@
 #include <limits.h>
 #include <stddef.h>
 
-static inline ssize_t ft_platform_write(int fd, const char *s, size_t len)
+static inline ssize_t ft_platform_write(int fd, const char *string, size_t length)
 {
 #ifdef _WIN32
-    return (ft_write(fd, s, static_cast<unsigned int>(len)));
+    return (ft_write(fd, string, static_cast<unsigned int>(length)));
 #else
-    return (ft_write(fd, s, len));
+    return (ft_write(fd, string, length));
 #endif
 }
 
-size_t ft_strlen_printf(const char *s)
+size_t ft_strlen_printf(const char *string)
 {
-    size_t len = 0;
-    if (!s)
+    size_t length = 0;
+    if (!string)
         return (6);
-    while (s[len])
-        len++;
-    return (len);
+    while (string[length])
+        length++;
+    return (length);
 }
 
-void ft_putchar_fd(const char c, int fd, size_t *count)
+void ft_putchar_fd(const char character, int fd, size_t *count)
 {
-    ssize_t return_value = ft_write(fd, &c, 1);
+    ssize_t return_value = ft_write(fd, &character, 1);
     (void)return_value;
     (*count)++;
     return ;
 }
 
-void ft_putstr_fd(const char *s, int fd, size_t *count)
+void ft_putstr_fd(const char *string, int fd, size_t *count)
 {
     ssize_t return_value;
-    if (!s)
+    if (!string)
     {
         return_value = ft_write(fd, "(null)", 6);
         *count += 6;
         return ;
     }
-    size_t len = ft_strlen_printf(s);
-    return_value = ft_platform_write(fd, s, len);
-    *count += len;
+    size_t length = ft_strlen_printf(string);
+    return_value = ft_platform_write(fd, string, length);
+    *count += length;
     (void)return_value;
     return ;
 }
 
-void ft_putnbr_fd_recursive(long n, int fd, size_t *count)
+void ft_putnbr_fd_recursive(long number, int fd, size_t *count)
 {
-    char c;
-    if (n < 0)
+    char character;
+    if (number < 0)
     {
         ft_putchar_fd('-', fd, count);
-        n = -n;
+        number = -number;
     }
-    if (n >= 10)
-        ft_putnbr_fd_recursive(n / 10, fd, count);
-    c = static_cast<char>('0' + (n % 10));
-    ft_putchar_fd(c, fd, count);
+    if (number >= 10)
+        ft_putnbr_fd_recursive(number / 10, fd, count);
+    character = static_cast<char>('0' + (number % 10));
+    ft_putchar_fd(character, fd, count);
     return ;
 }
 
-void ft_putnbr_fd(long n, int fd, size_t *count)
+void ft_putnbr_fd(long number, int fd, size_t *count)
 {
-    ft_putnbr_fd_recursive(n, fd, count);
+    ft_putnbr_fd_recursive(number, fd, count);
     return ;
 }
 
-void ft_putunsigned_fd_recursive(uintmax_t n, int fd, size_t *count)
+void ft_putunsigned_fd_recursive(uintmax_t number, int fd, size_t *count)
 {
-    char c;
-    if (n >= 10)
-        ft_putunsigned_fd_recursive(n / 10, fd, count);
-    c = static_cast<char>('0' + (n % 10));
-    ft_putchar_fd(c, fd, count);
+    char character;
+    if (number >= 10)
+        ft_putunsigned_fd_recursive(number / 10, fd, count);
+    character = static_cast<char>('0' + (number % 10));
+    ft_putchar_fd(character, fd, count);
     return ;
 }
 
-void ft_putunsigned_fd(uintmax_t n, int fd, size_t *count)
+void ft_putunsigned_fd(uintmax_t number, int fd, size_t *count)
 {
-    ft_putunsigned_fd_recursive(n, fd, count);
+    ft_putunsigned_fd_recursive(number, fd, count);
     return ;
 }
 
-void ft_puthex_fd_recursive(uintmax_t n, int fd, bool uppercase, size_t *count)
+void ft_puthex_fd_recursive(uintmax_t number, int fd, bool uppercase, size_t *count)
 {
-    char c;
+    char character;
 
-    if (n >= 16)
-        ft_puthex_fd_recursive(n / 16, fd, uppercase, count);
-    if ((n % 16) < 10)
-        c = '0' + (n % 16);
+    if (number >= 16)
+        ft_puthex_fd_recursive(number / 16, fd, uppercase, count);
+    if ((number % 16) < 10)
+        character = '0' + (number % 16);
     else
     {
         if (uppercase)
-            c = 'A' + ((n % 16) - 10);
+            character = 'A' + ((number % 16) - 10);
         else
-            c = 'a' + ((n % 16) - 10);
+            character = 'a' + ((number % 16) - 10);
     }
-    ft_putchar_fd(c, fd, count);
+    ft_putchar_fd(character, fd, count);
     return ;
 }
 
-void ft_puthex_fd(uintmax_t n, int fd, bool uppercase, size_t *count)
+void ft_puthex_fd(uintmax_t number, int fd, bool uppercase, size_t *count)
 {
-    ft_puthex_fd_recursive(n, fd, uppercase, count);
+    ft_puthex_fd_recursive(number, fd, uppercase, count);
     return ;
 }
 
-void ft_putptr_fd(void *ptr, int fd, size_t *count)
+void ft_putptr_fd(void *pointer, int fd, size_t *count)
 {
-    uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
+    uintptr_t address = reinterpret_cast<uintptr_t>(pointer);
     ft_putstr_fd("0x", fd, count);
-    ft_puthex_fd(addr, fd, false, count);
+    ft_puthex_fd(address, fd, false, count);
     return ;
 }

--- a/Printf/printf_internal.hpp
+++ b/Printf/printf_internal.hpp
@@ -16,16 +16,16 @@ typedef enum
     LEN_Z
 } LengthModifier;
 
-size_t ft_strlen_printf(const char *s);
-void ft_putchar_fd(const char c, int fd, size_t *count);
-void ft_putstr_fd(const char *s, int fd, size_t *count);
-void ft_putnbr_fd_recursive(long n, int fd, size_t *count);
-void ft_putnbr_fd(long n, int fd, size_t *count);
-void ft_putunsigned_fd_recursive(uintmax_t n, int fd, size_t *count);
-void ft_putunsigned_fd(uintmax_t n, int fd, size_t *count);
-void ft_puthex_fd_recursive(uintmax_t n, int fd, bool uppercase, size_t *count);
-void ft_puthex_fd(uintmax_t n, int fd, bool uppercase, size_t *count);
-void ft_putptr_fd(void *ptr, int fd, size_t *count);
+size_t ft_strlen_printf(const char *string);
+void ft_putchar_fd(const char character, int fd, size_t *count);
+void ft_putstr_fd(const char *string, int fd, size_t *count);
+void ft_putnbr_fd_recursive(long number, int fd, size_t *count);
+void ft_putnbr_fd(long number, int fd, size_t *count);
+void ft_putunsigned_fd_recursive(uintmax_t number, int fd, size_t *count);
+void ft_putunsigned_fd(uintmax_t number, int fd, size_t *count);
+void ft_puthex_fd_recursive(uintmax_t number, int fd, bool uppercase, size_t *count);
+void ft_puthex_fd(uintmax_t number, int fd, bool uppercase, size_t *count);
+void ft_putptr_fd(void *pointer, int fd, size_t *count);
 int pf_printf_fd_v(int fd, const char *format, va_list args);
 
 #endif

--- a/README.md
+++ b/README.md
@@ -406,23 +406,23 @@ HTTP client helpers in `API/api.hpp` and asynchronous wrappers:
 ```
 char       *api_request_string(const char *ip, uint16_t port,
                                const char *method, const char *path,
-                               json_group *payload = NULL,
-                               const char *headers = NULL, int *status = NULL,
+                               json_group *payload = ft_nullptr,
+                               const char *headers = ft_nullptr, int *status = ft_nullptr,
                                int timeout = 60000);
 char       *api_request_string_host(const char *host, uint16_t port,
                                     const char *method, const char *path,
-                                    json_group *payload = NULL,
-                                    const char *headers = NULL, int *status = NULL,
+                                    json_group *payload = ft_nullptr,
+                                    const char *headers = ft_nullptr, int *status = ft_nullptr,
                                     int timeout = 60000);
 json_group *api_request_json(const char *ip, uint16_t port,
                              const char *method, const char *path,
-                             json_group *payload = NULL,
-                             const char *headers = NULL, int *status = NULL,
+                             json_group *payload = ft_nullptr,
+                             const char *headers = ft_nullptr, int *status = ft_nullptr,
                              int timeout = 60000);
 json_group *api_request_json_host(const char *host, uint16_t port,
                                   const char *method, const char *path,
-                                  json_group *payload = NULL,
-                                  const char *headers = NULL, int *status = NULL,
+                                  json_group *payload = ft_nullptr,
+                                  const char *headers = ft_nullptr, int *status = ft_nullptr,
                                   int timeout = 60000);
 ```
 
@@ -434,11 +434,11 @@ string and JSON responses, and TLS variants for HTTPS.
 api_tls_client(const char *host, uint16_t port, int timeout = 60000);
 ~api_tls_client();
 bool is_valid() const;
-char *request(const char *method, const char *path, json_group *payload = NULL,
-              const char *headers = NULL, int *status = NULL);
+char *request(const char *method, const char *path, json_group *payload = ft_nullptr,
+              const char *headers = ft_nullptr, int *status = ft_nullptr);
 json_group *request_json(const char *method, const char *path,
-                         json_group *payload = NULL,
-                         const char *headers = NULL, int *status = NULL);
+                         json_group *payload = ft_nullptr,
+                         const char *headers = ft_nullptr, int *status = ft_nullptr);
 ```
 
 #### HTML

--- a/RNG/loot_table.hpp
+++ b/RNG/loot_table.hpp
@@ -43,19 +43,23 @@ ElementType *ft_loot_table<ElementType>::getRandomLoot() const
         return (ft_nullptr);
     }
     int totalWeight = 0;
-    for (size_t index = 0; index < this->size(); index++)
+    size_t index = 0;
+    while (index < this->size())
     {
         if (INT_MAX - totalWeight < (*this)[index].weight)
             return (ft_nullptr);
         totalWeight += (*this)[index].weight;
+        ++index;
     }
     int roll = ft_dice_roll(1, totalWeight);
     int accumulated = 0;
-    for (size_t index = 0; index < this->size(); index++)
+    index = 0;
+    while (index < this->size())
     {
         accumulated += (*this)[index].weight;
         if (roll <= accumulated)
             return ((*this)[index].item);
+        ++index;
     }
     return (ft_nullptr);
 }
@@ -70,15 +74,18 @@ ElementType *ft_loot_table<ElementType>::popRandomLoot()
         return (ft_nullptr);
     }
     int totalWeight = 0;
-    for (size_t index = 0; index < this->size(); index++)
+    size_t index = 0;
+    while (index < this->size())
     {
         if (INT_MAX - totalWeight < (*this)[index].weight)
             return (ft_nullptr);
         totalWeight += (*this)[index].weight;
+        ++index;
     }
     int roll = ft_dice_roll(1, totalWeight);
     int accumulated = 0;
-    for (size_t index = 0; index < this->size(); index++)
+    index = 0;
+    while (index < this->size())
     {
         accumulated += (*this)[index].weight;
         if (roll <= accumulated)
@@ -87,6 +94,7 @@ ElementType *ft_loot_table<ElementType>::popRandomLoot()
             this->release_at(index);
             return (elem);
         }
+        ++index;
     }
     return (ft_nullptr);
 }

--- a/RNG/random_seed.cpp
+++ b/RNG/random_seed.cpp
@@ -2,18 +2,18 @@
 #include <cstdint>
 #include <random>
 
-int ft_random_seed(const char *seed_str)
+int ft_random_seed(const char *seed_string)
 {
-    if (seed_str != ft_nullptr)
+    if (seed_string != ft_nullptr)
     {
         uint32_t hash = 2166136261u;
-        while (*seed_str)
+        while (*seed_string)
         {
-            hash ^= static_cast<unsigned char>(*seed_str++);
+            hash ^= static_cast<unsigned char>(*seed_string++);
             hash *= 16777619u;
         }
         return static_cast<int>(hash);
     }
-    std::random_device rd;
-    return static_cast<int>(rd());
+    std::random_device random_device;
+    return static_cast<int>(random_device());
 }

--- a/ReadLine/clear_history.cpp
+++ b/ReadLine/clear_history.cpp
@@ -1,17 +1,18 @@
 #include "readline.hpp"
 #include "readline_internal.hpp"
+#include "../CPP_class/nullptr.hpp"
 #include "../CMA/CMA.hpp"
 
 void rl_clear_history()
 {
-    int    i;
+    int    index;
 
-    i = 0;
-    while (i < history_count)
+    index = 0;
+    while (index < history_count)
     {
-        cma_free(history[i]);
-        history[i] = NULL;
-        i++;
+        cma_free(history[index]);
+        history[index] = ft_nullptr;
+        index++;
     }
     history_count = 0;
     return ;

--- a/ReadLine/readline.cpp
+++ b/ReadLine/readline.cpp
@@ -19,7 +19,7 @@ static void rl_cleanup_state(readline_state_t *state)
     if (state->buffer)
     {
         cma_free(state->buffer);
-        state->buffer = NULL;
+        state->buffer = ft_nullptr;
     }
     return ;
 }

--- a/Template/algorithm.hpp
+++ b/Template/algorithm.hpp
@@ -10,13 +10,17 @@
 template <typename RandomIt, typename Compare>
 void ft_sort(RandomIt first, RandomIt last, Compare comp)
 {
-    for (RandomIt i = first; i != last; ++i)
+    RandomIt i = first;
+    while (i != last)
     {
-        for (RandomIt j = i + 1; j != last; ++j)
+        RandomIt j = i + 1;
+        while (j != last)
         {
             if (comp(*j, *i))
                 ft_swap(*i, *j);
+            ++j;
         }
+        ++i;
     }
     return ;
 }
@@ -59,11 +63,13 @@ void ft_shuffle(RandomIt first, RandomIt last)
 {
     if (first == last)
         return ;
-    for (RandomIt i = last - 1; i > first; --i)
+    RandomIt iterator = last - 1;
+    while (iterator > first)
     {
-        size_t j = static_cast<size_t>(ft_random_int()) %
-                    static_cast<size_t>((i - first) + 1);
-        ft_swap(*(first + j), *i);
+        size_t random_index = static_cast<size_t>(ft_random_int()) %
+                    static_cast<size_t>((iterator - first) + 1);
+        ft_swap(*(first + random_index), *iterator);
+        --iterator;
     }
     return ;
 }

--- a/Template/circular_buffer.hpp
+++ b/Template/circular_buffer.hpp
@@ -251,8 +251,12 @@ void ft_circular_buffer<ElementType>::clear()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return ;
-    for (size_t i = 0; i < this->_size; ++i)
+    size_t i = 0;
+    while (i < this->_size)
+    {
         destroy_at(&this->_buffer[(this->_head + i) % this->_capacity]);
+        ++i;
+    }
     this->_head = 0;
     this->_tail = 0;
     this->_size = 0;

--- a/Template/event_emitter.hpp
+++ b/Template/event_emitter.hpp
@@ -142,12 +142,12 @@ bool ft_event_emitter<EventType, Args...>::ensure_capacity(size_t desired)
         this->setError(EVENT_EMITTER_ALLOC_FAIL);
         return (false);
     }
-    size_t i = 0;
-    while (i < this->_size)
+    size_t listener_index = 0;
+    while (listener_index < this->_size)
     {
-        construct_at(&newData[i], std::move(this->_listeners[i]));
-        destroy_at(&this->_listeners[i]);
-        ++i;
+        construct_at(&newData[listener_index], std::move(this->_listeners[listener_index]));
+        destroy_at(&this->_listeners[listener_index]);
+        ++listener_index;
     }
     if (this->_listeners != ft_nullptr)
         cma_free(this->_listeners);
@@ -178,15 +178,15 @@ void ft_event_emitter<EventType, Args...>::emit(const EventType& event, Args... 
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return ;
     bool found = false;
-    size_t i = 0;
-    while (i < this->_size)
+    size_t listener_index = 0;
+    while (listener_index < this->_size)
     {
-        if (this->_listeners[i]._event == event)
+        if (this->_listeners[listener_index]._event == event)
         {
             found = true;
-            this->_listeners[i]._callback(args...);
+            this->_listeners[listener_index]._callback(args...);
         }
-        ++i;
+        ++listener_index;
     }
     if (!found)
         this->setError(EVENT_EMITTER_NOT_FOUND);
@@ -199,24 +199,24 @@ void ft_event_emitter<EventType, Args...>::remove_listener(const EventType& even
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return ;
-    size_t i = 0;
-    while (i < this->_size)
+    size_t listener_index = 0;
+    while (listener_index < this->_size)
     {
-        if (this->_listeners[i]._event == event && this->_listeners[i]._callback == cb)
+        if (this->_listeners[listener_index]._event == event && this->_listeners[listener_index]._callback == cb)
         {
-            destroy_at(&this->_listeners[i]);
-            size_t j = i;
-            while (j + 1 < this->_size)
+            destroy_at(&this->_listeners[listener_index]);
+            size_t shift_index = listener_index;
+            while (shift_index + 1 < this->_size)
             {
-                construct_at(&this->_listeners[j], std::move(this->_listeners[j + 1]));
-                destroy_at(&this->_listeners[j + 1]);
-                ++j;
+                construct_at(&this->_listeners[shift_index], std::move(this->_listeners[shift_index + 1]));
+                destroy_at(&this->_listeners[shift_index + 1]);
+                ++shift_index;
             }
             --this->_size;
             this->_mutex.unlock(THREAD_ID);
             return ;
         }
-        ++i;
+        ++listener_index;
     }
     this->setError(EVENT_EMITTER_NOT_FOUND);
     this->_mutex.unlock(THREAD_ID);
@@ -252,11 +252,11 @@ void ft_event_emitter<EventType, Args...>::clear()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return ;
-    size_t i = 0;
-    while (i < this->_size)
+    size_t listener_index = 0;
+    while (listener_index < this->_size)
     {
-        destroy_at(&this->_listeners[i]);
-        ++i;
+        destroy_at(&this->_listeners[listener_index]);
+        ++listener_index;
     }
     this->_size = 0;
     this->_mutex.unlock(THREAD_ID);

--- a/Template/graph.hpp
+++ b/Template/graph.hpp
@@ -86,13 +86,13 @@ ft_graph<VertexType>::~ft_graph()
 {
     if (this->_nodes != ft_nullptr)
     {
-        size_t i = 0;
-        while (i < this->_size)
+        size_t node_index = 0;
+        while (node_index < this->_size)
         {
-            destroy_at(&this->_nodes[i]._value);
-            if (this->_nodes[i]._edges != ft_nullptr)
-                cma_free(this->_nodes[i]._edges);
-            ++i;
+            destroy_at(&this->_nodes[node_index]._value);
+            if (this->_nodes[node_index]._edges != ft_nullptr)
+                cma_free(this->_nodes[node_index]._edges);
+            ++node_index;
         }
         cma_free(this->_nodes);
     }
@@ -161,15 +161,15 @@ bool ft_graph<VertexType>::ensure_node_capacity(size_t desired)
         this->setError(GRAPH_ALLOC_FAIL);
         return (false);
     }
-    size_t i = 0;
-    while (i < this->_size)
+    size_t node_index = 0;
+    while (node_index < this->_size)
     {
-        construct_at(&newNodes[i]._value, std::move(this->_nodes[i]._value));
-        newNodes[i]._edges = this->_nodes[i]._edges;
-        newNodes[i]._degree = this->_nodes[i]._degree;
-        newNodes[i]._capacity = this->_nodes[i]._capacity;
-        destroy_at(&this->_nodes[i]._value);
-        ++i;
+        construct_at(&newNodes[node_index]._value, std::move(this->_nodes[node_index]._value));
+        newNodes[node_index]._edges = this->_nodes[node_index]._edges;
+        newNodes[node_index]._degree = this->_nodes[node_index]._degree;
+        newNodes[node_index]._capacity = this->_nodes[node_index]._capacity;
+        destroy_at(&this->_nodes[node_index]._value);
+        ++node_index;
     }
     if (this->_nodes != ft_nullptr)
         cma_free(this->_nodes);
@@ -192,11 +192,11 @@ bool ft_graph<VertexType>::ensure_edge_capacity(GraphNode& node, size_t desired)
         this->setError(GRAPH_ALLOC_FAIL);
         return (false);
     }
-    size_t i = 0;
-    while (i < node._degree)
+    size_t edge_index = 0;
+    while (edge_index < node._degree)
     {
-        newEdges[i] = node._edges[i];
-        ++i;
+        newEdges[edge_index] = node._edges[edge_index];
+        ++edge_index;
     }
     if (node._edges != ft_nullptr)
         cma_free(node._edges);
@@ -299,11 +299,11 @@ void ft_graph<VertexType>::bfs(size_t start, Func visit)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    size_t i = 0;
-    while (i < this->_size)
+    size_t node_index = 0;
+    while (node_index < this->_size)
     {
-        visited[i] = false;
-        ++i;
+        visited[node_index] = false;
+        ++node_index;
     }
     ft_queue<size_t> q;
     q.enqueue(start);
@@ -312,16 +312,16 @@ void ft_graph<VertexType>::bfs(size_t start, Func visit)
     {
         size_t v = q.dequeue();
         visit(this->_nodes[v]._value);
-        size_t j = 0;
-        while (j < this->_nodes[v]._degree)
+        size_t neighbor_index = 0;
+        while (neighbor_index < this->_nodes[v]._degree)
         {
-            size_t w = this->_nodes[v]._edges[j];
+            size_t w = this->_nodes[v]._edges[neighbor_index];
             if (!visited[w])
             {
                 visited[w] = true;
                 q.enqueue(w);
             }
-            ++j;
+            ++neighbor_index;
         }
     }
     cma_free(visited);
@@ -351,11 +351,11 @@ void ft_graph<VertexType>::dfs(size_t start, Func visit)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    size_t i = 0;
-    while (i < this->_size)
+    size_t node_index = 0;
+    while (node_index < this->_size)
     {
-        visited[i] = false;
-        ++i;
+        visited[node_index] = false;
+        ++node_index;
     }
     ft_stack<size_t> st;
     st.push(start);
@@ -366,11 +366,11 @@ void ft_graph<VertexType>::dfs(size_t start, Func visit)
             continue ;
         visited[v] = true;
         visit(this->_nodes[v]._value);
-        size_t j = this->_nodes[v]._degree;
-        while (j > 0)
+        size_t neighbor_index = this->_nodes[v]._degree;
+        while (neighbor_index > 0)
         {
-            --j;
-            size_t w = this->_nodes[v]._edges[j];
+            --neighbor_index;
+            size_t w = this->_nodes[v]._edges[neighbor_index];
             if (!visited[w])
                 st.push(w);
         }
@@ -425,18 +425,18 @@ void ft_graph<VertexType>::clear()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return ;
-    size_t i = 0;
-    while (i < this->_size)
+    size_t node_index_clear = 0;
+    while (node_index_clear < this->_size)
     {
-        destroy_at(&this->_nodes[i]._value);
-        if (this->_nodes[i]._edges != ft_nullptr)
+        destroy_at(&this->_nodes[node_index_clear]._value);
+        if (this->_nodes[node_index_clear]._edges != ft_nullptr)
         {
-            cma_free(this->_nodes[i]._edges);
-            this->_nodes[i]._edges = ft_nullptr;
-            this->_nodes[i]._degree = 0;
-            this->_nodes[i]._capacity = 0;
+            cma_free(this->_nodes[node_index_clear]._edges);
+            this->_nodes[node_index_clear]._edges = ft_nullptr;
+            this->_nodes[node_index_clear]._degree = 0;
+            this->_nodes[node_index_clear]._capacity = 0;
         }
-        ++i;
+        ++node_index_clear;
     }
     this->_size = 0;
     this->_mutex.unlock(THREAD_ID);

--- a/Template/matrix.hpp
+++ b/Template/matrix.hpp
@@ -244,23 +244,23 @@ ft_matrix<ElementType> ft_matrix<ElementType>::multiply(const ft_matrix& other) 
         this->_mutex.unlock(THREAD_ID);
         return (result);
     }
-    size_t i = 0;
-    while (i < this->_rows)
+    size_t row_index = 0;
+    while (row_index < this->_rows)
     {
-        size_t j = 0;
-        while (j < other._cols)
+        size_t column_index = 0;
+        while (column_index < other._cols)
         {
             ElementType sum = ElementType();
-            size_t k = 0;
-            while (k < this->_cols)
+            size_t inner_index = 0;
+            while (inner_index < this->_cols)
             {
-                sum = sum + this->_data[i * this->_cols + k] * other._data[k * other._cols + j];
-                ++k;
+                sum = sum + this->_data[row_index * this->_cols + inner_index] * other._data[inner_index * other._cols + column_index];
+                ++inner_index;
             }
-            result._data[i * other._cols + j] = sum;
-            ++j;
+            result._data[row_index * other._cols + column_index] = sum;
+            ++column_index;
         }
-        ++i;
+        ++row_index;
     }
     other._mutex.unlock(THREAD_ID);
     this->_mutex.unlock(THREAD_ID);
@@ -279,16 +279,16 @@ ft_matrix<ElementType> ft_matrix<ElementType>::transpose() const
         this->_mutex.unlock(THREAD_ID);
         return (result);
     }
-    size_t i = 0;
-    while (i < this->_rows)
+    size_t row_index = 0;
+    while (row_index < this->_rows)
     {
-        size_t j = 0;
-        while (j < this->_cols)
+        size_t column_index = 0;
+        while (column_index < this->_cols)
         {
-            result._data[j * this->_rows + i] = this->_data[i * this->_cols + j];
-            ++j;
+            result._data[column_index * this->_rows + row_index] = this->_data[row_index * this->_cols + column_index];
+            ++column_index;
         }
-        ++i;
+        ++row_index;
     }
     this->_mutex.unlock(THREAD_ID);
     return (result);
@@ -315,52 +315,52 @@ ElementType ft_matrix<ElementType>::determinant() const
         this->_mutex.unlock(THREAD_ID);
         return (det);
     }
-    size_t idx = 0;
-    while (idx < size)
+    size_t index = 0;
+    while (index < size)
     {
-        temp[idx] = this->_data[idx];
-        ++idx;
+        temp[index] = this->_data[index];
+        ++index;
     }
     ElementType result = ElementType();
     result = result + 1; // initialize to 1
-    size_t i = 0;
-    while (i < n)
+    size_t pivot_row = 0;
+    while (pivot_row < n)
     {
-        size_t pivot = i;
-        while (pivot < n && temp[pivot * n + i] == ElementType())
+        size_t pivot = pivot_row;
+        while (pivot < n && temp[pivot * n + pivot_row] == ElementType())
             ++pivot;
         if (pivot == n)
         {
             result = ElementType();
             break;
         }
-        if (pivot != i)
+        if (pivot != pivot_row)
         {
-            size_t k = 0;
-            while (k < n)
+            size_t swap_index = 0;
+            while (swap_index < n)
             {
-                ElementType tmp = temp[i * n + k];
-                temp[i * n + k] = temp[pivot * n + k];
-                temp[pivot * n + k] = tmp;
-                ++k;
+                ElementType tmp = temp[pivot_row * n + swap_index];
+                temp[pivot_row * n + swap_index] = temp[pivot * n + swap_index];
+                temp[pivot * n + swap_index] = tmp;
+                ++swap_index;
             }
             result = result * static_cast<ElementType>(-1);
         }
-        ElementType pivotVal = temp[i * n + i];
+        ElementType pivotVal = temp[pivot_row * n + pivot_row];
         result = result * pivotVal;
-        size_t j = i + 1;
-        while (j < n)
+        size_t row_below = pivot_row + 1;
+        while (row_below < n)
         {
-            ElementType factor = temp[j * n + i] / pivotVal;
-            size_t k = i;
-            while (k < n)
+            ElementType factor = temp[row_below * n + pivot_row] / pivotVal;
+            size_t column = pivot_row;
+            while (column < n)
             {
-                temp[j * n + k] = temp[j * n + k] - factor * temp[i * n + k];
-                ++k;
+                temp[row_below * n + column] = temp[row_below * n + column] - factor * temp[pivot_row * n + column];
+                ++column;
             }
-            ++j;
+            ++row_below;
         }
-        ++i;
+        ++pivot_row;
     }
     cma_free(temp);
     this->_mutex.unlock(THREAD_ID);

--- a/Template/shared_ptr.hpp
+++ b/Template/shared_ptr.hpp
@@ -534,8 +534,12 @@ void ft_sharedptr<ManagedType>::add(const ManagedType& element)
         this->set_error(SHARED_PTR_ALLOCATION_FAILED);
         return ;
     }
-    for (size_t i = 0; i < _arraySize; ++i)
-        newArray[i] = _managedPointer[i];
+    size_t array_index = 0;
+    while (array_index < _arraySize)
+    {
+        newArray[array_index] = _managedPointer[array_index];
+        ++array_index;
+    }
     newArray[_arraySize] = element;
     delete[] _managedPointer;
     _managedPointer = newArray;
@@ -563,10 +567,18 @@ void ft_sharedptr<ManagedType>::remove(int index)
         this->set_error(SHARED_PTR_ALLOCATION_FAILED);
         return ;
     }
-    for (size_t i = 0; i < static_cast<size_t>(index); ++i)
-        newArray[i] = _managedPointer[i];
-    for (size_t i = index; i < newSize; ++i)
-        newArray[i] = _managedPointer[i+1];
+    size_t array_index = 0;
+    while (array_index < static_cast<size_t>(index))
+    {
+        newArray[array_index] = _managedPointer[array_index];
+        ++array_index;
+    }
+    size_t copy_index = index;
+    while (copy_index < newSize)
+    {
+        newArray[copy_index] = _managedPointer[copy_index+1];
+        ++copy_index;
+    }
     delete[] _managedPointer;
     _managedPointer = newArray;
     _arraySize = newSize;

--- a/Template/thread_pool.hpp
+++ b/Template/thread_pool.hpp
@@ -132,10 +132,12 @@ inline void ft_thread_pool::destroy()
         this->_stop = true;
     }
     this->_cond.notify_all();
-    for (size_t i = 0; i < this->_workers.size(); ++i)
+    size_t i = 0;
+    while (i < this->_workers.size())
     {
         if (this->_workers[i].joinable())
             this->_workers[i].join();
+        ++i;
     }
     this->_workers.clear();
 }

--- a/Template/vector.hpp
+++ b/Template/vector.hpp
@@ -134,8 +134,12 @@ ft_vector<ElementType>& ft_vector<ElementType>::operator=(ft_vector<ElementType>
 template <typename ElementType>
 void ft_vector<ElementType>::destroy_elements(size_t from, size_t to)
 {
-    for (size_t index = from; index < to; index++)
+    size_t index = from;
+    while (index < to)
+    {
         destroy_at(&this->_data[index]);
+        ++index;
+    }
     return ;
 }
 
@@ -357,8 +361,12 @@ void ft_vector<ElementType>::resize(size_t new_size, const ElementType& value)
             this->_mutex.unlock(THREAD_ID);
             return ;
         }
-        for (size_t index = this->_size; index < new_size; index++)
+        size_t index = this->_size;
+        while (index < new_size)
+        {
             construct_at(&this->_data[index], value);
+            ++index;
+        }
     }
     this->_size = new_size;
     this->_mutex.unlock(THREAD_ID);
@@ -423,10 +431,12 @@ typename ft_vector<ElementType>::iterator ft_vector<ElementType>::erase(iterator
         return (endIt);
     }
     destroy_at(&this->_data[index]);
-    for (size_t i = index; i < this->_size - 1; i++)
+    size_t i = index;
+    while (i < this->_size - 1)
     {
         construct_at(&this->_data[i], this->_data[i + 1]);
         destroy_at(&this->_data[i + 1]);
+        ++i;
     }
     --this->_size;
     iterator ret;
@@ -453,8 +463,12 @@ ElementType ft_vector<ElementType>::release_at(size_t index)
         return (ElementType());
     }
     ElementType detached = ft_move(this->_data[index]);
-    for (size_t i = index; i < this->_size - 1; i++)
-        this->_data[i] = ft_move(this->_data[i + 1]);
+    size_t i2 = index;
+    while (i2 < this->_size - 1)
+    {
+        this->_data[i2] = ft_move(this->_data[i2 + 1]);
+        ++i2;
+    }
     --this->_size;
     this->_mutex.unlock(THREAD_ID);
     return (detached);

--- a/Test/test_html.cpp
+++ b/Test/test_html.cpp
@@ -1,5 +1,6 @@
 #include "../HTML/html_parser.hpp"
 #include "../CMA/CMA.hpp"
+#include "../CPP_class/nullptr.hpp"
 #include <cstring>
 
 int test_html_create_node(void)
@@ -15,8 +16,8 @@ int test_html_create_node(void)
 
 int test_html_find_by_tag(void)
 {
-    html_node *root = html_create_node("div", NULL);
-    html_node *child = html_create_node("span", NULL);
+    html_node *root = html_create_node("div", ft_nullptr);
+    html_node *child = html_create_node("span", ft_nullptr);
     html_add_child(root, child);
     html_node *found = html_find_by_tag(root, "span");
     int ok = (found == child);
@@ -38,8 +39,8 @@ int test_html_write_to_string(void)
 
 int test_html_find_by_attr(void)
 {
-    html_node *root = html_create_node("div", NULL);
-    html_node *child = html_create_node("p", NULL);
+    html_node *root = html_create_node("div", ft_nullptr);
+    html_node *child = html_create_node("p", ft_nullptr);
     html_attr *attr = html_create_attr("id", "main");
     html_add_attr(child, attr);
     html_add_child(root, child);

--- a/Windows/windows_file.cpp
+++ b/Windows/windows_file.cpp
@@ -127,7 +127,7 @@ ssize_t ft_read(int fd, void *buf, unsigned int count)
         }
     }
     DWORD bytesRead = 0;
-    BOOL ok = ReadFile(hFile, buf, count, &bytesRead, NULL);
+    BOOL ok = ReadFile(hFile, buf, count, &bytesRead, ft_nullptr);
     if (!ok)
     {
         g_file_mutex.unlock(GetCurrentThreadId());
@@ -143,7 +143,7 @@ ssize_t ft_write(int fd, const void *buf, unsigned int count)
     if (hFile == INVALID_HANDLE_VALUE)
         return (-1);
     DWORD bytesWritten = 0;
-    BOOL ok = WriteFile(hFile, buf, count, &bytesWritten, NULL);
+    BOOL ok = WriteFile(hFile, buf, count, &bytesWritten, ft_nullptr);
     g_file_mutex.unlock(GetCurrentThreadId());
     if (!ok)
         return (-1);

--- a/encryption/BasicEncryption.cpp
+++ b/encryption/BasicEncryption.cpp
@@ -8,35 +8,43 @@
 #include "../CPP_class/nullptr.hpp"
 #include "BasicEncryption.hpp"
 
-static void be_encrypt(char *data, size_t data_len, const char *key)
+static void be_encrypt(char *data, size_t data_length, const char *key)
 {
     uint32_t hash = 5381;
-    size_t key_len = ft_strlen(key);
-    for (size_t i = 0; i < key_len; ++i)
-        hash = ((hash << 5) + hash) + static_cast<uint8_t>(key[i]);
-    for (size_t i = 0; i < data_len; ++i)
-        data[i] ^= static_cast<char>((hash >> (i % 8)) & 0xFF);
+    size_t key_length = ft_strlen(key);
+    size_t key_index = 0;
+    while (key_index < key_length)
+    {
+        hash = ((hash << 5) + hash) + static_cast<uint8_t>(key[key_index]);
+        ++key_index;
+    }
+    size_t data_index = 0;
+    while (data_index < data_length)
+    {
+        data[data_index] ^= static_cast<char>((hash >> (data_index % 8)) & 0xFF);
+        ++data_index;
+    }
     return ;
 }
 
 int be_saveGame(const char *filename, const char *data, const char *key)
 {
-    size_t data_len = ft_strlen(data);
-    char *encryptedData = static_cast<char *>(cma_malloc(data_len));
-    if (!encryptedData)
+    size_t data_length = ft_strlen(data);
+    char *encrypted_data = static_cast<char *>(cma_malloc(data_length));
+    if (!encrypted_data)
         return (1);
-    ft_memcpy(encryptedData, data, data_len);
-    be_encrypt(encryptedData, data_len, key);
-    int fd = ft_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    if (fd < 0)
+    ft_memcpy(encrypted_data, data, data_length);
+    be_encrypt(encrypted_data, data_length, key);
+    int file_descriptor = ft_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (file_descriptor < 0)
     {
-        cma_free(encryptedData);
+        cma_free(encrypted_data);
         return (1);
     }
-    ssize_t written = ft_write(fd, encryptedData, static_cast<int>(data_len));
-    ft_close(fd);
-    cma_free(encryptedData);
-    if (written == static_cast<ssize_t>(data_len))
+    ssize_t bytes_written = ft_write(file_descriptor, encrypted_data, static_cast<int>(data_length));
+    ft_close(file_descriptor);
+    cma_free(encrypted_data);
+    if (bytes_written == static_cast<ssize_t>(data_length))
         return (0);
     return (1);
 }
@@ -45,7 +53,7 @@ char **be_DecryptData(char **data, const char *key)
 {
     if (!data || !*data)
         return (ft_nullptr);
-    size_t len = ft_strlen(*data);
-    be_encrypt(*data, len, key);
+    size_t data_length = ft_strlen(*data);
+    be_encrypt(*data, data_length, key);
     return (data);
 }

--- a/encryption/encryption_key.cpp
+++ b/encryption/encryption_key.cpp
@@ -9,46 +9,52 @@
 static void decoy_unusedFunction1(void)
 {
     volatile int dummy = 0;
-    for (int i = 0; i < 10; i++)
-        dummy += i;
+    int index = 0;
+    while (index < 10)
+    {
+        dummy += index;
+        ++index;
+    }
     return ;
 }
 
-static uint32_t decoy_unusedFunction2(uint32_t x)
+static uint32_t decoy_unusedFunction2(uint32_t value)
 {
-    x ^= 0xAAAAAAAA;
-    x ^= 0xAAAAAAAA;
-    return (x);
+    value ^= 0xAAAAAAAA;
+    value ^= 0xAAAAAAAA;
+    return (value);
 }
 
-static int decoy_unusedFunction3(const char* input)
+static int decoy_unusedFunction3(const char* input_string)
 {
-    (void)input;
+    (void)input_string;
     return (42);
 }
 
-static uint32_t obfuscate_seed(uint32_t seed)
+static uint32_t obfuscate_seed(uint32_t seed_value)
 {
     decoy_unusedFunction1();
-    seed = decoy_unusedFunction2(seed);
-    return (seed);
+    seed_value = decoy_unusedFunction2(seed_value);
+    return (seed_value);
 }
 
 const char *be_getEncryptionKey(void)
 {
-    size_t key_len = 32;
-    char *key = static_cast<char *>(cma_malloc(key_len + 1));
+    size_t key_length = 32;
+    char *key = static_cast<char *>(cma_malloc(key_length + 1));
     if (!key)
         return (ft_nullptr);
-    uint32_t seed = 0xDEADBEEF;
-    seed = obfuscate_seed(seed);
-    for (size_t i = 0; i < key_len; i++)
+    uint32_t seed_value = 0xDEADBEEF;
+    seed_value = obfuscate_seed(seed_value);
+    size_t index = 0;
+    while (index < key_length)
     {
         decoy_unusedFunction3(key);
-        seed = seed * 1103515245 + 12345;
-        key[i] = static_cast<char>('A' + (seed % 26));
+        seed_value = seed_value * 1103515245 + 12345;
+        key[index] = static_cast<char>('A' + (seed_value % 26));
+        ++index;
     }
-    key[key_len] = '\0';
+    key[key_length] = '\0';
     decoy_unusedFunction1();
     return (key);
 }

--- a/file/file_check_directory.cpp
+++ b/file/file_check_directory.cpp
@@ -17,10 +17,12 @@
 #if defined(_WIN32) || defined(_WIN64)
     if (!data)
         return ;
-    for (size_t i = 0; data[i] != '\0'; ++i)
+    size_t index = 0;
+    while (data[index] != '\0')
     {
-        if (data[i] == '/')
-            data[i] = PATH_SEP;
+        if (data[index] == '/')
+            data[index] = PATH_SEP;
+        ++index;
     }
 #else
     (void)data;
@@ -35,8 +37,8 @@ static inline int dir_exists_platform(const char *path)
     if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY))
         return (0);
 #else
-    struct stat st;
-    if (stat(path, &st) == 0 && S_ISDIR(st.st_mode))
+    struct stat stat_buffer;
+    if (stat(path, &stat_buffer) == 0 && S_ISDIR(stat_buffer.st_mode))
         return (0);
 #endif
     return (1);

--- a/file/file_mkdir.cpp
+++ b/file/file_mkdir.cpp
@@ -1,4 +1,5 @@
 #include "open_dir.hpp"
+#include "../CPP_class/nullptr.hpp"
 
 #ifdef _WIN32
 # include <windows.h>
@@ -8,7 +9,7 @@
 int file_create_directory(const char* path, mode_t mode)
 {
     (void)mode;
-    if (CreateDirectoryA(path, NULL))
+    if (CreateDirectoryA(path, ft_nullptr))
         return (0);
     return (-1);
 }


### PR DESCRIPTION
## Summary
- add helper functions to send API requests with Basic authorization headers
- add helper functions to send API requests with Bearer authorization headers
- add utility to gather single-letter flags from command line arguments
- add parser for long `--word` flags, ignoring duplicates
- refactor config parsing by moving flag parsers into `config_flags.cpp` for clarity
- replace remaining `for` loops with equivalent `while` loops across the library
- rename short variables to descriptive names in configuration parsing, numeric utilities, networking helpers, and broader library modules
- use `ft_nullptr` instead of `NULL` throughout the library and documentation

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b4290ef4448331a52231a0bc53bc8f