### PR TITLE
Free empty CMA pages for heap allocations

### DIFF
--- a/CMA/CMA_internal.hpp
+++ b/CMA/CMA_internal.hpp
@@ -61,6 +61,8 @@ Page    *create_page(std::size_t size);
 Block    *find_free_block(std::size_t size);
 Block    *merge_block(Block *block);
 void    print_block_info(Block *block);
+Page    *find_page_of_block(Block *block);
+void    free_page_if_empty(Page *page);
 
 inline __attribute__((always_inline, hot)) std::size_t align16(size_t size)
 {

--- a/CMA/cma_free.cpp
+++ b/CMA/cma_free.cpp
@@ -31,7 +31,9 @@ void cma_free(void* ptr)
         raise(SIGABRT);
     }
     block->free = true;
-    merge_block(block);
+    block = merge_block(block);
+    Page *page = find_page_of_block(block);
+    free_page_if_empty(page);
     g_malloc_mutex.unlock(THREAD_ID);
     if (ft_log_get_alloc_logging())
         ft_log_debug("cma_free %p", ptr);

--- a/CMA/cma_free_checked.cpp
+++ b/CMA/cma_free_checked.cpp
@@ -41,7 +41,9 @@ int cma_checked_free(void* ptr)
         return (-1);
     }
     found->free = true;
-    merge_block(found);
+    found = merge_block(found);
+    Page *pg = find_page_of_block(found);
+    free_page_if_empty(pg);
     g_malloc_mutex.unlock(THREAD_ID);
     return (0);
 }

--- a/CMA/cma_utils.cpp
+++ b/CMA/cma_utils.cpp
@@ -172,6 +172,41 @@ Block *merge_block(Block *block)
     return (block);
 }
 
+Page *find_page_of_block(Block *block)
+{
+    Page *page = page_list;
+    while (page)
+    {
+        char *start = static_cast<char*>(page->start);
+        char *end = start + page->size;
+        if (reinterpret_cast<char*>(block) >= start &&
+            reinterpret_cast<char*>(block) < end)
+            return (page);
+        page = page->next;
+    }
+    return (ft_nullptr);
+}
+
+void free_page_if_empty(Page *page)
+{
+    if (!page || page->heap == false)
+        return ;
+    if (page->blocks && page->blocks->free &&
+        page->blocks->next == ft_nullptr &&
+        page->blocks->prev == ft_nullptr)
+    {
+        if (page->prev)
+            page->prev->next = page->next;
+        if (page->next)
+            page->next->prev = page->prev;
+        if (page_list == page)
+            page_list = page->next;
+        std::free(page->start);
+        std::free(page);
+    }
+    return ;
+}
+
 static inline void print_block_info_impl(Block *block)
 {
 #ifdef _WIN32


### PR DESCRIPTION
## Summary
- free completely unused heap pages in the Custom Memory Allocator
- add helpers to locate a block's page and dispose of empty pages while ignoring the initial stack page

## Testing
- `make -C CMA`
- `make -C Test libft_tests SRCS="main.cpp test_cma.cpp"` *(fails: No rule to make target 'objs/main.o', needed by 'GetNextLine.a')*

------
https://chatgpt.com/codex/tasks/task_e_68b495c043fc833180734bad10553bcb