### PR TITLE
Add octal, %n, %f, %e, %g specifiers to printf, URL-based API helpers, HTML tag/attribute/text removal and search, and tag counting

### DIFF
--- a/API/api.hpp
+++ b/API/api.hpp
@@ -96,4 +96,12 @@ json_group *api_request_json_tls_basic(const char *host, uint16_t port,
         json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
         int *status = ft_nullptr, int timeout = 60000);
 
+char    *api_request_string_url(const char *url, const char *method,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
+json_group *api_request_json_url(const char *url, const char *method,
+        json_group *payload = ft_nullptr, const char *headers = ft_nullptr,
+        int *status = ft_nullptr, int timeout = 60000);
+
 #endif

--- a/HTML/html_cleanup.cpp
+++ b/HTML/html_cleanup.cpp
@@ -1,4 +1,6 @@
 #include "html_parser.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/nullptr.hpp"
 
 void html_free_nodes(html_node *nodeList)
 {
@@ -25,4 +27,92 @@ void html_free_nodes(html_node *nodeList)
         nodeList = nextNode;
     }
     return ;
+}
+
+void html_remove_nodes_by_tag(html_node **nodeList, const char *tagName)
+{
+    html_node *current = *nodeList;
+    html_node *prev = ft_nullptr;
+    while (current)
+    {
+        html_node *next = current->next;
+        if (current->tag && ft_strcmp(current->tag, tagName) == 0)
+        {
+            if (prev)
+                prev->next = next;
+            else
+                *nodeList = next;
+            current->next = ft_nullptr;
+            html_free_nodes(current);
+        }
+        else
+        {
+            html_remove_nodes_by_tag(&current->children, tagName);
+            prev = current;
+        }
+        current = next;
+    }
+}
+
+void html_remove_nodes_by_attr(html_node **nodeList, const char *key, const char *value)
+{
+    html_node *current = *nodeList;
+    html_node *prev = ft_nullptr;
+    while (current)
+    {
+        html_node *next = current->next;
+        html_attr *attr = current->attributes;
+        int match = 0;
+        while (attr)
+        {
+            if (attr->key && attr->value &&
+                ft_strcmp(attr->key, key) == 0 &&
+                ft_strcmp(attr->value, value) == 0)
+            {
+                match = 1;
+                break;
+            }
+            attr = attr->next;
+        }
+        if (match)
+        {
+            if (prev)
+                prev->next = next;
+            else
+                *nodeList = next;
+            current->next = ft_nullptr;
+            html_free_nodes(current);
+        }
+        else
+        {
+            html_remove_nodes_by_attr(&current->children, key, value);
+            prev = current;
+        }
+        current = next;
+    }
+}
+
+void html_remove_nodes_by_text(html_node **nodeList, const char *textContent)
+{
+    html_node *current = *nodeList;
+    html_node *prev = ft_nullptr;
+    while (current)
+    {
+        html_node *next = current->next;
+        if (current->text && ft_strcmp(current->text, textContent) == 0)
+        {
+            if (prev)
+                prev->next = next;
+            else
+                *nodeList = next;
+            current->next = ft_nullptr;
+            html_free_nodes(current);
+        }
+        else
+        {
+            html_remove_nodes_by_text(&current->children, textContent);
+            prev = current;
+        }
+        current = next;
+    }
 }

--- a/HTML/html_parser.hpp
+++ b/HTML/html_parser.hpp
@@ -28,7 +28,12 @@ void        html_remove_attr(html_node *targetNode, const char *key);
 int         html_write_to_file(const char *filePath, html_node *nodeList);
 char        *html_write_to_string(html_node *nodeList);
 void        html_free_nodes(html_node *nodeList);
+void        html_remove_nodes_by_tag(html_node **nodeList, const char *tagName);
+void        html_remove_nodes_by_attr(html_node **nodeList, const char *key, const char *value);
+void        html_remove_nodes_by_text(html_node **nodeList, const char *textContent);
 html_node   *html_find_by_tag(html_node *nodeList, const char *tagName);
 html_node   *html_find_by_attr(html_node *nodeList, const char *key, const char *value);
+html_node   *html_find_by_text(html_node *nodeList, const char *textContent);
+size_t      html_count_nodes_by_tag(html_node *nodeList, const char *tagName);
 
 #endif

--- a/HTML/html_search.cpp
+++ b/HTML/html_search.cpp
@@ -39,3 +39,32 @@ html_node *html_find_by_attr(html_node *nodeList, const char *key, const char *v
     }
     return (ft_nullptr);
 }
+
+html_node *html_find_by_text(html_node *nodeList, const char *textContent)
+{
+    html_node *currentNode = nodeList;
+    while (currentNode)
+    {
+        if (currentNode->text && ft_strcmp(currentNode->text, textContent) == 0)
+            return (currentNode);
+        html_node *found = html_find_by_text(currentNode->children, textContent);
+        if (found)
+            return (found);
+        currentNode = currentNode->next;
+    }
+    return (ft_nullptr);
+}
+
+size_t html_count_nodes_by_tag(html_node *nodeList, const char *tagName)
+{
+    size_t count = 0;
+    html_node *currentNode = nodeList;
+    while (currentNode)
+    {
+        if (currentNode->tag && ft_strcmp(currentNode->tag, tagName) == 0)
+            ++count;
+        count += html_count_nodes_by_tag(currentNode->children, tagName);
+        currentNode = currentNode->next;
+    }
+    return (count);
+}

--- a/Printf/format.cpp
+++ b/Printf/format.cpp
@@ -93,6 +93,41 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
                     ft_puthex_fd(number, fd, uppercase, &count);
                 }
             }
+            else if (spec == 'o')
+            {
+                if (len_mod == LEN_L)
+                {
+                    uintmax_t number = va_arg(args, unsigned long);
+                    ft_putoctal_fd(number, fd, &count);
+                }
+                else if (len_mod == LEN_Z)
+                {
+                    size_t number = va_arg(args, size_t);
+                    ft_putoctal_fd(number, fd, &count);
+                }
+                else
+                {
+                    unsigned int number = va_arg(args, unsigned int);
+                    ft_putoctal_fd(number, fd, &count);
+                }
+            }
+            else if (spec == 'f')
+            {
+                double number = va_arg(args, double);
+                ft_putfloat_fd(number, fd, &count);
+            }
+            else if (spec == 'e' || spec == 'E')
+            {
+                bool uppercase = (spec == 'E');
+                double number = va_arg(args, double);
+                ft_putscientific_fd(number, uppercase, fd, &count);
+            }
+            else if (spec == 'g' || spec == 'G')
+            {
+                bool uppercase = (spec == 'G');
+                double number = va_arg(args, double);
+                ft_putgeneral_fd(number, uppercase, fd, &count);
+            }
             else if (spec == 'p')
             {
                 void *pointer = va_arg(args, void *);
@@ -105,6 +140,27 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
                     ft_putstr_fd("true", fd, &count);
                 else
                     ft_putstr_fd("false", fd, &count);
+            }
+            else if (spec == 'n')
+            {
+                if (len_mod == LEN_L)
+                {
+                    long *out = va_arg(args, long *);
+                    if (out)
+                        *out = static_cast<long>(count);
+                }
+                else if (len_mod == LEN_Z)
+                {
+                    size_t *out = va_arg(args, size_t *);
+                    if (out)
+                        *out = count;
+                }
+                else
+                {
+                    int *out = va_arg(args, int *);
+                    if (out)
+                        *out = static_cast<int>(count);
+                }
             }
             else if (spec == '%')
                 ft_putchar_fd('%', fd, &count);

--- a/Printf/print_args.cpp
+++ b/Printf/print_args.cpp
@@ -113,10 +113,131 @@ void ft_puthex_fd(uintmax_t number, int fd, bool uppercase, size_t *count)
     return ;
 }
 
+void ft_putoctal_fd_recursive(uintmax_t number, int fd, size_t *count)
+{
+    char character;
+
+    if (number >= 8)
+        ft_putoctal_fd_recursive(number / 8, fd, count);
+    character = static_cast<char>('0' + (number % 8));
+    ft_putchar_fd(character, fd, count);
+    return ;
+}
+
+void ft_putoctal_fd(uintmax_t number, int fd, size_t *count)
+{
+    ft_putoctal_fd_recursive(number, fd, count);
+    return ;
+}
+
 void ft_putptr_fd(void *pointer, int fd, size_t *count)
 {
     uintptr_t address = reinterpret_cast<uintptr_t>(pointer);
     ft_putstr_fd("0x", fd, count);
     ft_puthex_fd(address, fd, false, count);
+    return ;
+}
+
+void ft_putfloat_fd(double number, int fd, size_t *count)
+{
+    if (number < 0)
+    {
+        ft_putchar_fd('-', fd, count);
+        number = -number;
+    }
+    long integer_part = static_cast<long>(number);
+    ft_putnbr_fd(integer_part, fd, count);
+    ft_putchar_fd('.', fd, count);
+    double fractional = number - static_cast<double>(integer_part);
+    for (int i = 0; i < 6; ++i)
+    {
+        fractional *= 10;
+        int digit = static_cast<int>(fractional);
+        ft_putchar_fd(static_cast<char>('0' + digit), fd, count);
+        fractional -= digit;
+    }
+    return ;
+}
+
+void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count)
+{
+    if (number == 0.0)
+    {
+        if (uppercase)
+            ft_putstr_fd("0.000000E+00", fd, count);
+        else
+            ft_putstr_fd("0.000000e+00", fd, count);
+        return ;
+    }
+    if (number < 0)
+    {
+        ft_putchar_fd('-', fd, count);
+        number = -number;
+    }
+    int exponent = 0;
+    while (number >= 10.0)
+    {
+        number /= 10.0;
+        exponent++;
+    }
+    while (number < 1.0)
+    {
+        number *= 10.0;
+        exponent--;
+    }
+    long integer_part = static_cast<long>(number);
+    ft_putchar_fd(static_cast<char>('0' + integer_part), fd, count);
+    ft_putchar_fd('.', fd, count);
+    double fractional = number - static_cast<double>(integer_part);
+    for (int i = 0; i < 6; ++i)
+    {
+        fractional *= 10.0;
+        int digit = static_cast<int>(fractional);
+        ft_putchar_fd(static_cast<char>('0' + digit), fd, count);
+        fractional -= digit;
+    }
+    ft_putchar_fd(uppercase ? 'E' : 'e', fd, count);
+    if (exponent >= 0)
+        ft_putchar_fd('+', fd, count);
+    else
+    {
+        ft_putchar_fd('-', fd, count);
+        exponent = -exponent;
+    }
+    if (exponent >= 100)
+        ft_putnbr_fd(exponent, fd, count);
+    else
+    {
+        ft_putchar_fd(static_cast<char>('0' + (exponent / 10)), fd, count);
+        ft_putchar_fd(static_cast<char>('0' + (exponent % 10)), fd, count);
+    }
+    return ;
+}
+
+void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count)
+{
+    if (number == 0.0)
+    {
+        ft_putfloat_fd(0.0, fd, count);
+        return ;
+    }
+    double temp = number;
+    if (temp < 0)
+        temp = -temp;
+    int exponent = 0;
+    while (temp >= 10.0)
+    {
+        temp /= 10.0;
+        exponent++;
+    }
+    while (temp < 1.0)
+    {
+        temp *= 10.0;
+        exponent--;
+    }
+    if (exponent < -4 || exponent >= 6)
+        ft_putscientific_fd(number, uppercase, fd, count);
+    else
+        ft_putfloat_fd(number, fd, count);
     return ;
 }

--- a/Printf/printf_internal.hpp
+++ b/Printf/printf_internal.hpp
@@ -25,7 +25,12 @@ void ft_putunsigned_fd_recursive(uintmax_t number, int fd, size_t *count);
 void ft_putunsigned_fd(uintmax_t number, int fd, size_t *count);
 void ft_puthex_fd_recursive(uintmax_t number, int fd, bool uppercase, size_t *count);
 void ft_puthex_fd(uintmax_t number, int fd, bool uppercase, size_t *count);
+void ft_putoctal_fd_recursive(uintmax_t number, int fd, size_t *count);
+void ft_putoctal_fd(uintmax_t number, int fd, size_t *count);
 void ft_putptr_fd(void *pointer, int fd, size_t *count);
+void ft_putfloat_fd(double number, int fd, size_t *count);
+void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count);
+void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count);
 int pf_printf_fd_v(int fd, const char *format, va_list args);
 
 #endif


### PR DESCRIPTION
## Summary
- extend printf library with `%g`/`%G`, `%e`/`%E`, `%f`, `%n`, and `%o` formatting support
- add convenience helpers `api_request_string_url`/`api_request_json_url` that accept full URLs and dispatch to HTTP or HTTPS as needed
- allow pruning HTML node trees via `html_remove_nodes_by_tag`, `html_remove_nodes_by_attr`, and `html_remove_nodes_by_text`
- enable searching for HTML nodes by exact text content with `html_find_by_text`
- count HTML nodes of a given tag using the new `html_count_nodes_by_tag`

## Testing
- `make -C HTML`
- `make -C Printf`
- `make -C API`


------
https://chatgpt.com/codex/tasks/task_e_68b73e2da9dc8331b2fbf8efa2f18e51