### PR TITLE
Fix ft_strchr behavior and add regression test

### DIFF
--- a/Libft/ft_strchr.cpp
+++ b/Libft/ft_strchr.cpp
@@ -3,22 +3,16 @@
 
 char    *ft_strchr(const char *string, int char_to_find)
 {
-    char    target_char;
-    char    *last_occurrence;
-
     if (!string)
         return (ft_nullptr);
-    if (!string)
-        return (ft_nullptr);
-    target_char = static_cast<char>(char_to_find);
-    last_occurrence = ft_nullptr;
+    char target_char = static_cast<char>(char_to_find);
     while (*string)
     {
         if (*string == target_char)
-            last_occurrence = const_cast<char *>(string);
-        string++;
+            return (const_cast<char *>(string));
+        ++string;
     }
     if (target_char == '\0')
         return (const_cast<char *>(string));
-    return (last_occurrence);
+    return (ft_nullptr);
 }

--- a/Libft/ft_strrchr.cpp
+++ b/Libft/ft_strrchr.cpp
@@ -3,14 +3,14 @@
 
 char    *ft_strrchr(const char *string, int char_to_find)
 {
-    int     string_length;
-
-    string_length = ft_strlen(string);
+    if (!string)
+        return (ft_nullptr);
+    int string_length = ft_strlen(string);
     while (string_length > 0)
     {
         if (string[string_length] == static_cast<char>(char_to_find))
             return (const_cast<char*>(string) + string_length);
-        string_length--;
+        --string_length;
     }
     if (string[string_length] == static_cast<char>(char_to_find))
         return (const_cast<char*>(string) + string_length);

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -81,6 +81,7 @@ int test_memcmp_basic(void);
 int test_memcmp_diff(void);
 int test_strchr_basic(void);
 int test_strchr_not_found(void);
+int test_strchr_first_occurrence(void);
 int test_strrchr_basic(void);
 int test_strrchr_not_found(void);
 int test_strnstr_basic(void);
@@ -280,6 +281,7 @@ int main(int argc, char **argv)
         { test_memchr_found, "memchr found" },
         { test_memcmp_basic, "memcmp basic" },
         { test_strchr_basic, "strchr basic" },
+        { test_strchr_first_occurrence, "strchr first occurrence" },
         { test_strrchr_basic, "strrchr basic" },
         { test_strnstr_basic, "strnstr basic" },
         { test_strlcpy_basic, "strlcpy basic" },

--- a/Test/test_extra_libft.cpp
+++ b/Test/test_extra_libft.cpp
@@ -131,6 +131,12 @@ int test_strchr_not_found(void)
     return (ft_strchr(str, 'x') == ft_nullptr);
 }
 
+int test_strchr_first_occurrence(void)
+{
+    const char *str = "banana";
+    return (ft_strchr(str, 'a') == str + 1);
+}
+
 int test_strrchr_basic(void)
 {
     const char *str = "hello";


### PR DESCRIPTION
## Summary
- Correct ft_strchr to return the first matching character and handle null pointers
- Guard ft_strrchr against null input
- Add regression test verifying ft_strchr finds first occurrence

## Testing
- `cd Test && make` (fails: 't_queue' not declared)


------
https://chatgpt.com/codex/tasks/task_e_68b826a9024083319cdf5413ae919374