### PR TITLE
Fix ft_strrchr length handling

### DIFF
--- a/Libft/ft_strrchr.cpp
+++ b/Libft/ft_strrchr.cpp
@@ -5,14 +5,15 @@ char    *ft_strrchr(const char *string, int char_to_find)
 {
     if (!string)
         return (ft_nullptr);
-    int string_length = ft_strlen(string);
+    size_t string_length = ft_strlen_size_t(string);
+    char target_char = static_cast<char>(char_to_find);
     while (string_length > 0)
     {
-        if (string[string_length] == static_cast<char>(char_to_find))
-            return (const_cast<char*>(string) + string_length);
+        if (string[string_length] == target_char)
+            return (const_cast<char *>(string) + string_length);
         --string_length;
     }
-    if (string[string_length] == static_cast<char>(char_to_find))
-        return (const_cast<char*>(string) + string_length);
+    if (string[string_length] == target_char)
+        return (const_cast<char *>(string) + string_length);
     return (ft_nullptr);
 }


### PR DESCRIPTION
## Summary
- prevent overflow in `ft_strrchr` by using `ft_strlen_size_t`

## Testing
- `make -C Test` *(fails: t_queue and related symbols undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68b87d3f99608331baf9ac4f1ac8cb7c