### PR TITLE
chore: include all submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,17 @@ else
 endif
 
 SUBDIRS :=  CMA \
-            GetNextLine \
-            Libft \
-            Logger \
-            Printf \
-            ReadLine \
-            PThread \
-            CPP_class \
-            Errno \
-            Config \
-            Networking \
-            API
+	    GetNextLine \
+	    Libft \
+	    Logger \
+	    Printf \
+	    ReadLine \
+	    PThread \
+	    CPP_class \
+	    Errno \
+	    Config \
+	    Networking \
+	    API
 
 ifeq ($(OS),Windows_NT)
 SUBDIRS += Windows
@@ -46,15 +46,8 @@ LIB_BASES := \
   Errno/errno \
   Config/config \
   Networking/networking \
-  API/API
-
-ifeq ($(OS),Windows_NT)
-LIB_BASES += Windows/Windows
-else
-LIB_BASES += Linux/Linux
-endif
-
-LIB_BASES += encryption/encryption \
+  API/API \
+  encryption/encryption \
   RNG/RNG \
   JSon/JSon \
   file/file \
@@ -62,15 +55,9 @@ LIB_BASES += encryption/encryption \
   Game/Game
 
 ifeq ($(OS),Windows_NT)
-OS_EXTRACT = $(call EXTRACT,Windows/Windows.a)
-DEBUG_OS_EXTRACT = $(call EXTRACT,Windows/Windows_debug.a)
-OS_CLEAN := $(MAKE) -C Windows clean
-OS_FCLEAN := $(MAKE) -C Windows fclean
+LIB_BASES += Windows/Windows
 else
-OS_EXTRACT = $(call EXTRACT,Linux/Linux.a)
-DEBUG_OS_EXTRACT = $(call EXTRACT,Linux/Linux_debug.a)
-OS_CLEAN := $(MAKE) -C Linux clean
-OS_FCLEAN := $(MAKE) -C Linux fclean
+LIB_BASES += Linux/Linux
 endif
 
 LIBS       := $(addsuffix .a, $(LIB_BASES))
@@ -88,32 +75,14 @@ both: all debug
 re: fclean all
 
 define EXTRACT
-cd temp_objs && $(AR) x ../$1 && cd ..
+cd temp_objs && $(AR) x ../$1 && cd ..;
 endef
 
 $(TARGET): $(LIBS)
 	@echo "Linking libraries into $(TARGET)..."
 	$(RM) $@
 	$(MKDIR) temp_objs
-	$(call EXTRACT,CMA/CustomMemoryAllocator.a)
-	$(call EXTRACT,GetNextLine/GetNextLine.a)
-	$(call EXTRACT,Libft/LibFT.a)
-	$(call EXTRACT,Logger/Logger.a)
-	$(call EXTRACT,Printf/Printf.a)
-	$(call EXTRACT,ReadLine/ReadLine.a)
-	$(call EXTRACT,PThread/PThread.a)
-	$(call EXTRACT,CPP_class/CPP_class.a)
-	$(call EXTRACT,Errno/errno.a)
-	$(call EXTRACT,Config/config.a)
-	$(call EXTRACT,Networking/networking.a)
-	$(call EXTRACT,API/API.a)
-	$(OS_EXTRACT)
-	$(call EXTRACT,encryption/encryption.a)
-	$(call EXTRACT,RNG/RNG.a)
-	$(call EXTRACT,JSon/JSon.a)
-	$(call EXTRACT,file/file.a)
-	$(call EXTRACT,HTML/HTMLParser.a)
-	$(call EXTRACT,Game/Game.a)
+	$(foreach lib,$(LIBS),$(call EXTRACT,$(lib)))
 	$(AR) $(ARFLAGS) $@ temp_objs/*.o
 	$(RMDIR) temp_objs
 
@@ -121,25 +90,7 @@ $(DEBUG_TARGET): $(DEBUG_LIBS)
 	@echo "Linking libraries into $(DEBUG_TARGET)..."
 	$(RM) $@
 	$(MKDIR) temp_objs
-	$(call EXTRACT,CMA/CustomMemoryAllocator_debug.a)
-	$(call EXTRACT,GetNextLine/GetNextLine_debug.a)
-	$(call EXTRACT,Libft/LibFT_debug.a)
-	$(call EXTRACT,Logger/Logger_debug.a)
-	$(call EXTRACT,Printf/Printf_debug.a)
-	$(call EXTRACT,ReadLine/ReadLine_debug.a)
-	$(call EXTRACT,PThread/PThread_debug.a)
-	$(call EXTRACT,CPP_class/CPP_class_debug.a)
-	$(call EXTRACT,Errno/errno_debug.a)
-	$(call EXTRACT,Config/config_debug.a)
-	$(call EXTRACT,Networking/networking_debug.a)
-	$(call EXTRACT,API/API_debug.a)
-	$(DEBUG_OS_EXTRACT)
-	$(call EXTRACT,encryption/encryption_debug.a)
-	$(call EXTRACT,RNG/RNG_debug.a)
-	$(call EXTRACT,JSon/JSon_debug.a)
-	$(call EXTRACT,file/file_debug.a)
-	$(call EXTRACT,HTML/HTMLParser_debug.a)
-	$(call EXTRACT,Game/Game_debug.a)
+	$(foreach lib,$(DEBUG_LIBS),$(call EXTRACT,$(lib)))
 	$(AR) $(ARFLAGS) $@ temp_objs/*.o
 	$(RMDIR) temp_objs
 
@@ -150,45 +101,11 @@ $(DEBUG_TARGET): $(DEBUG_LIBS)
 	$(MAKE) -C $(dir $@) debug
 
 clean:
-	$(MAKE) -C CMA clean
-	$(MAKE) -C GetNextLine clean
-	$(MAKE) -C Libft clean
-	$(MAKE) -C Printf clean
-	$(MAKE) -C ReadLine clean
-	$(MAKE) -C PThread clean
-	$(MAKE) -C CPP_class clean
-	$(MAKE) -C Errno clean
-	$(MAKE) -C Config clean
-	$(MAKE) -C Networking clean
-	$(MAKE) -C API clean
-	$(OS_CLEAN)
-	$(MAKE) -C encryption clean
-	$(MAKE) -C RNG clean
-	$(MAKE) -C JSon clean
-	$(MAKE) -C file clean
-	$(MAKE) -C HTML clean
-	$(MAKE) -C Game clean
+	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) clean;)
 	$(RM) $(TARGET) $(DEBUG_TARGET)
 
-fclean: clean
-	$(MAKE) -C CMA fclean
-	$(MAKE) -C GetNextLine fclean
-	$(MAKE) -C Libft fclean
-	$(MAKE) -C Printf fclean
-	$(MAKE) -C ReadLine fclean
-	$(MAKE) -C PThread fclean
-	$(MAKE) -C CPP_class fclean
-	$(MAKE) -C Errno fclean
-	$(MAKE) -C Config fclean
-	$(MAKE) -C Networking fclean
-	$(MAKE) -C API fclean
-	$(OS_FCLEAN)
-	$(MAKE) -C encryption fclean
-	$(MAKE) -C RNG fclean
-	$(MAKE) -C JSon fclean
-	$(MAKE) -C file fclean
-	$(MAKE) -C HTML fclean
-	$(MAKE) -C Game fclean
+fclean:
+	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) fclean;)
 	$(RM) $(TARGET) $(DEBUG_TARGET)
     
 .PHONY: all debug both re clean fclean


### PR DESCRIPTION
## Summary
- simplify root Makefile by looping over submodule libraries
- ensure cleaning rules cover every submodule
- consolidate LIB_BASES so all component archives are listed

## Testing
- `make`
- `make fclean`


------
https://chatgpt.com/codex/tasks/task_e_68bab7a0a2248331a4e5ebf60d627eac