### PR TITLE
Add optional logging for API calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Coding Guidelines
+
+- Use `return ;` for void functions. Include a space before the semicolon.
+- Use `return (value);` for non-void returns. Include a space before the opening parenthesis.
+- Do not use `for` loops, ternary operators, or `switch` statements.
+- Indent code using 4 spaces per level.

--- a/API/api_request.cpp
+++ b/API/api_request.cpp
@@ -3,6 +3,7 @@
 #include "../CPP_class/string_class.hpp"
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
+#include "../Logger/logger.hpp"
 #include <cstring>
 #include <cstdio>
 #include <string>
@@ -21,6 +22,20 @@ char *api_request_string(const char *ip, uint16_t port,
     const char *method, const char *path, json_group *payload,
     const char *headers, int *status, int timeout)
 {
+    if (ft_log_get_api_logging())
+    {
+        const char *log_ip = "(null)";
+        const char *log_method = "(null)";
+        const char *log_path = "(null)";
+        if (ip)
+            log_ip = ip;
+        if (method)
+            log_method = method;
+        if (path)
+            log_path = path;
+        ft_log_debug("api_request_string %s:%u %s %s",
+            log_ip, port, log_method, log_path);
+    }
     SocketConfig config;
     config._type = SocketType::CLIENT;
     config._ip = ip;
@@ -106,6 +121,20 @@ char *api_request_string_host(const char *host, uint16_t port,
     const char *method, const char *path, json_group *payload,
     const char *headers, int *status, int timeout)
 {
+    if (ft_log_get_api_logging())
+    {
+        const char *log_host = "(null)";
+        const char *log_method = "(null)";
+        const char *log_path = "(null)";
+        if (host)
+            log_host = host;
+        if (method)
+            log_method = method;
+        if (path)
+            log_path = path;
+        ft_log_debug("api_request_string_host %s:%u %s %s",
+            log_host, port, log_method, log_path);
+    }
     struct addrinfo hints;
     struct addrinfo *address_results = ft_nullptr;
     struct addrinfo *address_info;
@@ -360,10 +389,10 @@ static bool parse_url(const char *url, bool &tls, std::string &host,
                       uint16_t &port, std::string &path)
 {
     if (!url)
-        return false;
+        return (false);
     const char *scheme_end = std::strstr(url, "://");
     if (!scheme_end)
-        return false;
+        return (false);
     std::string scheme(url, scheme_end - url);
     tls = (scheme == "https");
     const char *host_start = scheme_end + 3;
@@ -386,27 +415,41 @@ static bool parse_url(const char *url, bool &tls, std::string &host,
     else
     {
         host = hostport;
-        port = tls ? 443 : 80;
+        if (tls)
+            port = 443;
+        else
+            port = 80;
     }
-    return true;
+    return (true);
 }
 
 char *api_request_string_url(const char *url, const char *method,
     json_group *payload, const char *headers, int *status, int timeout)
 {
+    if (ft_log_get_api_logging())
+    {
+        const char *log_url = "(null)";
+        const char *log_method = "(null)";
+        if (url)
+            log_url = url;
+        if (method)
+            log_method = method;
+        ft_log_debug("api_request_string_url %s %s",
+            log_url, log_method);
+    }
     bool tls;
     std::string host;
     std::string path;
     uint16_t port;
     if (!parse_url(url, tls, host, port, path))
-        return ft_nullptr;
+        return (ft_nullptr);
     if (tls)
-        return api_request_string_tls(host.c_str(), port, method,
+        return (api_request_string_tls(host.c_str(), port, method,
                                        path.c_str(), payload, headers,
-                                       status, timeout);
-    return api_request_string_host(host.c_str(), port, method,
+                                       status, timeout));
+    return (api_request_string_host(host.c_str(), port, method,
                                    path.c_str(), payload, headers,
-                                   status, timeout);
+                                   status, timeout));
 }
 
 json_group *api_request_json_url(const char *url, const char *method,
@@ -415,8 +458,8 @@ json_group *api_request_json_url(const char *url, const char *method,
     char *body = api_request_string_url(url, method, payload,
                                         headers, status, timeout);
     if (!body)
-        return ft_nullptr;
+        return (ft_nullptr);
     json_group *result = json_read_from_string(body);
     cma_free(body);
-    return result;
+    return (result);
 }

--- a/API/api_request_tls.cpp
+++ b/API/api_request_tls.cpp
@@ -4,6 +4,7 @@
 #include "../CPP_class/string_class.hpp"
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
+#include "../Logger/logger.hpp"
 #include <cstring>
 #include <cstdio>
 #ifdef _WIN32
@@ -36,6 +37,20 @@ char *api_request_string_tls(const char *host, uint16_t port,
     const char *method, const char *path, json_group *payload,
     const char *headers, int *status, int timeout)
 {
+    if (ft_log_get_api_logging())
+    {
+        const char *log_host = "(null)";
+        const char *log_method = "(null)";
+        const char *log_path = "(null)";
+        if (host)
+            log_host = host;
+        if (method)
+            log_method = method;
+        if (path)
+            log_path = path;
+        ft_log_debug("api_request_string_tls %s:%u %s %s",
+            log_host, port, log_method, log_path);
+    }
     SSL_CTX *context = ft_nullptr;
     SSL *ssl_session = ft_nullptr;
     int socket_fd = -1;

--- a/API/api_tls_client.cpp
+++ b/API/api_tls_client.cpp
@@ -5,6 +5,7 @@
 #include "../Networking/ssl_wrapper.hpp"
 #include "../Libft/libft.hpp"
 #include "../CMA/CMA.hpp"
+#include "../Logger/logger.hpp"
 #ifdef _WIN32
 # include <winsock2.h>
 # include <ws2tcpip.h>
@@ -39,13 +40,13 @@ api_tls_client::api_tls_client(const char *host_c, uint16_t port, int timeout_ms
     else
         this->_host = "";
     if (!host_c)
-        return;
+        return ;
     if (!OPENSSL_init_ssl(0, ft_nullptr))
-        return;
+        return ;
 
     this->_ctx = SSL_CTX_new(TLS_client_method());
     if (!this->_ctx)
-        return;
+        return ;
 
     struct addrinfo hints;
     struct addrinfo *address_results = ft_nullptr;
@@ -56,7 +57,7 @@ api_tls_client::api_tls_client(const char *host_c, uint16_t port, int timeout_ms
     char port_string[6];
     std::snprintf(port_string, sizeof(port_string), "%u", port);
     if (getaddrinfo(host_c, port_string, &hints, &address_results) != 0)
-        return;
+        return ;
 
     address_info = address_results;
     while (address_info != ft_nullptr)
@@ -82,18 +83,18 @@ api_tls_client::api_tls_client(const char *host_c, uint16_t port, int timeout_ms
     if (address_results)
         freeaddrinfo(address_results);
     if (this->_sock < 0)
-        return;
+        return ;
 
     this->_ssl = SSL_new(this->_ctx);
     if (!this->_ssl)
-        return;
+        return ;
     if (SSL_set_fd(this->_ssl, this->_sock) != 1)
-        return;
+        return ;
     if (SSL_connect(this->_ssl) <= 0)
     {
         SSL_free(this->_ssl);
         this->_ssl = ft_nullptr;
-        return;
+        return ;
     }
 }
 
@@ -120,6 +121,17 @@ char *api_tls_client::request(const char *method, const char *path, json_group *
 {
     if (!this->_ssl || !method || !path)
         return (ft_nullptr);
+    if (ft_log_get_api_logging())
+    {
+        const char *log_method = "(null)";
+        const char *log_path = "(null)";
+        if (method)
+            log_method = method;
+        if (path)
+            log_path = path;
+        ft_log_debug("api_tls_client::request %s %s",
+            log_method, log_path);
+    }
 
     ft_string request(method);
     request += " ";

--- a/Logger/Makefile
+++ b/Logger/Makefile
@@ -10,6 +10,8 @@ SRCS := \
     ft_log_set_file.cpp \
     ft_log_set_alloc_logging.cpp \
     ft_log_get_alloc_logging.cpp \
+    ft_log_set_api_logging.cpp \
+    ft_log_get_api_logging.cpp \
     ft_log_close.cpp \
     ft_log_debug.cpp \
     ft_log_info.cpp \

--- a/Logger/ft_log_get_api_logging.cpp
+++ b/Logger/ft_log_get_api_logging.cpp
@@ -1,0 +1,9 @@
+#include "logger.hpp"
+
+bool ft_log_get_api_logging()
+{
+    if (g_logger)
+        return (g_logger->get_api_logging());
+    return (false);
+}
+

--- a/Logger/ft_log_set_api_logging.cpp
+++ b/Logger/ft_log_set_api_logging.cpp
@@ -1,0 +1,8 @@
+#include "logger.hpp"
+
+void ft_log_set_api_logging(bool enable)
+{
+    if (g_logger)
+        g_logger->set_api_logging(enable);
+}
+

--- a/Logger/ft_logger.cpp
+++ b/Logger/ft_logger.cpp
@@ -4,7 +4,7 @@
 ft_logger *g_logger = ft_nullptr;
 
 ft_logger::ft_logger(const char *path, size_t max_size, t_log_level level) noexcept
-    : _alloc_logging(false)
+    : _alloc_logging(false), _api_logging(false)
 {
     ft_log_set_level(level);
     if (path)
@@ -30,7 +30,7 @@ void ft_logger::set_level(t_log_level level) noexcept
 
 int ft_logger::set_file(const char *path, size_t max_size) noexcept
 {
-    return ft_log_set_file(path, max_size);
+    return (ft_log_set_file(path, max_size));
 }
 
 void ft_logger::set_alloc_logging(bool enable) noexcept
@@ -41,6 +41,16 @@ void ft_logger::set_alloc_logging(bool enable) noexcept
 bool ft_logger::get_alloc_logging() const noexcept
 {
     return (this->_alloc_logging);
+}
+
+void ft_logger::set_api_logging(bool enable) noexcept
+{
+    this->_api_logging = enable;
+}
+
+bool ft_logger::get_api_logging() const noexcept
+{
+    return (this->_api_logging);
 }
 
 void ft_logger::close() noexcept

--- a/Logger/logger.hpp
+++ b/Logger/logger.hpp
@@ -16,6 +16,8 @@ int  ft_log_set_file(const char *path, size_t max_size);
 void ft_log_close();
 void ft_log_set_alloc_logging(bool enable);
 bool ft_log_get_alloc_logging();
+void ft_log_set_api_logging(bool enable);
+bool ft_log_get_api_logging();
 
 void ft_log_debug(const char *fmt, ...);
 void ft_log_info(const char *fmt, ...);
@@ -37,6 +39,8 @@ class ft_logger
         int  set_file(const char *path, size_t max_size) noexcept;
         void set_alloc_logging(bool enable) noexcept;
         bool get_alloc_logging() const noexcept;
+        void set_api_logging(bool enable) noexcept;
+        bool get_api_logging() const noexcept;
         void close() noexcept;
 
         void debug(const char *fmt, ...) noexcept;
@@ -46,6 +50,7 @@ class ft_logger
 
     private:
         bool _alloc_logging;
+        bool _api_logging;
 };
 
 extern ft_logger *g_logger;


### PR DESCRIPTION
## Summary
- allow toggling API call logging via `ft_log_set_api_logging`/`ft_log_get_api_logging`
- log API requests in plain, host, URL, TLS and TLS-client helpers when enabled
- build logger with new API logging files
- replace ternary operators with explicit `if`/`else` statements for logging and URL parsing
- standardize return statements: use `return ;` for void functions and wrap values in parentheses
- add repository-wide coding guidelines in `AGENTS.md`

## Testing
- `make -C Logger`
- `make -C API`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bac2a1f1c48331aab494c5c090e723