### PR TITLE
Propagate strict compile flags to submodules

### DIFF
--- a/HTML/html_writer.cpp
+++ b/HTML/html_writer.cpp
@@ -39,7 +39,7 @@ static void html_write_node(int fd, html_node *htmlNode, int indent)
             html_write_node(fd, childNode, indent + 1);
             childNode = childNode->next;
         }
-        int indent_index = 0;
+        indent_index = 0;
         while (indent_index < indent)
         {
             pf_printf_fd(fd, "  ");

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,27 @@
+OPT_LEVEL ?= 0
+
+ifeq ($(OPT_LEVEL),0)
+    OPT_FLAGS = -O0 -g
+else ifeq ($(OPT_LEVEL),1)
+    OPT_FLAGS = -O1 -flto -s -ffunction-sections -fdata-sections -Wl,--gc-sections
+else ifeq ($(OPT_LEVEL),2)
+    OPT_FLAGS = -O2 -flto -s -ffunction-sections -fdata-sections -Wl,--gc-sections
+else ifeq ($(OPT_LEVEL),3)
+    OPT_FLAGS = -O3 -flto -s -ffunction-sections -fdata-sections -Wl,--gc-sections
+else
+    $(error Unsupported OPT_LEVEL=$(OPT_LEVEL))
+endif
+
+COMPILE_FLAGS = -Wall -Werror -Wextra -std=c++17 -Wmissing-declarations \
+                -Wold-style-cast -Wshadow -Wconversion -Wformat=2 -Wundef \
+                -Wfloat-equal -Wconversion -Wodr -Wuseless-cast \
+                -Wzero-as-null-pointer-constant -Wmaybe-uninitialized $(OPT_FLAGS)
+
+export COMPILE_FLAGS
+
 CXX      := g++
 AR       := ar
 ARFLAGS  := rcs
-CXXFLAGS := -Wall -Wextra -Werror -g -O0 -std=c++17
 
 ifeq ($(OS),Windows_NT)
     MKDIR  = mkdir

--- a/Printf/ft_fprintf.cpp
+++ b/Printf/ft_fprintf.cpp
@@ -7,6 +7,8 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
+#include <cmath>
+#include <cfloat>
 
 typedef enum
 {
@@ -128,13 +130,13 @@ static void ft_putfloat_stream(double number, FILE *stream, size_t *count)
 
 static void ft_putscientific_stream(double number, bool uppercase, FILE *stream, size_t *count)
 {
-    if (number == 0.0)
+    if (std::fabs(number) <= DBL_EPSILON)
     {
         if (uppercase)
             ft_putstr_stream("0.000000E+00", stream, count);
         else
             ft_putstr_stream("0.000000e+00", stream, count);
-        return;
+        return ;
     }
     if (number < 0)
     {
@@ -182,10 +184,10 @@ static void ft_putscientific_stream(double number, bool uppercase, FILE *stream,
 
 static void ft_putgeneral_stream(double number, bool uppercase, FILE *stream, size_t *count)
 {
-    if (number == 0.0)
+    if (std::fabs(number) <= DBL_EPSILON)
     {
         ft_putfloat_stream(0.0, stream, count);
-        return;
+        return ;
     }
     double temp = number;
     if (temp < 0)

--- a/Printf/print_args.cpp
+++ b/Printf/print_args.cpp
@@ -7,6 +7,8 @@
 #include <stdint.h>
 #include <limits.h>
 #include <stddef.h>
+#include <cmath>
+#include <cfloat>
 
 static inline ssize_t ft_platform_write(int fd, const char *string, size_t length)
 {
@@ -161,7 +163,7 @@ void ft_putfloat_fd(double number, int fd, size_t *count)
 
 void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count)
 {
-    if (number == 0.0)
+    if (std::fabs(number) <= DBL_EPSILON)
     {
         if (uppercase)
             ft_putstr_fd("0.000000E+00", fd, count);
@@ -216,7 +218,7 @@ void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count)
 
 void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count)
 {
-    if (number == 0.0)
+    if (std::fabs(number) <= DBL_EPSILON)
     {
         ft_putfloat_fd(0.0, fd, count);
         return ;


### PR DESCRIPTION
## Summary
- Add configurable optimization levels and comprehensive warning flags
- Export compile flags so subproject Makefiles use them
- Replace unsafe floating-point equality checks with epsilon-based comparisons and fix shadowed variable

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bc4d0408508331b298ed80fa403a55