### PR TITLE
Add custom fabs and extend abs functions

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -35,6 +35,7 @@ SRCS := ft_atoi.cpp \
     ft_isspace.cpp \
     ft_strlen_size_t.cpp \
     ft_abs.cpp \
+    ft_fabs.cpp \
     ft_swap.cpp \
     ft_clamp.cpp \
     ft_pow.cpp \

--- a/Libft/ft_abs.cpp
+++ b/Libft/ft_abs.cpp
@@ -6,3 +6,17 @@ int ft_abs(int number)
         return (-number);
     return (number);
 }
+
+long ft_abs(long number)
+{
+    if (number < 0)
+        return (-number);
+    return (number);
+}
+
+long long ft_abs(long long number)
+{
+    if (number < 0)
+        return (-number);
+    return (number);
+}

--- a/Libft/ft_exp.cpp
+++ b/Libft/ft_exp.cpp
@@ -1,12 +1,5 @@
 #include "libft.hpp"
 
-static double ft_abs_double(double number)
-{
-    if (number < 0)
-        return (-number);
-    return (number);
-}
-
 double ft_exp(double x)
 {
     double term;
@@ -16,7 +9,7 @@ double ft_exp(double x)
     term = 1.0;
     sum = 1.0;
     n = 1;
-    while (ft_abs_double(term) > 0.0000000001)
+    while (ft_fabs(term) > 0.0000000001)
     {
         term *= x / n;
         sum += term;

--- a/Libft/ft_fabs.cpp
+++ b/Libft/ft_fabs.cpp
@@ -1,0 +1,8 @@
+#include "libft.hpp"
+
+double ft_fabs(double number)
+{
+    if (number < 0.0)
+        return (-number);
+    return (number);
+}

--- a/Libft/ft_sqrt.cpp
+++ b/Libft/ft_sqrt.cpp
@@ -1,12 +1,5 @@
 #include "libft.hpp"
 
-static double ft_abs_double(double number)
-{
-    if (number < 0)
-        return (-number);
-    return (number);
-}
-
 double ft_sqrt(double number)
 {
     double guess;
@@ -14,13 +7,13 @@ double ft_sqrt(double number)
 
     if (number < 0)
         return (-1.0);
-    if (ft_abs_double(number) < 1e-12)
+    if (ft_fabs(number) < 1e-12)
         return (0.0);
     guess = number;
     while (1)
     {
         next_guess = 0.5 * (guess + number / guess);
-        if (ft_abs_double(next_guess - guess) < 0.000001)
+        if (ft_fabs(next_guess - guess) < 0.000001)
             break;
         guess = next_guess;
     }

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -45,6 +45,9 @@ char             *ft_strncpy(char *destination, const char *source, size_t numbe
 void             *ft_memset(void *destination, int value, size_t number_of_bytes);
 int             ft_isspace(int character);
 int             ft_abs(int number);
+long            ft_abs(long number);
+long long       ft_abs(long long number);
+double          ft_fabs(double number);
 void            ft_swap(int *a, int *b);
 int             ft_clamp(int value, int min, int max);
 double          ft_pow(double base, int exponent);

--- a/Printf/ft_fprintf.cpp
+++ b/Printf/ft_fprintf.cpp
@@ -1,13 +1,13 @@
 // Custom implementation of vfprintf-style formatting for FILE streams
 #include "printf.hpp"
 #include "../CPP_class/nullptr.hpp"
+#include "../Libft/libft.hpp"
 #include <cstdio>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
-#include <cmath>
 #include <cfloat>
 
 typedef enum
@@ -130,7 +130,7 @@ static void ft_putfloat_stream(double number, FILE *stream, size_t *count)
 
 static void ft_putscientific_stream(double number, bool uppercase, FILE *stream, size_t *count)
 {
-    if (std::fabs(number) <= DBL_EPSILON)
+    if (ft_fabs(number) <= DBL_EPSILON)
     {
         if (uppercase)
             ft_putstr_stream("0.000000E+00", stream, count);
@@ -184,7 +184,7 @@ static void ft_putscientific_stream(double number, bool uppercase, FILE *stream,
 
 static void ft_putgeneral_stream(double number, bool uppercase, FILE *stream, size_t *count)
 {
-    if (std::fabs(number) <= DBL_EPSILON)
+    if (ft_fabs(number) <= DBL_EPSILON)
     {
         ft_putfloat_stream(0.0, stream, count);
         return ;

--- a/Printf/print_args.cpp
+++ b/Printf/print_args.cpp
@@ -1,4 +1,5 @@
 #include "printf_internal.hpp"
+#include "../Libft/libft.hpp"
 #include <cstdarg>
 #include <unistd.h>
 #include "../Linux/linux_file.hpp"
@@ -7,7 +8,6 @@
 #include <stdint.h>
 #include <limits.h>
 #include <stddef.h>
-#include <cmath>
 #include <cfloat>
 
 static inline ssize_t ft_platform_write(int fd, const char *string, size_t length)
@@ -163,7 +163,7 @@ void ft_putfloat_fd(double number, int fd, size_t *count)
 
 void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count)
 {
-    if (std::fabs(number) <= DBL_EPSILON)
+    if (ft_fabs(number) <= DBL_EPSILON)
     {
         if (uppercase)
             ft_putstr_fd("0.000000E+00", fd, count);
@@ -218,7 +218,7 @@ void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count)
 
 void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count)
 {
-    if (std::fabs(number) <= DBL_EPSILON)
+    if (ft_fabs(number) <= DBL_EPSILON)
     {
         ft_putfloat_fd(0.0, fd, count);
         return ;

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ char   *ft_strncpy(char *dst, const char *src, size_t n);
 void   *ft_memset(void *dst, int value, size_t n);
 int     ft_isspace(int c);
 int     ft_abs(int number);
+long    ft_abs(long number);
+long long ft_abs(long long number);
+double  ft_fabs(double number);
 ```
 
 `ft_limits.hpp` exposes integer boundary constants:


### PR DESCRIPTION
## Summary
- add `ft_fabs` for floating-point absolute values and overload `ft_abs` for wider integer types
- reuse `ft_fabs` across math utilities and printf routines instead of `std::fabs`
- document and build new absolute-value helpers

## Testing
- `make -C Libft`
- `make -C Printf`
- `make -C Test` *(fails: ‘t_queue’ was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a3da8c48331b6e76a43cb6a6a7b