### PR TITLE
Handle edge cases in abs and fabs

### DIFF
--- a/Libft/ft_abs.cpp
+++ b/Libft/ft_abs.cpp
@@ -1,22 +1,35 @@
 #include "libft.hpp"
+#include "ft_limits.hpp"
 
 int ft_abs(int number)
 {
     if (number < 0)
+    {
+        if (number == FT_INT_MIN)
+            return (FT_INT_MAX);
         return (-number);
+    }
     return (number);
 }
 
 long ft_abs(long number)
 {
     if (number < 0)
+    {
+        if (number == FT_LONG_MIN)
+            return (FT_LONG_MAX);
         return (-number);
+    }
     return (number);
 }
 
 long long ft_abs(long long number)
 {
     if (number < 0)
+    {
+        if (number == FT_LLONG_MIN)
+            return (FT_LLONG_MAX);
         return (-number);
+    }
     return (number);
 }

--- a/Libft/ft_fabs.cpp
+++ b/Libft/ft_fabs.cpp
@@ -2,7 +2,7 @@
 
 double ft_fabs(double number)
 {
-    if (number < 0.0)
+    if (ft_signbit(number))
         return (-number);
     return (number);
 }

--- a/Libft/ft_isnan.cpp
+++ b/Libft/ft_isnan.cpp
@@ -1,0 +1,8 @@
+#include "libft.hpp"
+
+int ft_isnan(double number)
+{
+    if (number != number)
+        return (1);
+    return (0);
+}

--- a/Libft/ft_limits.hpp
+++ b/Libft/ft_limits.hpp
@@ -11,4 +11,8 @@ static constexpr long  FT_LONG_MAX  = static_cast<long>(~0UL >> 1);
 static constexpr long  FT_LONG_MIN  = -FT_LONG_MAX - 1L;
 static constexpr unsigned long FT_ULONG_MAX = ~0UL;
 
+static constexpr long long  FT_LLONG_MAX  = static_cast<long long>(~0ULL >> 1);
+static constexpr long long  FT_LLONG_MIN  = -FT_LLONG_MAX - 1LL;
+static constexpr unsigned long long FT_ULLONG_MAX = ~0ULL;
+
 #endif

--- a/Libft/ft_nan.cpp
+++ b/Libft/ft_nan.cpp
@@ -1,0 +1,9 @@
+#include "libft.hpp"
+
+double ft_nan(void)
+{
+    double zero;
+
+    zero = 0.0;
+    return (zero / zero);
+}

--- a/Libft/ft_signbit.cpp
+++ b/Libft/ft_signbit.cpp
@@ -1,0 +1,17 @@
+#include "libft.hpp"
+
+typedef union u_double_bits
+{
+    double              d;
+    unsigned long long  u;
+}   t_double_bits;
+
+int ft_signbit(double number)
+{
+    t_double_bits bits;
+
+    bits.d = number;
+    if ((bits.u >> 63) != 0)
+        return (1);
+    return (0);
+}

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -4,6 +4,7 @@
 #define SUCCES 0
 #define FAILURE 1
 
+
 #include <cstddef>
 #include <unistd.h>
 #include <fcntl.h>
@@ -48,6 +49,9 @@ int             ft_abs(int number);
 long            ft_abs(long number);
 long long       ft_abs(long long number);
 double          ft_fabs(double number);
+int             ft_signbit(double number);
+int             ft_isnan(double number);
+double          ft_nan(void);
 void            ft_swap(int *a, int *b);
 int             ft_clamp(int value, int min, int max);
 double          ft_pow(double base, int exponent);

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -106,6 +106,10 @@ int test_tolower_no_change(void);
 int test_abs_basic(void);
 int test_abs_zero(void);
 int test_abs_positive(void);
+int test_abs_int_min(void);
+int test_abs_llong_min(void);
+int test_fabs_negative_zero(void);
+int test_fabs_nan(void);
 int test_atol_basic(void);
 int test_atol_whitespace(void);
 int test_atol_longmax(void);
@@ -295,6 +299,10 @@ int main(int argc, char **argv)
         { test_abs_basic, "abs basic" },
         { test_abs_zero, "abs zero" },
         { test_abs_positive, "abs positive" },
+        { test_abs_int_min, "abs INT_MIN" },
+        { test_abs_llong_min, "abs LLONG_MIN" },
+        { test_fabs_negative_zero, "fabs negative zero" },
+        { test_fabs_nan, "fabs NaN" },
         { test_atol_basic, "atol basic" },
         { test_atol_whitespace, "atol whitespace" },
         { test_atol_longmax, "atol longmax" },

--- a/Test/test_extra_libft.cpp
+++ b/Test/test_extra_libft.cpp
@@ -1,7 +1,7 @@
 #include "../Libft/libft.hpp"
+#include "../Libft/ft_limits.hpp"
 #include "../CPP_class/nullptr.hpp"
 #include <cstring>
-#include <climits>
 #include <string>
 
 int test_strlen_size_t_null(void)
@@ -278,6 +278,32 @@ int test_abs_positive(void)
     return (ft_abs(5) == 5);
 }
 
+int test_abs_int_min(void)
+{
+    return (ft_abs(FT_INT_MIN) == FT_INT_MAX);
+}
+
+int test_abs_llong_min(void)
+{
+    return (ft_abs(FT_LLONG_MIN) == FT_LLONG_MAX);
+}
+
+int test_fabs_negative_zero(void)
+{
+    double result;
+
+    result = ft_fabs(-0.0);
+    return (result == 0.0 && !ft_signbit(result));
+}
+
+int test_fabs_nan(void)
+{
+    double result;
+
+    result = ft_fabs(ft_nan());
+    return (ft_isnan(result));
+}
+
 int test_atol_basic(void)
 {
     return (ft_atol("-42") == -42);
@@ -290,14 +316,18 @@ int test_atol_whitespace(void)
 
 int test_atol_longmax(void)
 {
-    std::string s = std::to_string(LONG_MAX);
-    return (ft_atol(s.c_str()) == LONG_MAX);
+    std::string str;
+
+    str = std::to_string(FT_LONG_MAX);
+    return (ft_atol(str.c_str()) == FT_LONG_MAX);
 }
 
 int test_atol_longmin(void)
 {
-    std::string s = std::to_string(LONG_MIN);
-    return (ft_atol(s.c_str()) == LONG_MIN);
+    std::string str;
+
+    str = std::to_string(FT_LONG_MIN);
+    return (ft_atol(str.c_str()) == FT_LONG_MIN);
 }
 
 int test_setenv_getenv_basic(void)


### PR DESCRIPTION
## Summary
- replace standard limit macros and signbit with custom implementations
- extend ft_limits with long long boundaries and add helpers for NaN detection
- exercise new edge cases using custom utilities in tests

## Testing
- `make`
- `g++ -std=c++17 -I . /tmp/abs_fabs_test.cpp Libft/ft_abs.cpp Libft/ft_fabs.cpp Libft/ft_signbit.cpp Libft/ft_isnan.cpp Libft/ft_nan.cpp -o /tmp/abs_fabs_test && /tmp/abs_fabs_test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8365b6e88331ac62a49a47dae541