### PR TITLE
Add time utilities submodule

### DIFF
--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -65,6 +65,7 @@
 #include "Windows/windows_file.hpp"
 #include "encryption/BasicEncryption.hpp"
 #include "file/open_dir.hpp"
+#include "Time/time.hpp"
 #include "Game/achievement.hpp"
 #include "Game/experience_table.hpp"
 #include "Game/map3d.hpp"

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ else
 SUBDIRS += Linux
 endif
 
-SUBDIRS += encryption RNG JSon file HTML Game
+SUBDIRS += encryption RNG JSon file HTML Game Time
 
 LIB_BASES := \
   CMA/CustomMemoryAllocator \
@@ -72,7 +72,8 @@ LIB_BASES := \
   JSon/JSon \
   file/file \
   HTML/HTMLParser \
-  Game/Game
+  Game/Game \
+  Time/time
 
 ifeq ($(OS),Windows_NT)
 LIB_BASES += Windows/Windows

--- a/Time/Makefile
+++ b/Time/Makefile
@@ -1,0 +1,74 @@
+TARGET         := time.a
+DEBUG_TARGET   := time_debug.a
+
+SRCS := ft_time_now.cpp \
+        ft_time_now_ms.cpp \
+        ft_time_local.cpp \
+        ft_sleep.cpp \
+        ft_sleep_ms.cpp
+
+HEADERS := time.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
+clean:
+	-$(RM) $(CLEAN_FILES)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/Time/ft_sleep.cpp
+++ b/Time/ft_sleep.cpp
@@ -1,0 +1,10 @@
+#include "time.hpp"
+#include <thread>
+#include <chrono>
+
+void    ft_sleep(unsigned int seconds)
+{
+    std::this_thread::sleep_for(std::chrono::seconds(seconds));
+    return ;
+}
+

--- a/Time/ft_sleep_ms.cpp
+++ b/Time/ft_sleep_ms.cpp
@@ -1,0 +1,10 @@
+#include "time.hpp"
+#include <thread>
+#include <chrono>
+
+void    ft_sleep_ms(unsigned int milliseconds)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+    return ;
+}
+

--- a/Time/ft_time_local.cpp
+++ b/Time/ft_time_local.cpp
@@ -1,0 +1,14 @@
+#include "time.hpp"
+#include <ctime>
+
+void    ft_time_local(time_t time_value, struct tm *out)
+{
+    if (!out)
+        return ;
+    std::tm *tmp = std::localtime(&time_value);
+    if (!tmp)
+        return ;
+    *out = *tmp;
+    return ;
+}
+

--- a/Time/ft_time_now.cpp
+++ b/Time/ft_time_now.cpp
@@ -1,0 +1,8 @@
+#include "time.hpp"
+#include <ctime>
+
+time_t  ft_time_now(void)
+{
+    return (std::time(nullptr));
+}
+

--- a/Time/ft_time_now_ms.cpp
+++ b/Time/ft_time_now_ms.cpp
@@ -1,0 +1,10 @@
+#include "time.hpp"
+#include <chrono>
+
+long    ft_time_now_ms(void)
+{
+    std::chrono::system_clock::time_point time_now = std::chrono::system_clock::now();
+    std::chrono::milliseconds milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(time_now.time_since_epoch());
+    return (milliseconds.count());
+}
+

--- a/Time/time.hpp
+++ b/Time/time.hpp
@@ -1,0 +1,12 @@
+#ifndef TIME_HPP
+# define TIME_HPP
+
+#include <ctime>
+
+time_t  ft_time_now(void);
+long    ft_time_now_ms(void);
+void    ft_time_local(time_t time_value, struct tm *out);
+void    ft_sleep(unsigned int seconds);
+void    ft_sleep_ms(unsigned int milliseconds);
+
+#endif


### PR DESCRIPTION
## Summary
- add `Time` submodule with wrappers for current time, milliseconds, local time conversion, and sleeping
- include Time in build system and aggregate header

## Testing
- `make Time/time.a`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bc94db62b48331beb5b48af8a4706b