### PR TITLE
docs: forbid inline class function bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,7 @@ Do not use for loops, ternary operators, or switch statements.
 Indent code using 4 spaces per level.
 Function and variable names must use snake_case.
 Use Allman style braces (opening brace on a new line).
-In classes, member variable names must start with an underscore (_). Coding Guidelines
+In classes, member variable names must start with an underscore (_).
+Template classes may define member functions in the same file as the class declaration, but
+other classes must split declarations into .hpp files and definitions into .cpp files.
+Do not define member function bodies inside the class declaration; place all definitions outside the class.


### PR DESCRIPTION
## Summary
- document rule requiring class declarations in headers and function definitions in sources, with templates allowed in one file
- clarify that member function bodies must reside outside the class declaration

## Testing
- `make test` (fails: No rule to make target `test`)
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bd1f1fc88083318ea4776de12d172d