### PR TITLE
Standardize container naming

### DIFF
--- a/CPP_class/string_class.hpp
+++ b/CPP_class/string_class.hpp
@@ -10,10 +10,10 @@ class ft_string
         char*            _data;
         std::size_t      _length;
         std::size_t      _capacity;
-        int                _errorCode;
+        int                _error_code;
 
         void    resize(size_t new_capacity) noexcept;
-        void    setError(int errorCode) noexcept;
+        void    set_error(int error_code) noexcept;
 
     public:
         ft_string() noexcept;
@@ -28,7 +28,7 @@ class ft_string
         ft_string& operator+=(char c) noexcept;
         ~ft_string();
 
-        explicit ft_string(int errorCode) noexcept;
+        explicit ft_string(int error_code) noexcept;
 
         static void* operator new(size_t size) noexcept;
         static void operator delete(void* ptr) noexcept;

--- a/CPP_class/string_constructors.cpp
+++ b/CPP_class/string_constructors.cpp
@@ -5,13 +5,13 @@
 #include "nullptr.hpp"
 
 ft_string::ft_string() noexcept 
-    : _data(ft_nullptr), _length(0), _capacity(0), _errorCode(0)
+    : _data(ft_nullptr), _length(0), _capacity(0), _error_code(0)
 {
     return ;
 }
 
 ft_string::ft_string(const char* init_str) noexcept 
-    : _data(ft_nullptr), _length(0), _capacity(0), _errorCode(0)
+    : _data(ft_nullptr), _length(0), _capacity(0), _error_code(0)
 {
     if (init_str)
     {
@@ -20,7 +20,7 @@ ft_string::ft_string(const char* init_str) noexcept
         this->_data = static_cast<char*>(cma_calloc(this->_capacity + 1, sizeof(char)));
         if (!this->_data)
         {
-            this->setError(STRING_MEM_ALLOC_FAIL);
+            this->set_error(STRING_MEM_ALLOC_FAIL);
             return ;
         }
         ft_memcpy(this->_data, init_str, this->_length + 1);
@@ -30,14 +30,14 @@ ft_string::ft_string(const char* init_str) noexcept
 
 ft_string::ft_string(const ft_string& other) noexcept 
     : _data(ft_nullptr), _length(other._length), _capacity(other._capacity), 
-      _errorCode(other._errorCode)
+      _error_code(other._error_code)
 {
     if (other._data)
     {
         this->_data = static_cast<char*>(cma_calloc(this->_capacity + 1, sizeof(char)));
         if (!this->_data)
         {
-            this->setError(STRING_MEM_ALLOC_FAIL);
+            this->set_error(STRING_MEM_ALLOC_FAIL);
             return ;
         }
         ft_memcpy(this->_data, other._data, this->_length + 1);
@@ -49,12 +49,12 @@ ft_string::ft_string(ft_string&& other) noexcept
     : _data(other._data),
       _length(other._length),
       _capacity(other._capacity),
-      _errorCode(other._errorCode)
+      _error_code(other._error_code)
 {
     other._data = ft_nullptr;
     other._length = 0;
     other._capacity = 0;
-    other._errorCode = 0;
+    other._error_code = 0;
     return ;
 }
 
@@ -66,13 +66,13 @@ ft_string& ft_string::operator=(const ft_string& other) noexcept
     this->_data = ft_nullptr;
     this->_length = other._length;
     this->_capacity = other._capacity;
-    this->_errorCode = other._errorCode;
+    this->_error_code = other._error_code;
     if (other._data)
     {
         this->_data = static_cast<char*>(cma_calloc(this->_capacity + 1, sizeof(char)));
         if (!this->_data)
         {
-            this->setError(STRING_MEM_ALLOC_FAIL);
+            this->set_error(STRING_MEM_ALLOC_FAIL);
             return (*this);
         }
         ft_memcpy(this->_data, other._data, this->_length + 1);
@@ -86,13 +86,13 @@ ft_string& ft_string::operator=(const char*& other) noexcept
     this->_data = ft_nullptr;
     this->_length = ft_strlen(other);
     this->_capacity = ft_strlen(other);
-    this->_errorCode = 0;
+    this->_error_code = 0;
     if (other)
     {
         this->_data = static_cast<char*>(cma_calloc(this->_capacity + 1, sizeof(char)));
         if (!this->_data)
         {
-            this->setError(STRING_MEM_ALLOC_FAIL);
+            this->set_error(STRING_MEM_ALLOC_FAIL);
             return (*this);
         }
         ft_memcpy(this->_data, other, this->_length + 1);
@@ -108,11 +108,11 @@ ft_string& ft_string::operator=(ft_string&& other) noexcept
         this->_data = other._data;
         this->_length = other._length;
         this->_capacity = other._capacity;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._data = ft_nullptr;
         other._length = 0;
         other._capacity = 0;
-        other._errorCode = 0;
+        other._error_code = 0;
     }
     return (*this);
 }
@@ -151,11 +151,11 @@ void ft_string::operator delete[](void* ptr) noexcept
     return ;
 }
 
-ft_string::ft_string(int errorCode) noexcept
+ft_string::ft_string(int error_code) noexcept
     : _data(ft_nullptr)
     , _length(0)
     , _capacity(0)
-    , _errorCode(errorCode)
+    , _error_code(error_code)
 {
     return ;
 }

--- a/CPP_class/string_methods.cpp
+++ b/CPP_class/string_methods.cpp
@@ -11,7 +11,7 @@ void ft_string::resize(size_t new_capacity) noexcept
     char* new_data = static_cast<char*>(cma_realloc(this->_data, new_capacity));
     if (!new_data)
     {
-        this->setError(STRING_MEM_ALLOC_FAIL);
+        this->set_error(STRING_MEM_ALLOC_FAIL);
         return ;
     }
     this->_data = new_data;
@@ -29,7 +29,7 @@ void ft_string::append(char c) noexcept
         else
             new_capacity *= 2;
         this->resize(new_capacity);
-        if (this->_errorCode)
+        if (this->_error_code)
             return ;
     }
     this->_data[this->_length++] = c;
@@ -50,7 +50,7 @@ void ft_string::append(const ft_string& string) noexcept
         while (new_capacity <= new_length)
             new_capacity *= 2;
         this->resize(new_capacity);
-        if (this->_errorCode)
+        if (this->_error_code)
             return ;
     }
     ft_memcpy(this->_data + this->_length, string._data, string._length);
@@ -74,7 +74,7 @@ void ft_string::append(const char *string) noexcept
         while (this->_length + string_length >= new_capacity)
             new_capacity *= 2;
         this->resize(new_capacity);
-        if (this->_errorCode)
+        if (this->_error_code)
             return ;
     }
     ft_memcpy(this->_data + this->_length, string, string_length);
@@ -88,7 +88,7 @@ void ft_string::clear() noexcept
     this->_length = 0;
     if (this->_data)
         this->_data[0] = '\0';
-    this->_errorCode = 0;
+    this->_error_code = 0;
     return ;
 }
 
@@ -125,18 +125,18 @@ bool ft_string::empty() const noexcept
 
 int ft_string::get_error() const noexcept
 {
-    return (this->_errorCode);
+    return (this->_error_code);
 }
 
 const char* ft_string::get_error_str() const noexcept
 {
-    return (ft_strerror(this->_errorCode));
+    return (ft_strerror(this->_error_code));
 }
 
-void ft_string::setError(int errorCode) noexcept
+void ft_string::set_error(int error_code) noexcept
 {
-    this->_errorCode = errorCode;
-    ft_errno = errorCode;
+    this->_error_code = error_code;
+    ft_errno = error_code;
     return ;
 }
 
@@ -148,11 +148,11 @@ void ft_string::move(ft_string& other) noexcept
         this->_data = other._data;
         this->_length = other._length;
         this->_capacity = other._capacity;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._data = ft_nullptr;
         other._length = 0;
         other._capacity = 0;
-        other._errorCode = 0;
+        other._error_code = 0;
     }
     return ;
 }
@@ -164,7 +164,7 @@ ft_string& ft_string::operator+=(const ft_string& other) noexcept
     while (index < other._length)
     {
         this->append(other._data[index]);
-        if (this->_errorCode)
+        if (this->_error_code)
             return (*this);
         index++;
     }
@@ -179,7 +179,7 @@ ft_string& ft_string::operator+=(const char* cstr) noexcept
         while (cstr[i] != '\0')
         {
             this->append(cstr[i]);
-            if (this->_errorCode)
+            if (this->_error_code)
                 return (*this);
             ++i;
         }
@@ -197,7 +197,7 @@ void ft_string::erase(std::size_t index, std::size_t count) noexcept
 {
     if (index >= this->_length)
     {
-        this->setError(STRING_ERASE_OUT_OF_BOUNDS);
+        this->set_error(STRING_ERASE_OUT_OF_BOUNDS);
         return ;
     }
     if (index + count > this->_length)

--- a/Game/achievement.cpp
+++ b/Game/achievement.cpp
@@ -106,13 +106,13 @@ bool ft_achievement::is_goal_complete(int id) const noexcept
 
 bool ft_achievement::is_complete() const noexcept
 {
-    const Pair<int, ft_goal> *ptr = this->_goals.end() - this->_goals.getSize();
-    const Pair<int, ft_goal> *end = this->_goals.end();
-    while (ptr != end)
+    const Pair<int, ft_goal> *goal_ptr = this->_goals.end() - this->_goals.size();
+    const Pair<int, ft_goal> *goal_end = this->_goals.end();
+    while (goal_ptr != goal_end)
     {
-        if (ptr->value.progress < ptr->value.goal)
+        if (goal_ptr->value.progress < goal_ptr->value.goal)
             return (false);
-        ++ptr;
+        ++goal_ptr;
     }
     return (true);
 }

--- a/Game/inventory.cpp
+++ b/Game/inventory.cpp
@@ -31,12 +31,12 @@ void ft_inventory::resize(size_t capacity) noexcept
 
 size_t ft_inventory::get_used() const noexcept
 {
-    return (this->_items.getSize());
+    return (this->_items.size());
 }
 
 bool ft_inventory::is_full() const noexcept
 {
-    return (this->_items.getSize() >= this->_capacity);
+    return (this->_items.size() >= this->_capacity);
 }
 
 int ft_inventory::get_error() const noexcept
@@ -57,13 +57,13 @@ int ft_inventory::add_item(const ft_item &item) noexcept
     int remaining = item.get_current_stack();
     int item_id = item.get_item_id();
 
-    Pair<int, ft_item> *ptr = this->_items.end() - this->_items.getSize();
-    Pair<int, ft_item> *end = this->_items.end();
-    while (ptr != end && remaining > 0)
+    Pair<int, ft_item> *item_ptr = this->_items.end() - this->_items.size();
+    Pair<int, ft_item> *item_end = this->_items.end();
+    while (item_ptr != item_end && remaining > 0)
     {
-        if (ptr->value.get_item_id() == item_id)
+        if (item_ptr->value.get_item_id() == item_id)
         {
-            int free_space = ptr->value.get_max_stack() - ptr->value.get_current_stack();
+            int free_space = item_ptr->value.get_max_stack() - item_ptr->value.get_current_stack();
             if (free_space > 0)
             {
                 int to_add;
@@ -71,16 +71,16 @@ int ft_inventory::add_item(const ft_item &item) noexcept
                     to_add = remaining;
                 else
                     to_add = free_space;
-                ptr->value.add_to_stack(to_add);
+                item_ptr->value.add_to_stack(to_add);
                 remaining -= to_add;
             }
         }
-        ++ptr;
+        ++item_ptr;
     }
 
     while (remaining > 0)
     {
-        if (this->_items.getSize() >= this->_capacity)
+        if (this->_items.size() >= this->_capacity)
         {
             this->set_error(CHARACTER_INVENTORY_FULL);
             return (CHARACTER_INVENTORY_FULL);
@@ -112,14 +112,14 @@ void ft_inventory::remove_item(int slot) noexcept
 
 int ft_inventory::count_item(int item_id) const noexcept
 {
-    const Pair<int, ft_item> *ptr = this->_items.end() - this->_items.getSize();
-    const Pair<int, ft_item> *end = this->_items.end();
+    const Pair<int, ft_item> *item_ptr = this->_items.end() - this->_items.size();
+    const Pair<int, ft_item> *item_end = this->_items.end();
     int total = 0;
-    while (ptr != end)
+    while (item_ptr != item_end)
     {
-        if (ptr->value.get_item_id() == item_id)
-            total += ptr->value.get_current_stack();
-        ++ptr;
+        if (item_ptr->value.get_item_id() == item_id)
+            total += item_ptr->value.get_current_stack();
+        ++item_ptr;
     }
     return (total);
 }

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ ft_string& operator+=(const ft_string& other) noexcept;
 ft_string& operator+=(const char* cstr) noexcept;
 ft_string& operator+=(char c) noexcept;
 ~ft_string();
-explicit ft_string(int errorCode) noexcept;
+explicit ft_string(int error_code) noexcept;
 static void* operator new(size_t size) noexcept;
 static void operator delete(void* ptr) noexcept;
 static void* operator new[](size_t size) noexcept;

--- a/RNG/deck.hpp
+++ b/RNG/deck.hpp
@@ -23,7 +23,7 @@ ElementType *ft_deck<ElementType>::popRandomElement()
     if (this->empty())
     {
         ft_errno = DECK_EMPTY;
-        this->setError(DECK_EMPTY);
+        this->set_error(DECK_EMPTY);
         return (ft_nullptr);
     }
     size_t index = static_cast<size_t>(ft_dice_roll(1, static_cast<int>(this->size())) - 1);
@@ -38,7 +38,7 @@ ElementType *ft_deck<ElementType>::getRandomElement() const
     if (this->empty())
     {
         ft_errno = DECK_EMPTY;
-        this->setError(DECK_EMPTY);
+        this->set_error(DECK_EMPTY);
         return (ft_nullptr);
     }
     size_t index = static_cast<size_t>(ft_dice_roll(1, static_cast<int>(this->size())) - 1);
@@ -51,7 +51,7 @@ ElementType *ft_deck<ElementType>::drawTopElement()
     if (this->empty())
     {
         ft_errno = DECK_EMPTY;
-        this->setError(DECK_EMPTY);
+        this->set_error(DECK_EMPTY);
         return (ft_nullptr);
     }
     size_t index = this->size() - 1;
@@ -66,7 +66,7 @@ ElementType *ft_deck<ElementType>::peekTopElement() const
     if (this->empty())
     {
         ft_errno = DECK_EMPTY;
-        this->setError(DECK_EMPTY);
+        this->set_error(DECK_EMPTY);
         return (ft_nullptr);
     }
     size_t index = this->size() - 1;
@@ -80,7 +80,7 @@ void ft_deck<ElementType>::shuffle()
     if (this->empty())
     {
         ft_errno = DECK_EMPTY;
-        this->setError(DECK_EMPTY);
+        this->set_error(DECK_EMPTY);
         return ;
     }
     size_t index = this->size - 1;

--- a/RNG/loot_table.hpp
+++ b/RNG/loot_table.hpp
@@ -39,7 +39,7 @@ ElementType *ft_loot_table<ElementType>::getRandomLoot() const
     if (this->size() == 0)
     {
         ft_errno = LOOT_TABLE_EMPTY;
-        const_cast<ft_loot_table<ElementType>*>(this)->setError(LOOT_TABLE_EMPTY);
+        const_cast<ft_loot_table<ElementType>*>(this)->set_error(LOOT_TABLE_EMPTY);
         return (ft_nullptr);
     }
     int totalWeight = 0;
@@ -70,7 +70,7 @@ ElementType *ft_loot_table<ElementType>::popRandomLoot()
     if (this->size() == 0)
     {
         ft_errno = LOOT_TABLE_EMPTY;
-        this->setError(LOOT_TABLE_EMPTY);
+        this->set_error(LOOT_TABLE_EMPTY);
         return (ft_nullptr);
     }
     int totalWeight = 0;

--- a/Template/bitset.hpp
+++ b/Template/bitset.hpp
@@ -21,12 +21,12 @@ class ft_bitset
         size_t      _size;
         size_t      _blockCount;
         size_t*     _data;
-        mutable int _errorCode;
+        mutable int _error_code;
         mutable pt_mutex _mutex;
 
         static const size_t BITS_PER_BLOCK = sizeof(size_t) * CHAR_BIT;
 
-        void    setError(int error) const;
+        void    set_error(int error) const;
         size_t  block_index(size_t pos) const;
         size_t  bit_mask(size_t pos) const;
 
@@ -61,9 +61,9 @@ inline size_t ft_bitset::bit_mask(size_t pos) const
     return (static_cast<size_t>(1) << (pos % BITS_PER_BLOCK));
 }
 
-inline void ft_bitset::setError(int error) const
+inline void ft_bitset::set_error(int error) const
 {
-    this->_errorCode = error;
+    this->_error_code = error;
     ft_errno = error;
     return ;
 }
@@ -72,14 +72,14 @@ inline ft_bitset::ft_bitset(size_t bits)
     : _size(bits),
       _blockCount((bits + BITS_PER_BLOCK - 1) / BITS_PER_BLOCK),
       _data(ft_nullptr),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     if (this->_blockCount > 0)
     {
         this->_data = static_cast<size_t*>(cma_malloc(sizeof(size_t) * this->_blockCount));
         if (this->_data == ft_nullptr)
         {
-            this->setError(BITSET_ALLOC_FAIL);
+            this->set_error(BITSET_ALLOC_FAIL);
             return ;
         }
         size_t i = 0;
@@ -100,12 +100,12 @@ inline ft_bitset::ft_bitset(ft_bitset&& other) noexcept
     : _size(other._size),
       _blockCount(other._blockCount),
       _data(other._data),
-      _errorCode(other._errorCode)
+      _error_code(other._error_code)
 {
     other._size = 0;
     other._blockCount = 0;
     other._data = ft_nullptr;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
     return ;
 }
 
@@ -125,11 +125,11 @@ inline ft_bitset& ft_bitset::operator=(ft_bitset&& other) noexcept
         this->_size = other._size;
         this->_blockCount = other._blockCount;
         this->_data = other._data;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._size = 0;
         other._blockCount = 0;
         other._data = ft_nullptr;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
         other._mutex.unlock(THREAD_ID);
         this->_mutex.unlock(THREAD_ID);
     }
@@ -140,12 +140,12 @@ inline void ft_bitset::set(size_t pos)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (pos >= this->_size)
     {
-        this->setError(BITSET_OUT_OF_RANGE);
+        this->set_error(BITSET_OUT_OF_RANGE);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -158,12 +158,12 @@ inline void ft_bitset::reset(size_t pos)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (pos >= this->_size)
     {
-        this->setError(BITSET_OUT_OF_RANGE);
+        this->set_error(BITSET_OUT_OF_RANGE);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -176,12 +176,12 @@ inline void ft_bitset::flip(size_t pos)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (pos >= this->_size)
     {
-        this->setError(BITSET_OUT_OF_RANGE);
+        this->set_error(BITSET_OUT_OF_RANGE);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -194,12 +194,12 @@ inline bool ft_bitset::test(size_t pos) const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        const_cast<ft_bitset*>(this)->setError(PT_ERR_MUTEX_OWNER);
+        const_cast<ft_bitset*>(this)->set_error(PT_ERR_MUTEX_OWNER);
         return (false);
     }
     if (pos >= this->_size)
     {
-        const_cast<ft_bitset*>(this)->setError(BITSET_OUT_OF_RANGE);
+        const_cast<ft_bitset*>(this)->set_error(BITSET_OUT_OF_RANGE);
         this->_mutex.unlock(THREAD_ID);
         return (false);
     }
@@ -231,8 +231,8 @@ inline void ft_bitset::clear()
 inline int ft_bitset::get_error() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (this->_errorCode);
-    int err = this->_errorCode;
+        return (this->_error_code);
+    int err = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
     return (err);
 }

--- a/Template/circular_buffer.hpp
+++ b/Template/circular_buffer.hpp
@@ -19,10 +19,10 @@ class ft_circular_buffer
         size_t        _head;
         size_t        _tail;
         size_t        _size;
-        mutable int   _errorCode;
+        mutable int   _error_code;
         mutable pt_mutex _mutex;
 
-        void setError(int error) const;
+        void set_error(int error) const;
 
     public:
         explicit ft_circular_buffer(size_t capacity);
@@ -51,14 +51,14 @@ class ft_circular_buffer
 
 template <typename ElementType>
 ft_circular_buffer<ElementType>::ft_circular_buffer(size_t capacity)
-    : _buffer(ft_nullptr), _capacity(capacity), _head(0), _tail(0), _size(0), _errorCode(ER_SUCCESS)
+    : _buffer(ft_nullptr), _capacity(capacity), _head(0), _tail(0), _size(0), _error_code(ER_SUCCESS)
 {
     if (capacity == 0)
         return ;
     _buffer = static_cast<ElementType*>(cma_malloc(sizeof(ElementType) * capacity));
     if (_buffer == ft_nullptr)
     {
-        this->setError(CIRCULAR_BUFFER_ALLOC_FAIL);
+        this->set_error(CIRCULAR_BUFFER_ALLOC_FAIL);
         _capacity = 0;
     }
 }
@@ -74,14 +74,14 @@ ft_circular_buffer<ElementType>::~ft_circular_buffer()
 template <typename ElementType>
 ft_circular_buffer<ElementType>::ft_circular_buffer(ft_circular_buffer&& other) noexcept
     : _buffer(other._buffer), _capacity(other._capacity), _head(other._head),
-      _tail(other._tail), _size(other._size), _errorCode(other._errorCode)
+      _tail(other._tail), _size(other._size), _error_code(other._error_code)
 {
     other._buffer = ft_nullptr;
     other._capacity = 0;
     other._head = 0;
     other._tail = 0;
     other._size = 0;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
 }
 
 template <typename ElementType>
@@ -104,13 +104,13 @@ ft_circular_buffer<ElementType>& ft_circular_buffer<ElementType>::operator=(ft_c
         this->_head = other._head;
         this->_tail = other._tail;
         this->_size = other._size;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._buffer = ft_nullptr;
         other._capacity = 0;
         other._head = 0;
         other._tail = 0;
         other._size = 0;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
         other._mutex.unlock(THREAD_ID);
         this->_mutex.unlock(THREAD_ID);
     }
@@ -118,9 +118,9 @@ ft_circular_buffer<ElementType>& ft_circular_buffer<ElementType>::operator=(ft_c
 }
 
 template <typename ElementType>
-void ft_circular_buffer<ElementType>::setError(int error) const
+void ft_circular_buffer<ElementType>::set_error(int error) const
 {
-    this->_errorCode = error;
+    this->_error_code = error;
     ft_errno = error;
 }
 
@@ -129,12 +129,12 @@ void ft_circular_buffer<ElementType>::push(const ElementType& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (this->_size == this->_capacity)
     {
-        this->setError(CIRCULAR_BUFFER_FULL);
+        this->set_error(CIRCULAR_BUFFER_FULL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -149,12 +149,12 @@ void ft_circular_buffer<ElementType>::push(ElementType&& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (this->_size == this->_capacity)
     {
-        this->setError(CIRCULAR_BUFFER_FULL);
+        this->set_error(CIRCULAR_BUFFER_FULL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -169,12 +169,12 @@ ElementType ft_circular_buffer<ElementType>::pop()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return (ElementType());
     }
     if (this->_size == 0)
     {
-        this->setError(CIRCULAR_BUFFER_EMPTY);
+        this->set_error(CIRCULAR_BUFFER_EMPTY);
         this->_mutex.unlock(THREAD_ID);
         return (ElementType());
     }
@@ -230,8 +230,8 @@ template <typename ElementType>
 int ft_circular_buffer<ElementType>::get_error() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (this->_errorCode);
-    int err = this->_errorCode;
+        return (this->_error_code);
+    int err = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
     return (err);
 }
@@ -240,8 +240,8 @@ template <typename ElementType>
 const char* ft_circular_buffer<ElementType>::get_error_str() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (ft_strerror(this->_errorCode));
-    int err = this->_errorCode;
+        return (ft_strerror(this->_error_code));
+    int err = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
     return (ft_strerror(err));
 }

--- a/Template/deque.hpp
+++ b/Template/deque.hpp
@@ -24,10 +24,10 @@ class ft_deque
         DequeNode*   _front;
         DequeNode*   _back;
         size_t       _size;
-        mutable int  _errorCode;
+        mutable int  _error_code;
         mutable pt_mutex _mutex;
 
-        void    setError(int error) const;
+        void    set_error(int error) const;
 
     public:
         ft_deque();
@@ -62,7 +62,7 @@ class ft_deque
 
 template <typename ElementType>
 ft_deque<ElementType>::ft_deque()
-    : _front(ft_nullptr), _back(ft_nullptr), _size(0), _errorCode(ER_SUCCESS)
+    : _front(ft_nullptr), _back(ft_nullptr), _size(0), _error_code(ER_SUCCESS)
 {
     return ;
 }
@@ -76,12 +76,12 @@ ft_deque<ElementType>::~ft_deque()
 
 template <typename ElementType>
 ft_deque<ElementType>::ft_deque(ft_deque&& other) noexcept
-    : _front(other._front), _back(other._back), _size(other._size), _errorCode(other._errorCode)
+    : _front(other._front), _back(other._back), _size(other._size), _error_code(other._error_code)
 {
     other._front = ft_nullptr;
     other._back = ft_nullptr;
     other._size = 0;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
     return ;
 }
 
@@ -101,11 +101,11 @@ ft_deque<ElementType>& ft_deque<ElementType>::operator=(ft_deque&& other) noexce
         this->_front = other._front;
         this->_back = other._back;
         this->_size = other._size;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._front = ft_nullptr;
         other._back = ft_nullptr;
         other._size = 0;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
         other._mutex.unlock(THREAD_ID);
         this->_mutex.unlock(THREAD_ID);
     }
@@ -113,9 +113,9 @@ ft_deque<ElementType>& ft_deque<ElementType>::operator=(ft_deque&& other) noexce
 }
 
 template <typename ElementType>
-void ft_deque<ElementType>::setError(int error) const
+void ft_deque<ElementType>::set_error(int error) const
 {
-    this->_errorCode = error;
+    this->_error_code = error;
     ft_errno = error;
     return ;
 }
@@ -125,13 +125,13 @@ void ft_deque<ElementType>::push_front(const ElementType& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     DequeNode* node = static_cast<DequeNode*>(cma_malloc(sizeof(DequeNode)));
     if (node == ft_nullptr)
     {
-        this->setError(DEQUE_ALLOC_FAIL);
+        this->set_error(DEQUE_ALLOC_FAIL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -153,13 +153,13 @@ void ft_deque<ElementType>::push_front(ElementType&& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     DequeNode* node = static_cast<DequeNode*>(cma_malloc(sizeof(DequeNode)));
     if (node == ft_nullptr)
     {
-        this->setError(DEQUE_ALLOC_FAIL);
+        this->set_error(DEQUE_ALLOC_FAIL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -181,13 +181,13 @@ void ft_deque<ElementType>::push_back(const ElementType& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     DequeNode* node = static_cast<DequeNode*>(cma_malloc(sizeof(DequeNode)));
     if (node == ft_nullptr)
     {
-        this->setError(DEQUE_ALLOC_FAIL);
+        this->set_error(DEQUE_ALLOC_FAIL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -209,13 +209,13 @@ void ft_deque<ElementType>::push_back(ElementType&& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     DequeNode* node = static_cast<DequeNode*>(cma_malloc(sizeof(DequeNode)));
     if (node == ft_nullptr)
     {
-        this->setError(DEQUE_ALLOC_FAIL);
+        this->set_error(DEQUE_ALLOC_FAIL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -237,12 +237,12 @@ ElementType ft_deque<ElementType>::pop_front()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return (ElementType());
     }
     if (this->_front == ft_nullptr)
     {
-        this->setError(DEQUE_EMPTY);
+        this->set_error(DEQUE_EMPTY);
         this->_mutex.unlock(THREAD_ID);
         return (ElementType());
     }
@@ -265,12 +265,12 @@ ElementType ft_deque<ElementType>::pop_back()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return (ElementType());
     }
     if (this->_back == ft_nullptr)
     {
-        this->setError(DEQUE_EMPTY);
+        this->set_error(DEQUE_EMPTY);
         this->_mutex.unlock(THREAD_ID);
         return (ElementType());
     }
@@ -291,81 +291,81 @@ ElementType ft_deque<ElementType>::pop_back()
 template <typename ElementType>
 ElementType& ft_deque<ElementType>::front()
 {
-    static ElementType errorElement = ElementType();
+    static ElementType error_element = ElementType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
-        return (errorElement);
+        this->set_error(PT_ERR_MUTEX_OWNER);
+        return (error_element);
     }
     if (this->_front == ft_nullptr)
     {
-        this->setError(DEQUE_EMPTY);
+        this->set_error(DEQUE_EMPTY);
         this->_mutex.unlock(THREAD_ID);
-        return (errorElement);
+        return (error_element);
     }
-    ElementType& ref = this->_front->_data;
+    ElementType& reference = this->_front->_data;
     this->_mutex.unlock(THREAD_ID);
-    return (ref);
+    return (reference);
 }
 
 template <typename ElementType>
 const ElementType& ft_deque<ElementType>::front() const
 {
-    static ElementType errorElement = ElementType();
+    static ElementType error_element = ElementType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
-        return (errorElement);
+        this->set_error(PT_ERR_MUTEX_OWNER);
+        return (error_element);
     }
     if (this->_front == ft_nullptr)
     {
-        this->setError(DEQUE_EMPTY);
+        this->set_error(DEQUE_EMPTY);
         this->_mutex.unlock(THREAD_ID);
-        return (errorElement);
+        return (error_element);
     }
-    ElementType& ref = this->_front->_data;
+    const ElementType& reference = this->_front->_data;
     this->_mutex.unlock(THREAD_ID);
-    return (ref);
+    return (reference);
 }
 
 template <typename ElementType>
 ElementType& ft_deque<ElementType>::back()
 {
-    static ElementType errorElement = ElementType();
+    static ElementType error_element = ElementType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
-        return (errorElement);
+        this->set_error(PT_ERR_MUTEX_OWNER);
+        return (error_element);
     }
     if (this->_back == ft_nullptr)
     {
-        this->setError(DEQUE_EMPTY);
+        this->set_error(DEQUE_EMPTY);
         this->_mutex.unlock(THREAD_ID);
-        return (errorElement);
+        return (error_element);
     }
-    ElementType& ref = this->_back->_data;
+    ElementType& reference = this->_back->_data;
     this->_mutex.unlock(THREAD_ID);
-    return (ref);
+    return (reference);
 }
 
 template <typename ElementType>
 const ElementType& ft_deque<ElementType>::back() const
 {
-    static ElementType errorElement = ElementType();
+    static ElementType error_element = ElementType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
-        return (errorElement);
+        this->set_error(PT_ERR_MUTEX_OWNER);
+        return (error_element);
     }
     if (this->_back == ft_nullptr)
     {
-        this->setError(DEQUE_EMPTY);
+        this->set_error(DEQUE_EMPTY);
         this->_mutex.unlock(THREAD_ID);
-        return (errorElement);
+        return (error_element);
     }
-    ElementType& ref = this->_back->_data;
+    const ElementType& reference = this->_back->_data;
     this->_mutex.unlock(THREAD_ID);
-    return (ref);
+    return (reference);
 }
 
 template <typename ElementType>
@@ -373,9 +373,9 @@ size_t ft_deque<ElementType>::size() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (0);
-    size_t s = this->_size;
+    size_t current_size = this->_size;
     this->_mutex.unlock(THREAD_ID);
-    return (s);
+    return (current_size);
 }
 
 template <typename ElementType>
@@ -383,29 +383,29 @@ bool ft_deque<ElementType>::empty() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (true);
-    bool res = (this->_size == 0);
+    bool result = (this->_size == 0);
     this->_mutex.unlock(THREAD_ID);
-    return (res);
+    return (result);
 }
 
 template <typename ElementType>
 int ft_deque<ElementType>::get_error() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (this->_errorCode);
-    int err = this->_errorCode;
+        return (this->_error_code);
+    int error = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
-    return (err);
+    return (error);
 }
 
 template <typename ElementType>
 const char* ft_deque<ElementType>::get_error_str() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (ft_strerror(this->_errorCode));
-    int err = this->_errorCode;
+        return (ft_strerror(this->_error_code));
+    int error = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
-    return (ft_strerror(err));
+    return (ft_strerror(error));
 }
 
 template <typename ElementType>

--- a/Template/event_emitter.hpp
+++ b/Template/event_emitter.hpp
@@ -29,14 +29,14 @@ class ft_event_emitter
         Listener*   _listeners;
         size_t      _capacity;
         size_t      _size;
-        mutable int _errorCode;
+        mutable int _error_code;
         mutable pt_mutex _mutex;
 
-        void    setError(int error) const;
+        void    set_error(int error) const;
         bool    ensure_capacity(size_t desired);
 
     public:
-        ft_event_emitter(size_t initialCapacity = 0);
+        ft_event_emitter(size_t initial_capacity = 0);
         ~ft_event_emitter();
 
         ft_event_emitter(const ft_event_emitter&) = delete;
@@ -45,9 +45,9 @@ class ft_event_emitter
         ft_event_emitter(ft_event_emitter&& other) noexcept;
         ft_event_emitter& operator=(ft_event_emitter&& other) noexcept;
 
-        void on(const EventType& event, void (*cb)(Args...));
+        void on(const EventType& event, void (*callback)(Args...));
         void emit(const EventType& event, Args... args);
-        void remove_listener(const EventType& event, void (*cb)(Args...));
+        void remove_listener(const EventType& event, void (*callback)(Args...));
         size_t size() const;
         bool empty() const;
         int get_error() const;
@@ -56,16 +56,16 @@ class ft_event_emitter
 };
 
 template <typename EventType, typename... Args>
-ft_event_emitter<EventType, Args...>::ft_event_emitter(size_t initialCapacity)
-    : _listeners(ft_nullptr), _capacity(0), _size(0), _errorCode(ER_SUCCESS)
+ft_event_emitter<EventType, Args...>::ft_event_emitter(size_t initial_capacity)
+    : _listeners(ft_nullptr), _capacity(0), _size(0), _error_code(ER_SUCCESS)
 {
-    if (initialCapacity > 0)
+    if (initial_capacity > 0)
     {
-        this->_listeners = static_cast<Listener*>(cma_malloc(sizeof(Listener) * initialCapacity));
+        this->_listeners = static_cast<Listener*>(cma_malloc(sizeof(Listener) * initial_capacity));
         if (this->_listeners == ft_nullptr)
-            this->setError(EVENT_EMITTER_ALLOC_FAIL);
+            this->set_error(EVENT_EMITTER_ALLOC_FAIL);
         else
-            this->_capacity = initialCapacity;
+            this->_capacity = initial_capacity;
     }
     return ;
 }
@@ -82,12 +82,12 @@ ft_event_emitter<EventType, Args...>::~ft_event_emitter()
 template <typename EventType, typename... Args>
 ft_event_emitter<EventType, Args...>::ft_event_emitter(ft_event_emitter&& other) noexcept
     : _listeners(other._listeners), _capacity(other._capacity), _size(other._size),
-      _errorCode(other._errorCode)
+      _error_code(other._error_code)
 {
     other._listeners = ft_nullptr;
     other._capacity = 0;
     other._size = 0;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
     return ;
 }
 
@@ -109,11 +109,11 @@ ft_event_emitter<EventType, Args...>& ft_event_emitter<EventType, Args...>::oper
         this->_listeners = other._listeners;
         this->_capacity = other._capacity;
         this->_size = other._size;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._listeners = ft_nullptr;
         other._capacity = 0;
         other._size = 0;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
         other._mutex.unlock(THREAD_ID);
         this->_mutex.unlock(THREAD_ID);
     }
@@ -121,9 +121,9 @@ ft_event_emitter<EventType, Args...>& ft_event_emitter<EventType, Args...>::oper
 }
 
 template <typename EventType, typename... Args>
-void ft_event_emitter<EventType, Args...>::setError(int error) const
+void ft_event_emitter<EventType, Args...>::set_error(int error) const
 {
-    this->_errorCode = error;
+    this->_error_code = error;
     ft_errno = error;
     return ;
 }
@@ -133,35 +133,35 @@ bool ft_event_emitter<EventType, Args...>::ensure_capacity(size_t desired)
 {
     if (desired <= this->_capacity)
         return (true);
-    size_t newCap;
+    size_t new_capacity;
     if (this->_capacity == 0)
-        newCap = 1;
+        new_capacity = 1;
     else
-        newCap = this->_capacity * 2;
-    while (newCap < desired)
-        newCap *= 2;
-    Listener* newData = static_cast<Listener*>(cma_malloc(sizeof(Listener) * newCap));
-    if (newData == ft_nullptr)
+        new_capacity = this->_capacity * 2;
+    while (new_capacity < desired)
+        new_capacity *= 2;
+    Listener* new_data = static_cast<Listener*>(cma_malloc(sizeof(Listener) * new_capacity));
+    if (new_data == ft_nullptr)
     {
-        this->setError(EVENT_EMITTER_ALLOC_FAIL);
+        this->set_error(EVENT_EMITTER_ALLOC_FAIL);
         return (false);
     }
     size_t listener_index = 0;
     while (listener_index < this->_size)
     {
-        construct_at(&newData[listener_index], std::move(this->_listeners[listener_index]));
+        construct_at(&new_data[listener_index], std::move(this->_listeners[listener_index]));
         destroy_at(&this->_listeners[listener_index]);
         ++listener_index;
     }
     if (this->_listeners != ft_nullptr)
         cma_free(this->_listeners);
-    this->_listeners = newData;
-    this->_capacity = newCap;
+    this->_listeners = new_data;
+    this->_capacity = new_capacity;
     return (true);
 }
 
 template <typename EventType, typename... Args>
-void ft_event_emitter<EventType, Args...>::on(const EventType& event, void (*cb)(Args...))
+void ft_event_emitter<EventType, Args...>::on(const EventType& event, void (*callback)(Args...))
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return ;
@@ -170,7 +170,7 @@ void ft_event_emitter<EventType, Args...>::on(const EventType& event, void (*cb)
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&this->_listeners[this->_size], Listener{event, cb});
+    construct_at(&this->_listeners[this->_size], Listener{event, callback});
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
     return ;
@@ -193,20 +193,20 @@ void ft_event_emitter<EventType, Args...>::emit(const EventType& event, Args... 
         ++listener_index;
     }
     if (!found)
-        this->setError(EVENT_EMITTER_NOT_FOUND);
+        this->set_error(EVENT_EMITTER_NOT_FOUND);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
 
 template <typename EventType, typename... Args>
-void ft_event_emitter<EventType, Args...>::remove_listener(const EventType& event, void (*cb)(Args...))
+void ft_event_emitter<EventType, Args...>::remove_listener(const EventType& event, void (*callback)(Args...))
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return ;
     size_t listener_index = 0;
     while (listener_index < this->_size)
     {
-        if (this->_listeners[listener_index]._event == event && this->_listeners[listener_index]._callback == cb)
+        if (this->_listeners[listener_index]._event == event && this->_listeners[listener_index]._callback == callback)
         {
             destroy_at(&this->_listeners[listener_index]);
             size_t shift_index = listener_index;
@@ -222,7 +222,7 @@ void ft_event_emitter<EventType, Args...>::remove_listener(const EventType& even
         }
         ++listener_index;
     }
-    this->setError(EVENT_EMITTER_NOT_FOUND);
+    this->set_error(EVENT_EMITTER_NOT_FOUND);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -242,13 +242,13 @@ bool ft_event_emitter<EventType, Args...>::empty() const
 template <typename EventType, typename... Args>
 int ft_event_emitter<EventType, Args...>::get_error() const
 {
-    return (this->_errorCode);
+    return (this->_error_code);
 }
 
 template <typename EventType, typename... Args>
 const char* ft_event_emitter<EventType, Args...>::get_error_str() const
 {
-    return (ft_strerror(this->_errorCode));
+    return (ft_strerror(this->_error_code));
 }
 
 template <typename EventType, typename... Args>

--- a/Template/future.hpp
+++ b/Template/future.hpp
@@ -14,27 +14,27 @@ class ft_future
 {
 private:
     ft_promise<ValueType>* _promise;
-    mutable int _errorCode;
+    mutable int _error_code;
 
-    void setError(int error) const
+    void set_error(int error) const
     {
-        this->_errorCode = error;
+        this->_error_code = error;
         ft_errno = error;
     }
 
 public:
-    ft_future() : _promise(nullptr), _errorCode(ER_SUCCESS) {}
-    explicit ft_future(ft_promise<ValueType>& promise) : _promise(&promise), _errorCode(ER_SUCCESS) {}
+    ft_future() : _promise(nullptr), _error_code(ER_SUCCESS) {}
+    explicit ft_future(ft_promise<ValueType>& promise) : _promise(&promise), _error_code(ER_SUCCESS) {}
 
     ValueType get() const
     {
         if (!this->valid())
         {
-            this->setError(FUTURE_INVALID);
+            this->set_error(FUTURE_INVALID);
             return (ValueType());
         }
         this->wait();
-        if (this->_errorCode != ER_SUCCESS)
+        if (this->_error_code != ER_SUCCESS)
             return (ValueType());
         return (this->_promise->get());
     }
@@ -43,7 +43,7 @@ public:
     {
         if (!this->valid())
         {
-            this->setError(FUTURE_INVALID);
+            this->set_error(FUTURE_INVALID);
             return ;
         }
         using namespace std::chrono;
@@ -52,7 +52,7 @@ public:
         {
             if (steady_clock::now() - start > seconds(1))
             {
-                this->setError(FUTURE_BROKEN);
+                this->set_error(FUTURE_BROKEN);
                 return ;
             }
             std::this_thread::yield();
@@ -66,12 +66,12 @@ public:
 
     int get_error() const
     {
-        return (this->_errorCode);
+        return (this->_error_code);
     }
 
     const char* get_error_str() const
     {
-        return (ft_strerror(this->_errorCode));
+        return (ft_strerror(this->_error_code));
     }
 };
 

--- a/Template/graph.hpp
+++ b/Template/graph.hpp
@@ -32,10 +32,10 @@ class ft_graph
         GraphNode*   _nodes;
         size_t       _capacity;
         size_t       _size;
-        mutable int  _errorCode;
+        mutable int  _error_code;
         mutable pt_mutex _mutex;
 
-        void    setError(int error) const;
+        void    set_error(int error) const;
         bool    ensure_node_capacity(size_t desired);
         bool    ensure_edge_capacity(GraphNode& node, size_t desired);
 
@@ -68,13 +68,13 @@ class ft_graph
 
 template <typename VertexType>
 ft_graph<VertexType>::ft_graph(size_t initialCapacity)
-    : _nodes(ft_nullptr), _capacity(0), _size(0), _errorCode(ER_SUCCESS)
+    : _nodes(ft_nullptr), _capacity(0), _size(0), _error_code(ER_SUCCESS)
 {
     if (initialCapacity > 0)
     {
         this->_nodes = static_cast<GraphNode*>(cma_malloc(sizeof(GraphNode) * initialCapacity));
         if (this->_nodes == ft_nullptr)
-            this->setError(GRAPH_ALLOC_FAIL);
+            this->set_error(GRAPH_ALLOC_FAIL);
         else
             this->_capacity = initialCapacity;
     }
@@ -101,12 +101,12 @@ ft_graph<VertexType>::~ft_graph()
 
 template <typename VertexType>
 ft_graph<VertexType>::ft_graph(ft_graph&& other) noexcept
-    : _nodes(other._nodes), _capacity(other._capacity), _size(other._size), _errorCode(other._errorCode)
+    : _nodes(other._nodes), _capacity(other._capacity), _size(other._size), _error_code(other._error_code)
 {
     other._nodes = ft_nullptr;
     other._capacity = 0;
     other._size = 0;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
     return ;
 }
 
@@ -128,11 +128,11 @@ ft_graph<VertexType>& ft_graph<VertexType>::operator=(ft_graph&& other) noexcept
         this->_nodes = other._nodes;
         this->_capacity = other._capacity;
         this->_size = other._size;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._nodes = ft_nullptr;
         other._capacity = 0;
         other._size = 0;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
         other._mutex.unlock(THREAD_ID);
         this->_mutex.unlock(THREAD_ID);
     }
@@ -140,9 +140,9 @@ ft_graph<VertexType>& ft_graph<VertexType>::operator=(ft_graph&& other) noexcept
 }
 
 template <typename VertexType>
-void ft_graph<VertexType>::setError(int error) const
+void ft_graph<VertexType>::set_error(int error) const
 {
-    this->_errorCode = error;
+    this->_error_code = error;
     ft_errno = error;
     return ;
 }
@@ -162,7 +162,7 @@ bool ft_graph<VertexType>::ensure_node_capacity(size_t desired)
     GraphNode* newNodes = static_cast<GraphNode*>(cma_malloc(sizeof(GraphNode) * newCap));
     if (newNodes == ft_nullptr)
     {
-        this->setError(GRAPH_ALLOC_FAIL);
+        this->set_error(GRAPH_ALLOC_FAIL);
         return (false);
     }
     size_t node_index = 0;
@@ -197,7 +197,7 @@ bool ft_graph<VertexType>::ensure_edge_capacity(GraphNode& node, size_t desired)
     size_t* newEdges = static_cast<size_t*>(cma_malloc(sizeof(size_t) * newCap));
     if (newEdges == ft_nullptr)
     {
-        this->setError(GRAPH_ALLOC_FAIL);
+        this->set_error(GRAPH_ALLOC_FAIL);
         return (false);
     }
     size_t edge_index = 0;
@@ -218,7 +218,7 @@ size_t ft_graph<VertexType>::add_vertex(const VertexType& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return (this->_size);
     }
     if (!ensure_node_capacity(this->_size + 1))
@@ -241,7 +241,7 @@ size_t ft_graph<VertexType>::add_vertex(VertexType&& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return (this->_size);
     }
     if (!ensure_node_capacity(this->_size + 1))
@@ -264,12 +264,12 @@ void ft_graph<VertexType>::add_edge(size_t from, size_t to)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (from >= this->_size || to >= this->_size)
     {
-        this->setError(GRAPH_NOT_FOUND);
+        this->set_error(GRAPH_NOT_FOUND);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -291,19 +291,19 @@ void ft_graph<VertexType>::bfs(size_t start, Func visit)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (start >= this->_size)
     {
-        this->setError(GRAPH_NOT_FOUND);
+        this->set_error(GRAPH_NOT_FOUND);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
     bool* visited = static_cast<bool*>(cma_malloc(sizeof(bool) * this->_size));
     if (visited == ft_nullptr)
     {
-        this->setError(GRAPH_ALLOC_FAIL);
+        this->set_error(GRAPH_ALLOC_FAIL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -343,19 +343,19 @@ void ft_graph<VertexType>::dfs(size_t start, Func visit)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (start >= this->_size)
     {
-        this->setError(GRAPH_NOT_FOUND);
+        this->set_error(GRAPH_NOT_FOUND);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
     bool* visited = static_cast<bool*>(cma_malloc(sizeof(bool) * this->_size));
     if (visited == ft_nullptr)
     {
-        this->setError(GRAPH_ALLOC_FAIL);
+        this->set_error(GRAPH_ALLOC_FAIL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -412,8 +412,8 @@ template <typename VertexType>
 int ft_graph<VertexType>::get_error() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (this->_errorCode);
-    int err = this->_errorCode;
+        return (this->_error_code);
+    int err = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
     return (err);
 }
@@ -422,8 +422,8 @@ template <typename VertexType>
 const char* ft_graph<VertexType>::get_error_str() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (ft_strerror(this->_errorCode));
-    int err = this->_errorCode;
+        return (ft_strerror(this->_error_code));
+    int err = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
     return (ft_strerror(err));
 }

--- a/Template/map.hpp
+++ b/Template/map.hpp
@@ -20,12 +20,12 @@ private:
     mutable int             _error;
     mutable pt_mutex        _mutex;
 
-    void    resize(size_t newCapacity);
-    size_t  findIndex(const Key& key) const;
-    void    setError(int error) const;
+    void    resize(size_t new_capacity);
+    size_t  find_index(const Key& key) const;
+    void    set_error(int error) const;
 
 public:
-    ft_map(size_t initialCapacity = 10);
+    ft_map(size_t initial_capacity = 10);
     ft_map(const ft_map& other);
     ft_map& operator=(const ft_map& other);
     ft_map(ft_map&& other) noexcept;
@@ -37,8 +37,8 @@ public:
     void        remove(const Key& key);
     bool        empty() const;
     void        clear();
-    size_t      getSize() const;
-    size_t      getCapacity() const;
+    size_t      size() const;
+    size_t      capacity() const;
     int         get_error() const;
     const char* get_error_str() const;
 
@@ -51,17 +51,17 @@ public:
 };
 
 template <typename Key, typename MappedType>
-ft_map<Key, MappedType>::ft_map(size_t initialCapacity)
-    : _capacity(initialCapacity), _size(0), _error(ER_SUCCESS)
+ft_map<Key, MappedType>::ft_map(size_t initial_capacity)
+    : _capacity(initial_capacity), _size(0), _error(ER_SUCCESS)
 {
-    void* rawMemory = cma_malloc(sizeof(Pair<Key, MappedType>) * this->_capacity);
-    if (!rawMemory)
+    void* raw_memory = cma_malloc(sizeof(Pair<Key, MappedType>) * this->_capacity);
+    if (!raw_memory)
     {
-        this->setError(SHARED_PTR_ALLOCATION_FAILED);
+        this->set_error(SHARED_PTR_ALLOCATION_FAILED);
         this->_data = ft_nullptr;
         return ;
     }
-    this->_data = static_cast<Pair<Key, MappedType>*>(rawMemory);
+    this->_data = static_cast<Pair<Key, MappedType>*>(raw_memory);
 }
 
 template <typename Key, typename MappedType>
@@ -70,16 +70,16 @@ ft_map<Key, MappedType>::ft_map(const ft_map<Key, MappedType>& other)
 {
     if (other._data != ft_nullptr && this->_size > 0)
     {
-        void* rawMemory = cma_malloc(sizeof(Pair<Key, MappedType>) * this->_capacity);
-        if (!rawMemory)
+        void* raw_memory = cma_malloc(sizeof(Pair<Key, MappedType>) * this->_capacity);
+        if (!raw_memory)
         {
-            this->setError(SHARED_PTR_ALLOCATION_FAILED);
+            this->set_error(SHARED_PTR_ALLOCATION_FAILED);
             this->_data = ft_nullptr;
             this->_size = 0;
             this->_capacity = 0;
             return ;
         }
-        this->_data = static_cast<Pair<Key, MappedType>*>(rawMemory);
+        this->_data = static_cast<Pair<Key, MappedType>*>(raw_memory);
         size_t index = 0;
         while (index < this->_size)
         {
@@ -112,16 +112,16 @@ ft_map<Key, MappedType>& ft_map<Key, MappedType>::operator=(const ft_map<Key, Ma
         this->_error = other._error;
         if (other._data != ft_nullptr && other._size > 0)
         {
-            void* rawMemory = cma_malloc(sizeof(Pair<Key, MappedType>) * other._capacity);
-            if (!rawMemory)
+            void* raw_memory = cma_malloc(sizeof(Pair<Key, MappedType>) * other._capacity);
+            if (!raw_memory)
             {
-                this->setError(SHARED_PTR_ALLOCATION_FAILED);
+                this->set_error(SHARED_PTR_ALLOCATION_FAILED);
                 this->_data = ft_nullptr;
                 this->_size = 0;
                 this->_capacity = 0;
                 return (*this);
             }
-            this->_data = static_cast<Pair<Key, MappedType>*>(rawMemory);
+            this->_data = static_cast<Pair<Key, MappedType>*>(raw_memory);
             size_t index = 0;
             while (index < other._size)
             {
@@ -204,11 +204,11 @@ void ft_map<Key, MappedType>::insert(const Key& key, const MappedType& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     this->_error = ER_SUCCESS;
-    size_t index = findIndex(key);
+    size_t index = find_index(key);
     if (index != this->_size)
     {
         this->_data[index].value = value;
@@ -235,7 +235,7 @@ Pair<Key, MappedType> *ft_map<Key, MappedType>::find(const Key& key)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return (ft_nullptr);
     }
     size_t index = 0;
@@ -243,9 +243,9 @@ Pair<Key, MappedType> *ft_map<Key, MappedType>::find(const Key& key)
     {
         if (this->_data[index].key == key)
         {
-            Pair<Key, MappedType>* res = &this->_data[index];
+            Pair<Key, MappedType>* result = &this->_data[index];
             this->_mutex.unlock(THREAD_ID);
-            return (res);
+            return (result);
         }
         index++;
     }
@@ -258,7 +258,7 @@ const Pair<Key, MappedType> *ft_map<Key, MappedType>::find(const Key& key) const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return (ft_nullptr);
     }
     size_t index = 0;
@@ -266,9 +266,9 @@ const Pair<Key, MappedType> *ft_map<Key, MappedType>::find(const Key& key) const
     {
         if (this->_data[index].key == key)
         {
-            const Pair<Key, MappedType>* res = &this->_data[index];
+            const Pair<Key, MappedType>* result = &this->_data[index];
             this->_mutex.unlock(THREAD_ID);
-            return (res);
+            return (result);
         }
         index++;
     }
@@ -281,7 +281,7 @@ void ft_map<Key, MappedType>::remove(const Key& key)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     size_t index = 0;
@@ -310,9 +310,9 @@ bool ft_map<Key, MappedType>::empty() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (true);
-    bool res = (this->_size == 0);
+    bool result = (this->_size == 0);
     this->_mutex.unlock(THREAD_ID);
-    return (res);
+    return (result);
 }
 
 template <typename Key, typename MappedType>
@@ -320,7 +320,7 @@ void ft_map<Key, MappedType>::clear()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     size_t index = 0;
@@ -335,23 +335,23 @@ void ft_map<Key, MappedType>::clear()
 }
 
 template <typename Key, typename MappedType>
-size_t ft_map<Key, MappedType>::getSize() const
+size_t ft_map<Key, MappedType>::size() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (0);
-    size_t s = this->_size;
+    size_t current_size = this->_size;
     this->_mutex.unlock(THREAD_ID);
-    return (s);
+    return (current_size);
 }
 
 template <typename Key, typename MappedType>
-size_t ft_map<Key, MappedType>::getCapacity() const
+size_t ft_map<Key, MappedType>::capacity() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (0);
-    size_t c = this->_capacity;
+    size_t current_capacity = this->_capacity;
     this->_mutex.unlock(THREAD_ID);
-    return (c);
+    return (current_capacity);
 }
 
 template <typename Key, typename MappedType>
@@ -359,9 +359,9 @@ int ft_map<Key, MappedType>::get_error() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (_error);
-    int err = this->_error;
+    int error_value = this->_error;
     this->_mutex.unlock(THREAD_ID);
-    return (err);
+    return (error_value);
 }
 
 template <typename Key, typename MappedType>
@@ -369,13 +369,13 @@ const char* ft_map<Key, MappedType>::get_error_str() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (ft_strerror(_error));
-    int err = this->_error;
+    int error_value = this->_error;
     this->_mutex.unlock(THREAD_ID);
-    return (ft_strerror(err));
+    return (ft_strerror(error_value));
 }
 
 template<typename Key, typename MappedType>
-void ft_map<Key, MappedType>::setError(int error) const
+void ft_map<Key, MappedType>::set_error(int error) const
 {
     ft_errno = error;
     this->_error = error;
@@ -383,31 +383,31 @@ void ft_map<Key, MappedType>::setError(int error) const
 }
 
 template <typename Key, typename MappedType>
-void ft_map<Key, MappedType>::resize(size_t newCapacity)
+void ft_map<Key, MappedType>::resize(size_t new_capacity)
 {
     this->_error = ER_SUCCESS;
-    void* rawMemory = cma_malloc(sizeof(Pair<Key, MappedType>) * newCapacity);
-    if (!rawMemory)
+    void* raw_memory = cma_malloc(sizeof(Pair<Key, MappedType>) * new_capacity);
+    if (!raw_memory)
     {
-        this->setError(SHARED_PTR_ALLOCATION_FAILED);
+        this->set_error(SHARED_PTR_ALLOCATION_FAILED);
         return ;
     }
-    Pair<Key, MappedType>* newData = static_cast<Pair<Key, MappedType>*>(rawMemory);
+    Pair<Key, MappedType>* new_data = static_cast<Pair<Key, MappedType>*>(raw_memory);
     size_t index = 0;
     while (index < this->_size)
     {
-        construct_at(&newData[index], std::move(this->_data[index]));
+        construct_at(&new_data[index], std::move(this->_data[index]));
         destroy_at(&this->_data[index]);
         index++;
     }
     cma_free(this->_data);
-    this->_data = newData;
-    this->_capacity = newCapacity;
+    this->_data = new_data;
+    this->_capacity = new_capacity;
     return ;
 }
 
 template <typename Key, typename MappedType>
-size_t ft_map<Key, MappedType>::findIndex(const Key& key) const
+size_t ft_map<Key, MappedType>::find_index(const Key& key) const
 {
     size_t index = 0;
     while  (index < this->_size)
@@ -424,9 +424,9 @@ Pair<Key, MappedType>* ft_map<Key, MappedType>::end()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (this->_data + this->_size);
-    Pair<Key, MappedType>* res = this->_data + this->_size;
+    Pair<Key, MappedType>* result = this->_data + this->_size;
     this->_mutex.unlock(THREAD_ID);
-    return (res);
+    return (result);
 }
 
 template <typename Key, typename MappedType>
@@ -434,26 +434,26 @@ const Pair<Key, MappedType>* ft_map<Key, MappedType>::end() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (this->_data + this->_size);
-    const Pair<Key, MappedType>* res = this->_data + this->_size;
+    const Pair<Key, MappedType>* result = this->_data + this->_size;
     this->_mutex.unlock(THREAD_ID);
-    return (res);
+    return (result);
 }
 
 template <typename Key, typename MappedType>
 MappedType& ft_map<Key, MappedType>::at(const Key& key)
 {
-    static MappedType errorMappedType = MappedType();
+    static MappedType error_mapped_type = MappedType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
-        return (errorMappedType);
+        set_error(PT_ERR_MUTEX_OWNER);
+        return (error_mapped_type);
     }
-    size_t index = findIndex(key);
+    size_t index = find_index(key);
     if (this->_size == 0 || index == this->_size)
     {
-        this->setError(UNORD_MAP_UNKNOWN);
+        this->set_error(UNORD_MAP_UNKNOWN);
         this->_mutex.unlock(THREAD_ID);
-        return (errorMappedType);
+        return (error_mapped_type);
     }
     MappedType& value = this->_data[index].value;
     this->_mutex.unlock(THREAD_ID);
@@ -463,18 +463,18 @@ MappedType& ft_map<Key, MappedType>::at(const Key& key)
 template <typename Key, typename MappedType>
 const MappedType& ft_map<Key, MappedType>::at(const Key& key) const
 {
-    static MappedType errorMappedType = MappedType();
+    static MappedType error_mapped_type = MappedType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
-        return (errorMappedType);
+        set_error(PT_ERR_MUTEX_OWNER);
+        return (error_mapped_type);
     }
-    size_t index = findIndex(key);
+    size_t index = find_index(key);
     if (this->_size == 0 || index == this->_size)
     {
-        this->setError(UNORD_MAP_UNKNOWN);
+        this->set_error(UNORD_MAP_UNKNOWN);
         this->_mutex.unlock(THREAD_ID);
-        return (errorMappedType);
+        return (error_mapped_type);
     }
     const MappedType& value = this->_data[index].value;
     this->_mutex.unlock(THREAD_ID);

--- a/Template/promise.hpp
+++ b/Template/promise.hpp
@@ -11,16 +11,16 @@ class ft_promise
 private:
     ValueType _value;
     std::atomic_bool _ready;
-    mutable int _errorCode;
+    mutable int _error_code;
 
-    void setError(int error) const
+    void set_error(int error) const
     {
-        this->_errorCode = error;
+        this->_error_code = error;
         ft_errno = error;
     }
 
 public:
-    ft_promise() : _value(), _ready(false), _errorCode(ER_SUCCESS) {}
+    ft_promise() : _value(), _ready(false), _error_code(ER_SUCCESS) {}
 
     void set_value(const ValueType& value)
     {
@@ -38,7 +38,7 @@ public:
     {
         if (!this->_ready.load(std::memory_order_acquire))
         {
-            this->setError(FT_EINVAL);
+            this->set_error(FT_EINVAL);
             return (ValueType());
         }
         return (this->_value);
@@ -51,12 +51,12 @@ public:
 
     int get_error() const
     {
-        return (this->_errorCode);
+        return (this->_error_code);
     }
 
     const char* get_error_str() const
     {
-        return (ft_strerror(this->_errorCode));
+        return (ft_strerror(this->_error_code));
     }
 };
 

--- a/Template/shared_ptr.hpp
+++ b/Template/shared_ptr.hpp
@@ -19,7 +19,7 @@ class ft_sharedptr
         int* _referenceCount;
         size_t _arraySize;
         bool _isArrayType;
-        mutable int _errorCode;
+        mutable int _error_code;
 
         void release();
 
@@ -49,9 +49,9 @@ class ft_sharedptr
               _referenceCount(other._referenceCount),
               _arraySize(other._arraySize),
               _isArrayType(other._isArrayType),
-              _errorCode(other._errorCode)
+              _error_code(other._error_code)
         {
-            if (_referenceCount && _errorCode == ER_SUCCESS)
+            if (_referenceCount && _error_code == ER_SUCCESS)
                 ++(*_referenceCount);
         }
 
@@ -62,13 +62,13 @@ class ft_sharedptr
               _referenceCount(other._referenceCount),
               _arraySize(other._arraySize),
               _isArrayType(other._isArrayType),
-              _errorCode(other._errorCode)
+              _error_code(other._error_code)
         {
             other._managedPointer = ft_nullptr;
             other._referenceCount = ft_nullptr;
             other._arraySize = 0;
             other._isArrayType = false;
-            other._errorCode = ER_SUCCESS;
+            other._error_code = ER_SUCCESS;
         }
 
         ManagedType& operator*();
@@ -102,7 +102,7 @@ ft_sharedptr<ManagedType>::ft_sharedptr(Args&&... args)
       _referenceCount(new (std::nothrow) int),
       _arraySize(0),
       _isArrayType(false),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     if (!_referenceCount)
     {
@@ -126,7 +126,7 @@ ft_sharedptr<ManagedType>::ft_sharedptr(ManagedType* pointer, bool isArray, size
       _referenceCount(ft_nullptr),
       _arraySize(arraySize),
       _isArrayType(isArray),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     if (pointer)
         _referenceCount = new (std::nothrow) int;
@@ -144,7 +144,7 @@ ft_sharedptr<ManagedType>::ft_sharedptr()
       _referenceCount(ft_nullptr),
       _arraySize(0),
       _isArrayType(false),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
 }
 
@@ -154,7 +154,7 @@ ft_sharedptr<ManagedType>::ft_sharedptr(size_t size)
       _referenceCount(new (std::nothrow) int),
       _arraySize(size),
       _isArrayType(true),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     if (_referenceCount)
     {
@@ -179,9 +179,9 @@ ft_sharedptr<ManagedType>::ft_sharedptr(const ft_sharedptr<ManagedType>& other)
       _referenceCount(other._referenceCount),
       _arraySize(other._arraySize),
       _isArrayType(other._isArrayType),
-      _errorCode(other._errorCode)
+      _error_code(other._error_code)
 {
-    if (_referenceCount && _errorCode == ER_SUCCESS)
+    if (_referenceCount && _error_code == ER_SUCCESS)
         ++(*_referenceCount);
 }
 
@@ -191,13 +191,13 @@ ft_sharedptr<ManagedType>::ft_sharedptr(ft_sharedptr<ManagedType>&& other) noexc
       _referenceCount(other._referenceCount),
       _arraySize(other._arraySize),
       _isArrayType(other._isArrayType),
-      _errorCode(other._errorCode)
+      _error_code(other._error_code)
 {
     other._managedPointer = ft_nullptr;
     other._referenceCount = ft_nullptr;
     other._arraySize = 0;
     other._isArrayType = false;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
 }
 
 template <typename ManagedType>
@@ -239,12 +239,12 @@ ft_sharedptr<ManagedType>& ft_sharedptr<ManagedType>::operator=(ft_sharedptr<Man
         _referenceCount = other._referenceCount;
         _arraySize = other._arraySize;
         _isArrayType = other._isArrayType;
-        _errorCode = other._errorCode;
+        _error_code = other._error_code;
         other._managedPointer = ft_nullptr;
         other._referenceCount = ft_nullptr;
         other._arraySize = 0;
         other._isArrayType = false;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
     }
     return (*this);
 }
@@ -259,8 +259,8 @@ ft_sharedptr<ManagedType>& ft_sharedptr<ManagedType>::operator=(const ft_sharedp
         _referenceCount = other._referenceCount;
         _arraySize = other._arraySize;
         _isArrayType = other._isArrayType;
-        _errorCode = other._errorCode;
-        if (_referenceCount && _errorCode == ER_SUCCESS)
+        _error_code = other._error_code;
+        if (_referenceCount && _error_code == ER_SUCCESS)
             ++(*_referenceCount);
     }
     return (*this);
@@ -274,8 +274,8 @@ ManagedType& ft_sharedptr<ManagedType>::operator*()
         this->set_error(SHARED_PTR_NULL_PTR);
         if constexpr (!std::is_abstract_v<ManagedType>)
         {
-            static ManagedType defaultInstance;
-            return (defaultInstance);
+            static ManagedType default_instance;
+            return (default_instance);
         }
         else
         {
@@ -295,8 +295,8 @@ const ManagedType& ft_sharedptr<ManagedType>::operator*() const
         const_cast<ft_sharedptr<ManagedType>*>(this)->set_error(SHARED_PTR_NULL_PTR);
         if constexpr (!std::is_abstract_v<ManagedType>)
         {
-            static ManagedType defaultInstance;
-            return (defaultInstance);
+            static ManagedType default_instance;
+            return (default_instance);
         }
         else
         {
@@ -338,8 +338,8 @@ ManagedType& ft_sharedptr<ManagedType>::operator[](size_t index)
         this->set_error(SHARED_PTR_INVALID_OPERATION);
         if constexpr (!std::is_abstract_v<ManagedType>)
         {
-            static ManagedType defaultInstance;
-            return (defaultInstance);
+            static ManagedType default_instance;
+            return (default_instance);
         }
         else
         {
@@ -352,8 +352,8 @@ ManagedType& ft_sharedptr<ManagedType>::operator[](size_t index)
         this->set_error(SHARED_PTR_NULL_PTR);
         if constexpr (!std::is_abstract_v<ManagedType>)
         {
-            static ManagedType defaultInstance;
-            return (defaultInstance);
+            static ManagedType default_instance;
+            return (default_instance);
         }
         else
         {
@@ -366,8 +366,8 @@ ManagedType& ft_sharedptr<ManagedType>::operator[](size_t index)
         this->set_error(SHARED_PTR_OUT_OF_BOUNDS);
         if constexpr (!std::is_abstract_v<ManagedType>)
         {
-            static ManagedType defaultInstance;
-            return (defaultInstance);
+            static ManagedType default_instance;
+            return (default_instance);
         }
         else
         {
@@ -386,8 +386,8 @@ const ManagedType& ft_sharedptr<ManagedType>::operator[](size_t index) const
         const_cast<ft_sharedptr<ManagedType>*>(this)->set_error(SHARED_PTR_INVALID_OPERATION);
         if constexpr (!std::is_abstract_v<ManagedType>)
         {
-            static ManagedType defaultInstance;
-            return (defaultInstance);
+            static ManagedType default_instance;
+            return (default_instance);
         }
         else
         {
@@ -400,8 +400,8 @@ const ManagedType& ft_sharedptr<ManagedType>::operator[](size_t index) const
         const_cast<ft_sharedptr<ManagedType>*>(this)->set_error(SHARED_PTR_NULL_PTR);
         if constexpr (!std::is_abstract_v<ManagedType>)
         {
-            static ManagedType defaultInstance;
-            return (defaultInstance);
+            static ManagedType default_instance;
+            return (default_instance);
         }
         else
         {
@@ -414,8 +414,8 @@ const ManagedType& ft_sharedptr<ManagedType>::operator[](size_t index) const
         const_cast<ft_sharedptr<ManagedType>*>(this)->set_error(SHARED_PTR_OUT_OF_BOUNDS);
         if constexpr (!std::is_abstract_v<ManagedType>)
         {
-            static ManagedType defaultInstance;
-            return (defaultInstance);
+            static ManagedType default_instance;
+            return (default_instance);
         }
         else
         {
@@ -429,7 +429,7 @@ const ManagedType& ft_sharedptr<ManagedType>::operator[](size_t index) const
 template <typename ManagedType>
 int ft_sharedptr<ManagedType>::use_count() const
 {
-    if (_referenceCount && _errorCode == ER_SUCCESS)
+    if (_referenceCount && _error_code == ER_SUCCESS)
         return (*_referenceCount);
     return (0);
 }
@@ -437,19 +437,19 @@ int ft_sharedptr<ManagedType>::use_count() const
 template <typename ManagedType>
 bool ft_sharedptr<ManagedType>::hasError() const
 {
-    return (_errorCode != ER_SUCCESS);
+    return (_error_code != ER_SUCCESS);
 }
 
 template <typename ManagedType>
 int ft_sharedptr<ManagedType>::get_error() const
 {
-    return (_errorCode);
+    return (_error_code);
 }
 
 template <typename ManagedType>
 const char* ft_sharedptr<ManagedType>::get_error_str() const
 {
-    return (ft_strerror(_errorCode));
+    return (ft_strerror(_error_code));
 }
 
 template <typename ManagedType>
@@ -474,7 +474,7 @@ template <typename ManagedType>
 void ft_sharedptr<ManagedType>::set_error(int error) const
 {
     ft_errno = error;
-    _errorCode = error;
+    _error_code = error;
     return ;
 }
 
@@ -491,7 +491,7 @@ void ft_sharedptr<ManagedType>::reset(ManagedType* pointer, size_t size, bool ar
     _managedPointer = pointer;
     _arraySize = size;
     _isArrayType = arrayType;
-    _errorCode = ER_SUCCESS;
+    _error_code = ER_SUCCESS;
     _referenceCount = new (std::nothrow) int;
     if (_referenceCount)
     {
@@ -519,7 +519,7 @@ void ft_sharedptr<ManagedType>::swap(ft_sharedptr<ManagedType>& other)
     ft_swap(_referenceCount, other._referenceCount);
     ft_swap(_arraySize, other._arraySize);
     ft_swap(_isArrayType, other._isArrayType);
-    ft_swap(_errorCode, other._errorCode);
+    ft_swap(_error_code, other._error_code);
     return ;
 }
 

--- a/Template/stack.hpp
+++ b/Template/stack.hpp
@@ -22,10 +22,10 @@ class ft_stack
 
             StackNode*  _top;
             size_t      _size;
-            mutable int _errorCode;
+            mutable int _error_code;
             mutable pt_mutex _mutex;
 
-        void    setError(int error) const;
+        void    set_error(int error) const;
 
     public:
         ft_stack();
@@ -55,7 +55,7 @@ class ft_stack
 
 template <typename ElementType>
 ft_stack<ElementType>::ft_stack()
-    : _top(ft_nullptr), _size(0), _errorCode(ER_SUCCESS)
+    : _top(ft_nullptr), _size(0), _error_code(ER_SUCCESS)
 {
     return ;
 }
@@ -69,11 +69,11 @@ ft_stack<ElementType>::~ft_stack()
 
 template <typename ElementType>
 ft_stack<ElementType>::ft_stack(ft_stack&& other) noexcept
-    : _top(other._top), _size(other._size), _errorCode(other._errorCode)
+    : _top(other._top), _size(other._size), _error_code(other._error_code)
 {
     other._top = ft_nullptr;
     other._size = 0;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
     return ;
 }
 
@@ -92,10 +92,10 @@ ft_stack<ElementType>& ft_stack<ElementType>::operator=(ft_stack&& other) noexce
         this->clear();
         this->_top = other._top;
         this->_size = other._size;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._top = ft_nullptr;
         other._size = 0;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
         other._mutex.unlock(THREAD_ID);
         this->_mutex.unlock(THREAD_ID);
     }
@@ -103,9 +103,9 @@ ft_stack<ElementType>& ft_stack<ElementType>::operator=(ft_stack&& other) noexce
 }
 
 template <typename ElementType>
-void ft_stack<ElementType>::setError(int error) const
+void ft_stack<ElementType>::set_error(int error) const
 {
-    this->_errorCode = error;
+    this->_error_code = error;
     ft_errno = error;
     return ;
 }
@@ -115,19 +115,19 @@ void ft_stack<ElementType>::push(const ElementType& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
-    StackNode* newNode = static_cast<StackNode*>(cma_malloc(sizeof(StackNode)));
-    if (newNode == ft_nullptr)
+    StackNode* new_node = static_cast<StackNode*>(cma_malloc(sizeof(StackNode)));
+    if (new_node == ft_nullptr)
     {
-        this->setError(STACK_ALLOC_FAIL);
+        this->set_error(STACK_ALLOC_FAIL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&newNode->_data, value);
-    newNode->_next = this->_top;
-    this->_top = newNode;
+    construct_at(&new_node->_data, value);
+    new_node->_next = this->_top;
+    this->_top = new_node;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
     return ;
@@ -138,19 +138,19 @@ void ft_stack<ElementType>::push(ElementType&& value)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
-    StackNode* newNode = static_cast<StackNode*>(cma_malloc(sizeof(StackNode)));
-    if (newNode == ft_nullptr)
+    StackNode* new_node = static_cast<StackNode*>(cma_malloc(sizeof(StackNode)));
+    if (new_node == ft_nullptr)
     {
-        this->setError(STACK_ALLOC_FAIL);
+        this->set_error(STACK_ALLOC_FAIL);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
-    construct_at(&newNode->_data, std::move(value));
-    newNode->_next = this->_top;
-    this->_top = newNode;
+    construct_at(&new_node->_data, std::move(value));
+    new_node->_next = this->_top;
+    this->_top = new_node;
     ++this->_size;
     this->_mutex.unlock(THREAD_ID);
     return ;
@@ -161,12 +161,12 @@ ElementType ft_stack<ElementType>::pop()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return (ElementType());
     }
     if (this->_top == ft_nullptr)
     {
-        this->setError(STACK_EMPTY);
+        this->set_error(STACK_EMPTY);
         this->_mutex.unlock(THREAD_ID);
         return (ElementType());
     }
@@ -183,41 +183,41 @@ ElementType ft_stack<ElementType>::pop()
 template <typename ElementType>
 ElementType& ft_stack<ElementType>::top()
 {
-    static ElementType errorElement = ElementType();
+    static ElementType error_element = ElementType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
-        return (errorElement);
+        this->set_error(PT_ERR_MUTEX_OWNER);
+        return (error_element);
     }
     if (this->_top == ft_nullptr)
     {
-        this->setError(STACK_EMPTY);
+        this->set_error(STACK_EMPTY);
         this->_mutex.unlock(THREAD_ID);
-        return (errorElement);
+        return (error_element);
     }
-    ElementType& ref = this->_top->_data;
+    ElementType& value = this->_top->_data;
     this->_mutex.unlock(THREAD_ID);
-    return (ref);
+    return (value);
 }
 
 template <typename ElementType>
 const ElementType& ft_stack<ElementType>::top() const
 {
-    static ElementType errorElement = ElementType();
+    static ElementType error_element = ElementType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
-        return (errorElement);
+        this->set_error(PT_ERR_MUTEX_OWNER);
+        return (error_element);
     }
     if (this->_top == ft_nullptr)
     {
-        this->setError(STACK_EMPTY);
+        this->set_error(STACK_EMPTY);
         this->_mutex.unlock(THREAD_ID);
-        return (errorElement);
+        return (error_element);
     }
-    ElementType& ref = this->_top->_data;
+    const ElementType& value = this->_top->_data;
     this->_mutex.unlock(THREAD_ID);
-    return (ref);
+    return (value);
 }
 
 template <typename ElementType>
@@ -225,9 +225,9 @@ size_t ft_stack<ElementType>::size() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (0);
-    size_t s = this->_size;
+    size_t current_size = this->_size;
     this->_mutex.unlock(THREAD_ID);
-    return (s);
+    return (current_size);
 }
 
 template <typename ElementType>
@@ -235,29 +235,29 @@ bool ft_stack<ElementType>::empty() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
         return (true);
-    bool res = (this->_size == 0);
+    bool result = (this->_size == 0);
     this->_mutex.unlock(THREAD_ID);
-    return (res);
+    return (result);
 }
 
 template <typename ElementType>
 int ft_stack<ElementType>::get_error() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (this->_errorCode);
-    int err = this->_errorCode;
+        return (this->_error_code);
+    int error_value = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
-    return (err);
+    return (error_value);
 }
 
 template <typename ElementType>
 const char* ft_stack<ElementType>::get_error_str() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (ft_strerror(this->_errorCode));
-    int err = this->_errorCode;
+        return (ft_strerror(this->_error_code));
+    int error_value = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
-    return (ft_strerror(err));
+    return (ft_strerror(error_value));
 }
 
 template <typename ElementType>

--- a/Template/thread_pool.hpp
+++ b/Template/thread_pool.hpp
@@ -20,18 +20,18 @@ class ft_thread_pool
     private:
         std::vector<std::thread>      _workers;
         std::queue<std::function<void()> > _tasks;
-        size_t                        _maxTasks;
+        size_t                        _max_tasks;
         bool                          _stop;
         size_t                        _active;
-        mutable std::atomic<int>      _errorCode;
+        mutable std::atomic<int>      _error_code;
         std::mutex                    _mutex;
         std::condition_variable       _cond;
 
-        void setError(int error) const;
+        void set_error(int error) const;
         void worker();
 
     public:
-        ft_thread_pool(size_t threadCount = 0, size_t maxTasks = 0);
+        ft_thread_pool(size_t thread_count = 0, size_t max_tasks = 0);
         ~ft_thread_pool();
 
         ft_thread_pool(const ft_thread_pool&) = delete;
@@ -39,8 +39,8 @@ class ft_thread_pool
         ft_thread_pool(ft_thread_pool&&) = delete;
         ft_thread_pool& operator=(ft_thread_pool&&) = delete;
 
-        template <typename Func>
-        void submit(Func &&f);
+        template <typename Function>
+        void submit(Function &&function);
 
         void wait();
         void destroy();
@@ -73,28 +73,28 @@ inline void ft_thread_pool::worker()
     }
 }
 
-inline void ft_thread_pool::setError(int error) const
+inline void ft_thread_pool::set_error(int error) const
 {
-    this->_errorCode.store(error, std::memory_order_relaxed);
+    this->_error_code.store(error, std::memory_order_relaxed);
     ft_errno = error;
 }
 
-inline ft_thread_pool::ft_thread_pool(size_t threadCount, size_t maxTasks)
-    : _workers(), _tasks(), _maxTasks(maxTasks), _stop(false), _active(0), _errorCode(ER_SUCCESS)
+inline ft_thread_pool::ft_thread_pool(size_t thread_count, size_t max_tasks)
+    : _workers(), _tasks(), _max_tasks(max_tasks), _stop(false), _active(0), _error_code(ER_SUCCESS)
 {
     try
     {
-        this->_workers.reserve(threadCount);
-        size_t i = 0;
-        while (i < threadCount)
+        this->_workers.reserve(thread_count);
+        size_t worker_index = 0;
+        while (worker_index < thread_count)
         {
             this->_workers.emplace_back(&ft_thread_pool::worker, this);
-            ++i;
+            ++worker_index;
         }
     }
     catch (...)
     {
-        this->setError(THREAD_POOL_ALLOC_FAIL);
+        this->set_error(THREAD_POOL_ALLOC_FAIL);
         this->_stop = true;
     }
 }
@@ -104,18 +104,18 @@ inline ft_thread_pool::~ft_thread_pool()
     this->destroy();
 }
 
-template <typename Func>
-inline void ft_thread_pool::submit(Func &&f)
+template <typename Function>
+inline void ft_thread_pool::submit(Function &&function)
 {
     std::unique_lock<std::mutex> lock(this->_mutex);
     if (this->_stop)
         return ;
-    if (this->_maxTasks != 0 && this->_tasks.size() >= this->_maxTasks)
+    if (this->_max_tasks != 0 && this->_tasks.size() >= this->_max_tasks)
     {
-        this->setError(THREAD_POOL_FULL);
+        this->set_error(THREAD_POOL_FULL);
         return ;
     }
-    this->_tasks.emplace(std::forward<Func>(f));
+    this->_tasks.emplace(std::forward<Function>(function));
     lock.unlock();
     this->_cond.notify_one();
 }
@@ -133,24 +133,24 @@ inline void ft_thread_pool::destroy()
         this->_stop = true;
     }
     this->_cond.notify_all();
-    size_t i = 0;
-    while (i < this->_workers.size())
+    size_t worker_index = 0;
+    while (worker_index < this->_workers.size())
     {
-        if (this->_workers[i].joinable())
-            this->_workers[i].join();
-        ++i;
+        if (this->_workers[worker_index].joinable())
+            this->_workers[worker_index].join();
+        ++worker_index;
     }
     this->_workers.clear();
 }
 
 inline int ft_thread_pool::get_error() const
 {
-      return (this->_errorCode.load(std::memory_order_relaxed));
+      return (this->_error_code.load(std::memory_order_relaxed));
 }
 
 inline const char* ft_thread_pool::get_error_str() const
 {
-      return (ft_strerror(this->_errorCode.load(std::memory_order_relaxed)));
+      return (ft_strerror(this->_error_code.load(std::memory_order_relaxed)));
 }
 
 #endif // FT_THREAD_POOL_HPP

--- a/Template/tuple.hpp
+++ b/Template/tuple.hpp
@@ -23,10 +23,10 @@ class ft_tuple
     private:
         using tuple_t = std::tuple<Types...>;
         tuple_t*        _data;
-        mutable int     _errorCode;
+        mutable int     _error_code;
         mutable pt_mutex _mutex;
 
-        void setError(int error) const;
+        void set_error(int error) const;
 
     public:
         ft_tuple();
@@ -63,7 +63,7 @@ class ft_tuple
 
 template <typename... Types>
 ft_tuple<Types...>::ft_tuple()
-    : _data(ft_nullptr), _errorCode(ER_SUCCESS)
+    : _data(ft_nullptr), _error_code(ER_SUCCESS)
 {
     return ;
 }
@@ -77,10 +77,10 @@ ft_tuple<Types...>::~ft_tuple()
 
 template <typename... Types>
 ft_tuple<Types...>::ft_tuple(ft_tuple&& other) noexcept
-    : _data(other._data), _errorCode(other._errorCode)
+    : _data(other._data), _error_code(other._error_code)
 {
     other._data = ft_nullptr;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
     return ;
 }
 
@@ -98,21 +98,21 @@ ft_tuple<Types...>& ft_tuple<Types...>::operator=(ft_tuple&& other) noexcept
         }
         this->reset();
         this->_data = other._data;
-        this->_errorCode = other._errorCode;
+        this->_error_code = other._error_code;
         other._data = ft_nullptr;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
         other._mutex.unlock(THREAD_ID);
         this->_mutex.unlock(THREAD_ID);
     }
     return (*this);
 }
 
-/* setError */
+/* set_error */
 
 template <typename... Types>
-void ft_tuple<Types...>::setError(int error) const
+void ft_tuple<Types...>::set_error(int error) const
 {
-    this->_errorCode = error;
+    this->_error_code = error;
     ft_errno = error;
     return ;
 }
@@ -122,11 +122,11 @@ void ft_tuple<Types...>::setError(int error) const
 template <typename... Types>
 template <typename... Args>
 ft_tuple<Types...>::ft_tuple(Args&&... args)
-    : _data(ft_nullptr), _errorCode(ER_SUCCESS)
+    : _data(ft_nullptr), _error_code(ER_SUCCESS)
 {
     _data = static_cast<tuple_t*>(cma_malloc(sizeof(tuple_t)));
     if (_data == ft_nullptr)
-        this->setError(TUPLE_ALLOC_FAIL);
+        this->set_error(TUPLE_ALLOC_FAIL);
     else
         construct_at(_data, std::forward<Args>(args)...);
     return ;
@@ -140,18 +140,18 @@ typename std::tuple_element<I, typename ft_tuple<Types...>::tuple_t>::type&
 ft_tuple<Types...>::get()
 {
     using elem_t = typename std::tuple_element<I, tuple_t>::type;
-    static elem_t defaultInstance = elem_t();
+    static elem_t default_instance = elem_t();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
-        return (defaultInstance);
+        this->set_error(PT_ERR_MUTEX_OWNER);
+        return (default_instance);
     }
     if (this->_data == ft_nullptr)
     {
-        this->setError(TUPLE_BAD_ACCESS);
+        this->set_error(TUPLE_BAD_ACCESS);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<elem_t>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(elem_t)] = {0};
@@ -169,18 +169,18 @@ const typename std::tuple_element<I, typename ft_tuple<Types...>::tuple_t>::type
 ft_tuple<Types...>::get() const
 {
     using elem_t = typename std::tuple_element<I, tuple_t>::type;
-    static elem_t defaultInstance = elem_t();
+    static elem_t default_instance = elem_t();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        const_cast<ft_tuple*>(this)->setError(PT_ERR_MUTEX_OWNER);
-        return (defaultInstance);
+        const_cast<ft_tuple*>(this)->set_error(PT_ERR_MUTEX_OWNER);
+        return (default_instance);
     }
     if (this->_data == ft_nullptr)
     {
-        const_cast<ft_tuple*>(this)->setError(TUPLE_BAD_ACCESS);
+        const_cast<ft_tuple*>(this)->set_error(TUPLE_BAD_ACCESS);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<elem_t>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(elem_t)] = {0};
@@ -198,18 +198,18 @@ template <typename... Types>
 template <typename T>
 T& ft_tuple<Types...>::get()
 {
-    static T defaultInstance = T();
+    static T default_instance = T();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
-        return (defaultInstance);
+        this->set_error(PT_ERR_MUTEX_OWNER);
+        return (default_instance);
     }
     if (this->_data == ft_nullptr)
     {
-        this->setError(TUPLE_BAD_ACCESS);
+        this->set_error(TUPLE_BAD_ACCESS);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<T>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(T)] = {0};
@@ -225,18 +225,18 @@ template <typename... Types>
 template <typename T>
 const T& ft_tuple<Types...>::get() const
 {
-    static T defaultInstance = T();
+    static T default_instance = T();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        const_cast<ft_tuple*>(this)->setError(PT_ERR_MUTEX_OWNER);
-        return (defaultInstance);
+        const_cast<ft_tuple*>(this)->set_error(PT_ERR_MUTEX_OWNER);
+        return (default_instance);
     }
     if (this->_data == ft_nullptr)
     {
-        const_cast<ft_tuple*>(this)->setError(TUPLE_BAD_ACCESS);
+        const_cast<ft_tuple*>(this)->set_error(TUPLE_BAD_ACCESS);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<T>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(T)] = {0};
@@ -255,7 +255,7 @@ void ft_tuple<Types...>::reset()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        this->setError(PT_ERR_MUTEX_OWNER);
+        this->set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     if (this->_data != ft_nullptr)
@@ -274,8 +274,8 @@ template <typename... Types>
 int ft_tuple<Types...>::get_error() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (this->_errorCode);
-    int err = this->_errorCode;
+        return (this->_error_code);
+    int err = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
     return (err);
 }
@@ -284,8 +284,8 @@ template <typename... Types>
 const char* ft_tuple<Types...>::get_error_str() const
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
-        return (ft_strerror(this->_errorCode));
-    int err = this->_errorCode;
+        return (ft_strerror(this->_error_code));
+    int err = this->_error_code;
     this->_mutex.unlock(THREAD_ID);
     return (ft_strerror(err));
 }

--- a/Template/unique_ptr.hpp
+++ b/Template/unique_ptr.hpp
@@ -19,7 +19,7 @@ class ft_uniqueptr
         ManagedType* _managedPointer;
         size_t _arraySize;
         bool _isArrayType;
-        mutable int _errorCode;
+        mutable int _error_code;
         mutable pt_mutex _mutex;
 
         void destroy();
@@ -66,7 +66,7 @@ ft_uniqueptr<ManagedType>::ft_uniqueptr(Args&&... args)
     : _managedPointer(new (std::nothrow) ManagedType(std::forward<Args>(args)...)),
       _arraySize(1),
       _isArrayType(false),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     if (!_managedPointer)
         this->set_error(UNIQUE_PTR_ALLOCATION_FAILED);
@@ -79,7 +79,7 @@ ft_uniqueptr<ManagedType>::ft_uniqueptr(ManagedType* pointer, bool isArray,
     : _managedPointer(pointer),
       _arraySize(arraySize),
       _isArrayType(isArray),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     return ;
 }
@@ -89,7 +89,7 @@ ft_uniqueptr<ManagedType>::ft_uniqueptr()
     : _managedPointer(ft_nullptr),
       _arraySize(0),
       _isArrayType(false),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     return ;
 }
@@ -99,7 +99,7 @@ ft_uniqueptr<ManagedType>::ft_uniqueptr(size_t size)
     : _managedPointer(new (std::nothrow) ManagedType[size]),
       _arraySize(size),
       _isArrayType(true),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     if (size > 0 && !_managedPointer)
         this->set_error(UNIQUE_PTR_ALLOCATION_FAILED);
@@ -111,18 +111,18 @@ ft_uniqueptr<ManagedType>::ft_uniqueptr(ft_uniqueptr&& other) noexcept
     : _managedPointer(ft_nullptr),
       _arraySize(0),
       _isArrayType(false),
-      _errorCode(ER_SUCCESS)
+      _error_code(ER_SUCCESS)
 {
     if (other._mutex.lock(THREAD_ID) != SUCCES)
         return ;
     _managedPointer = other._managedPointer;
     _arraySize = other._arraySize;
     _isArrayType = other._isArrayType;
-    _errorCode = other._errorCode;
+    _error_code = other._error_code;
     other._managedPointer = ft_nullptr;
     other._arraySize = 0;
     other._isArrayType = false;
-    other._errorCode = ER_SUCCESS;
+    other._error_code = ER_SUCCESS;
     other._mutex.unlock(THREAD_ID);
     return ;
 }
@@ -139,11 +139,11 @@ ft_uniqueptr<ManagedType>& ft_uniqueptr<ManagedType>::operator=(ft_uniqueptr&& o
         _managedPointer = other._managedPointer;
         _arraySize = other._arraySize;
         _isArrayType = other._isArrayType;
-        _errorCode = other._errorCode;
+        _error_code = other._error_code;
         other._managedPointer = ft_nullptr;
         other._arraySize = 0;
         other._isArrayType = false;
-        other._errorCode = ER_SUCCESS;
+        other._error_code = ER_SUCCESS;
         other._mutex.unlock(THREAD_ID);
     }
     return (*this);
@@ -178,18 +178,18 @@ void ft_uniqueptr<ManagedType>::destroy()
 template <typename ManagedType>
 ManagedType& ft_uniqueptr<ManagedType>::operator*()
 {
-    static ManagedType defaultInstance = ManagedType();
+    static ManagedType default_instance = ManagedType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
         set_error(PT_ERR_MUTEX_OWNER);
-        return (defaultInstance);
+        return (default_instance);
     }
     if (!_managedPointer)
     {
         this->set_error(UNIQUE_PTR_NULL_PTR);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<ManagedType>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(ManagedType)] = {0};
@@ -204,18 +204,18 @@ ManagedType& ft_uniqueptr<ManagedType>::operator*()
 template <typename ManagedType>
 const ManagedType& ft_uniqueptr<ManagedType>::operator*() const
 {
-    static ManagedType defaultInstance = ManagedType();
+    static ManagedType default_instance = ManagedType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
         const_cast<ft_uniqueptr<ManagedType>*>(this)->set_error(PT_ERR_MUTEX_OWNER);
-        return (defaultInstance);
+        return (default_instance);
     }
     if (!_managedPointer)
     {
         const_cast<ft_uniqueptr<ManagedType>*>(this)->set_error(UNIQUE_PTR_NULL_PTR);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<ManagedType>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(ManagedType)] = {0};
@@ -268,18 +268,18 @@ const ManagedType* ft_uniqueptr<ManagedType>::operator->() const
 template <typename ManagedType>
 ManagedType& ft_uniqueptr<ManagedType>::operator[](size_t index)
 {
-    static ManagedType defaultInstance = ManagedType();
+    static ManagedType default_instance = ManagedType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
         set_error(PT_ERR_MUTEX_OWNER);
-        return (defaultInstance);
+        return (default_instance);
     }
     if (!_isArrayType)
     {
         this->set_error(UNIQUE_PTR_INVALID_OPERATION);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<ManagedType>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(ManagedType)] = {0};
@@ -291,7 +291,7 @@ ManagedType& ft_uniqueptr<ManagedType>::operator[](size_t index)
         this->set_error(UNIQUE_PTR_NULL_PTR);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<ManagedType>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(ManagedType)] = {0};
@@ -303,7 +303,7 @@ ManagedType& ft_uniqueptr<ManagedType>::operator[](size_t index)
         this->set_error(UNIQUE_PTR_OUT_OF_BOUNDS);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<ManagedType>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(ManagedType)] = {0};
@@ -318,11 +318,11 @@ ManagedType& ft_uniqueptr<ManagedType>::operator[](size_t index)
 template <typename ManagedType>
 const ManagedType& ft_uniqueptr<ManagedType>::operator[](size_t index) const
 {
-    static ManagedType defaultInstance = ManagedType();
+    static ManagedType default_instance = ManagedType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
         const_cast<ft_uniqueptr<ManagedType>*>(this)->set_error(PT_ERR_MUTEX_OWNER);
-        return (defaultInstance);
+        return (default_instance);
     }
     if (!_isArrayType)
     {
@@ -330,7 +330,7 @@ const ManagedType& ft_uniqueptr<ManagedType>::operator[](size_t index) const
             (UNIQUE_PTR_INVALID_OPERATION);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<ManagedType>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(ManagedType)] = {0};
@@ -342,7 +342,7 @@ const ManagedType& ft_uniqueptr<ManagedType>::operator[](size_t index) const
         const_cast<ft_uniqueptr<ManagedType>*>(this)->set_error(UNIQUE_PTR_NULL_PTR);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<ManagedType>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(ManagedType)] = {0};
@@ -355,7 +355,7 @@ const ManagedType& ft_uniqueptr<ManagedType>::operator[](size_t index) const
             (UNIQUE_PTR_OUT_OF_BOUNDS);
         this->_mutex.unlock(THREAD_ID);
         if constexpr (!std::is_abstract_v<ManagedType>)
-            return (defaultInstance);
+            return (default_instance);
         else
         {
             static char dummy_buffer[sizeof(ManagedType)] = {0};
@@ -405,7 +405,7 @@ ManagedType* ft_uniqueptr<ManagedType>::release()
     _managedPointer = ft_nullptr;
     _arraySize = 0;
     _isArrayType = false;
-    _errorCode = ER_SUCCESS;
+    _error_code = ER_SUCCESS;
     this->_mutex.unlock(THREAD_ID);
     return (tmp);
 }
@@ -428,26 +428,26 @@ void ft_uniqueptr<ManagedType>::reset(ManagedType* pointer, size_t size, bool ar
     _managedPointer = pointer;
     _arraySize = size;
     _isArrayType = arrayType;
-    _errorCode = ER_SUCCESS;
+    _error_code = ER_SUCCESS;
     this->_mutex.unlock(THREAD_ID);
 }
 
 template <typename ManagedType>
 bool ft_uniqueptr<ManagedType>::hasError() const
 {
-    return (_errorCode != ER_SUCCESS);
+    return (_error_code != ER_SUCCESS);
 }
 
 template <typename ManagedType>
 int ft_uniqueptr<ManagedType>::get_error() const
 {
-    return (_errorCode);
+    return (_error_code);
 }
 
 template <typename ManagedType>
 const char* ft_uniqueptr<ManagedType>::get_error_str() const
 {
-    return (ft_strerror(_errorCode));
+    return (ft_strerror(_error_code));
 }
 
 template <typename ManagedType>
@@ -469,7 +469,7 @@ void ft_uniqueptr<ManagedType>::swap(ft_uniqueptr& other)
     ft_swap(_managedPointer, other._managedPointer);
     ft_swap(_arraySize, other._arraySize);
     ft_swap(_isArrayType, other._isArrayType);
-    ft_swap(_errorCode, other._errorCode);
+    ft_swap(_error_code, other._error_code);
     other._mutex.unlock(THREAD_ID);
     this->_mutex.unlock(THREAD_ID);
 }
@@ -478,7 +478,7 @@ template <typename ManagedType>
 void ft_uniqueptr<ManagedType>::set_error(int error) const
 {
     ft_errno = error;
-    _errorCode = error;
+    _error_code = error;
 }
 
 #endif

--- a/Template/unordened_map.hpp
+++ b/Template/unordened_map.hpp
@@ -32,7 +32,7 @@ private:
 
     void    resize(size_t newCapacity);
     size_t  findIndex(const Key& key) const;
-    void    setError(int error) const;
+    void    set_error(int error) const;
     size_t  hashKey(const Key& key) const;
     void    insert_internal(const Key& key, const MappedType& value);
 
@@ -212,7 +212,7 @@ ft_unord_map<Key, MappedType>::ft_unord_map(size_t initialCapacity)
     void* rawData = cma_malloc(sizeof(ft_pair<Key, MappedType>) * _capacity);
     if (!rawData)
     {
-        setError(UNORD_MAP_MEMORY);
+        set_error(UNORD_MAP_MEMORY);
         _data = ft_nullptr;
         _occupied = ft_nullptr;
         return ;
@@ -221,7 +221,7 @@ ft_unord_map<Key, MappedType>::ft_unord_map(size_t initialCapacity)
     void* rawOccupied = cma_malloc(sizeof(bool) * _capacity);
     if (!rawOccupied)
     {
-        setError(UNORD_MAP_MEMORY);
+        set_error(UNORD_MAP_MEMORY);
         cma_free(_data);
         _data = ft_nullptr;
         _occupied = ft_nullptr;
@@ -245,7 +245,7 @@ ft_unord_map<Key, MappedType>::ft_unord_map(const ft_unord_map<Key, MappedType>&
         void* rawData = cma_malloc(sizeof(ft_pair<Key, MappedType>) * _capacity);
         if (!rawData)
         {
-            setError(UNORD_MAP_MEMORY);
+            set_error(UNORD_MAP_MEMORY);
             _data = ft_nullptr;
             _occupied = ft_nullptr;
             _size = 0;
@@ -256,7 +256,7 @@ ft_unord_map<Key, MappedType>::ft_unord_map(const ft_unord_map<Key, MappedType>&
         void* rawOccupied = cma_malloc(sizeof(bool) * _capacity);
         if (!rawOccupied)
         {
-            setError(UNORD_MAP_MEMORY);
+            set_error(UNORD_MAP_MEMORY);
             cma_free(_data);
             _data = ft_nullptr;
             _occupied = ft_nullptr;
@@ -320,7 +320,7 @@ ft_unord_map<Key, MappedType>& ft_unord_map<Key, MappedType>::operator=(const ft
             void* rawData = cma_malloc(sizeof(ft_pair<Key, MappedType>) * other._capacity);
             if (!rawData)
             {
-                setError(UNORD_MAP_MEMORY);
+                set_error(UNORD_MAP_MEMORY);
                 _data = ft_nullptr;
                 _occupied = ft_nullptr;
                 _size = 0;
@@ -331,7 +331,7 @@ ft_unord_map<Key, MappedType>& ft_unord_map<Key, MappedType>::operator=(const ft
             void* rawOccupied = cma_malloc(sizeof(bool) * other._capacity);
             if (!rawOccupied)
             {
-                setError(UNORD_MAP_MEMORY);
+                set_error(UNORD_MAP_MEMORY);
                 cma_free(_data);
                 _data = ft_nullptr;
                 _occupied = ft_nullptr;
@@ -445,7 +445,7 @@ ft_unord_map<Key, MappedType>::~ft_unord_map()
 }
 
 template<typename Key, typename MappedType>
-void ft_unord_map<Key, MappedType>::setError(int error) const
+void ft_unord_map<Key, MappedType>::set_error(int error) const
 {
     ft_errno = error;
     _error = error;
@@ -485,14 +485,14 @@ void ft_unord_map<Key, MappedType>::resize(size_t newCapacity)
     void* rawData = cma_malloc(sizeof(ft_pair<Key, MappedType>) * newCapacity);
     if (!rawData)
     {
-        setError(UNORD_MAP_MEMORY);
+        set_error(UNORD_MAP_MEMORY);
         return ;
     }
     ft_pair<Key, MappedType>* newData = static_cast<ft_pair<Key, MappedType>*>(rawData);
     void* rawOccupied = cma_malloc(sizeof(bool) * newCapacity);
     if (!rawOccupied)
     {
-        setError(UNORD_MAP_MEMORY);
+        set_error(UNORD_MAP_MEMORY);
         cma_free(newData);
         return ;
     }
@@ -566,7 +566,7 @@ void ft_unord_map<Key, MappedType>::insert(const Key& key, const MappedType& val
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     _error = ER_SUCCESS;
@@ -580,7 +580,7 @@ typename ft_unord_map<Key, MappedType>::iterator ft_unord_map<Key, MappedType>::
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return (iterator(_data, _occupied, _capacity, _capacity));
     }
     size_t idx = findIndex(key);
@@ -600,7 +600,7 @@ typename ft_unord_map<Key, MappedType>::const_iterator ft_unord_map<Key, MappedT
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return (const_iterator(_data, _occupied, _capacity, _capacity));
     }
     size_t idx = findIndex(key);
@@ -620,7 +620,7 @@ void ft_unord_map<Key, MappedType>::remove(const Key& key)
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     size_t idx = findIndex(key);
@@ -665,7 +665,7 @@ void ft_unord_map<Key, MappedType>::clear()
 {
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return ;
     }
     size_t i = 0;
@@ -771,13 +771,13 @@ MappedType& ft_unord_map<Key, MappedType>::at(const Key& key)
     static MappedType errorMappedType = MappedType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return (errorMappedType);
     }
     size_t idx = findIndex(key);
     if (idx == _capacity)
     {
-        setError(UNORD_MAP_UNKNOWN);
+        set_error(UNORD_MAP_UNKNOWN);
         this->_mutex.unlock(THREAD_ID);
         return (errorMappedType);
     }
@@ -792,13 +792,13 @@ const MappedType& ft_unord_map<Key, MappedType>::at(const Key& key) const
     static MappedType errorMappedType = MappedType();
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return (errorMappedType);
     }
     size_t idx = findIndex(key);
     if (idx == _capacity)
     {
-        setError(UNORD_MAP_UNKNOWN);
+        set_error(UNORD_MAP_UNKNOWN);
         this->_mutex.unlock(THREAD_ID);
         return (errorMappedType);
     }
@@ -813,7 +813,7 @@ MappedType& ft_unord_map<Key, MappedType>::operator[](const Key& key)
     if (this->_mutex.lock(THREAD_ID) != SUCCES)
     {
         static MappedType errorVal = MappedType();
-        setError(PT_ERR_MUTEX_OWNER);
+        set_error(PT_ERR_MUTEX_OWNER);
         return (errorVal);
     }
     _error = ER_SUCCESS;
@@ -852,7 +852,7 @@ MappedType& ft_unord_map<Key, MappedType>::operator[](const Key& key)
             break;
     }
     static MappedType errorVal = MappedType();
-    setError(UNORD_MAP_UNKNOWN);
+    set_error(UNORD_MAP_UNKNOWN);
     this->_mutex.unlock(THREAD_ID);
     return (errorVal);
 }


### PR DESCRIPTION
## Summary
- rename event emitter parameters and helpers to descriptive snake_case
- replace stack temporaries with clearer names and update error handling
- refactor map interface to snake_case and adjust game modules to use `size()`

## Testing
- `make -C CPP_class`
- `make -C RNG`


------
https://chatgpt.com/codex/tasks/task_e_68bda6e3389083319d2be97099f5a1f8