### PR TITLE
Hide global logger pointer from public API

### DIFF
--- a/Logger/ft_log_get_alloc_logging.cpp
+++ b/Logger/ft_log_get_alloc_logging.cpp
@@ -1,4 +1,4 @@
-#include "logger.hpp"
+#include "logger_internal.hpp"
 
 bool ft_log_get_alloc_logging()
 {

--- a/Logger/ft_log_get_api_logging.cpp
+++ b/Logger/ft_log_get_api_logging.cpp
@@ -1,4 +1,4 @@
-#include "logger.hpp"
+#include "logger_internal.hpp"
 
 bool ft_log_get_api_logging()
 {

--- a/Logger/ft_log_set_alloc_logging.cpp
+++ b/Logger/ft_log_set_alloc_logging.cpp
@@ -1,4 +1,4 @@
-#include "logger.hpp"
+#include "logger_internal.hpp"
 
 void ft_log_set_alloc_logging(bool enable)
 {

--- a/Logger/ft_log_set_api_logging.cpp
+++ b/Logger/ft_log_set_api_logging.cpp
@@ -1,4 +1,4 @@
-#include "logger.hpp"
+#include "logger_internal.hpp"
 
 void ft_log_set_api_logging(bool enable)
 {

--- a/Logger/logger.hpp
+++ b/Logger/logger.hpp
@@ -53,6 +53,4 @@ class ft_logger
         bool _api_logging;
 };
 
-extern ft_logger *g_logger;
-
 #endif

--- a/Logger/logger_internal.hpp
+++ b/Logger/logger_internal.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include "logger.hpp"
 
+extern ft_logger *g_logger;
 extern t_log_level g_level;
 extern int g_fd;
 extern std::string g_path;

--- a/README.md
+++ b/README.md
@@ -365,9 +365,9 @@ closes the log when the object is destroyed:
 }
 ```
 
-A global pointer `g_logger` is provided for optional shared access. Call
-`set_global()` on an `ft_logger` instance to populate it; the pointer is reset
-to `ft_nullptr` when that instance is destroyed. Allocation logging for the
+Calling `set_global()` on an `ft_logger` instance makes it the library-wide
+logger used internally by logging helpers. The pointer is reset to
+`ft_nullptr` when that instance is destroyed. Allocation logging for the
 custom memory allocator can be toggled with `set_alloc_logging` and
 `get_alloc_logging`.
 


### PR DESCRIPTION
## Summary
- move `g_logger` declaration to `logger_internal.hpp` so it's not exposed in public headers
- switch logger helper implementations to include the internal header
- document new global logger behavior in README

## Testing
- `make -C Logger`


------
https://chatgpt.com/codex/tasks/task_e_68bdf77908f88331b89135ef65909f43