### PR TITLE
Extract logger-backed assert into System_utils module and add thread-safe env helpers

### DIFF
--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -37,6 +37,7 @@
 #include "Logger/logger.hpp"
 #include "ReadLine/readline.hpp"
 #include "ReadLine/readline_internal.hpp"
+#include "System_utils/system_utils.hpp"
 #include "Template/constructor.hpp"
 #include "Template/iterator.hpp"
 #include "Template/algorithm.hpp"

--- a/Makefile
+++ b/Makefile
@@ -38,15 +38,15 @@ SUBDIRS :=  CMA \
             Libft \
             Math \
             Logger \
-	    Printf \
-	    ReadLine \
-	    PThread \
-	    CPP_class \
-	    Errno \
-	    Config \
-	    Networking \
-	    API
-
+            System_utils \
+            Printf \
+            ReadLine \
+            PThread \
+            CPP_class \
+            Errno \
+            Config \
+            Networking \
+            API
 ifeq ($(OS),Windows_NT)
 SUBDIRS += Windows
 else
@@ -61,6 +61,7 @@ LIB_BASES := \
   Libft/LibFT \
   Math/Math \
   Logger/Logger \
+  System_utils/System_utils \
   Printf/Printf \
   ReadLine/ReadLine \
   PThread/PThread \

--- a/README.md
+++ b/README.md
@@ -389,6 +389,19 @@ logger used internally by logging helpers. The pointer is reset to
 custom memory allocator can be toggled with `set_alloc_logging` and
 `get_alloc_logging`.
 
+### System Utils
+
+`System_utils/system_utils.hpp` provides a simple assertion helper that logs failures using the
+global logger before terminating the process. The header also offers thread-safe wrappers around
+common environment helpers. Each call locks a global mutex before touching the process environment.
+
+```
+void    su_assert(bool condition, const char *message);
+char    *su_getenv_thread_safe(const char *name);
+int     su_setenv_thread_safe(const char *name, const char *value, int overwrite);
+int     su_putenv_thread_safe(char *string);
+```
+
 ### Template Utilities
 
 `Template/` contains a wide range of generic helpers and containers. Key
@@ -436,6 +449,7 @@ const char *get_error_str() const;
 ```
 
 ### Additional Modules
+
 
 #### Errno
 `Errno/errno.hpp` defines error codes and helpers for retrieving messages.

--- a/System_utils/Makefile
+++ b/System_utils/Makefile
@@ -1,0 +1,71 @@
+TARGET := System_utils.a
+DEBUG_TARGET := System_utils_debug.a
+
+SRCS := System_utils_assert.cpp \
+        System_utils_env.cpp
+
+HEADERS := system_utils.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
+clean:
+	-$(RM) $(CLEAN_FILES)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/System_utils/System_utils_assert.cpp
+++ b/System_utils/System_utils_assert.cpp
@@ -1,0 +1,13 @@
+#include "../Logger/logger_internal.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "system_utils.hpp"
+#include <cstdlib>
+
+void su_assert(bool condition, const char *message)
+{
+    if (condition)
+        return ;
+    if (g_logger != ft_nullptr)
+        g_logger->error("Assertion failed: %s", message);
+    abort();
+}

--- a/System_utils/System_utils_env.cpp
+++ b/System_utils/System_utils_env.cpp
@@ -1,0 +1,50 @@
+#include "system_utils.hpp"
+#include "../Libft/libft.hpp"
+#include "../PThread/mutex.hpp"
+#include "../PThread/pthread.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include <cstdlib>
+
+static pt_mutex g_env_mutex;
+
+char    *su_getenv_thread_safe(const char *name)
+{
+    char    *result;
+
+    if (g_env_mutex.lock(THREAD_ID) != SUCCES)
+        return (ft_nullptr);
+    result = ft_getenv(name);
+    if (g_env_mutex.unlock(THREAD_ID) != SUCCES)
+        return (ft_nullptr);
+    return (result);
+}
+
+int su_setenv_thread_safe(const char *name, const char *value, int overwrite)
+{
+    int result;
+
+    if (g_env_mutex.lock(THREAD_ID) != SUCCES)
+        return (-1);
+    result = ft_setenv(name, value, overwrite);
+    if (g_env_mutex.unlock(THREAD_ID) != SUCCES)
+        return (-1);
+    return (result);
+}
+
+int su_putenv_thread_safe(char *string)
+{
+    int result;
+
+    if (string == ft_nullptr)
+        return (-1);
+    if (g_env_mutex.lock(THREAD_ID) != SUCCES)
+        return (-1);
+#if defined(_WIN32) || defined(_WIN64)
+    result = _putenv(string);
+#else
+    result = putenv(string);
+#endif
+    if (g_env_mutex.unlock(THREAD_ID) != SUCCES)
+        return (-1);
+    return (result);
+}

--- a/System_utils/system_utils.hpp
+++ b/System_utils/system_utils.hpp
@@ -1,0 +1,9 @@
+#ifndef SYSTEM_UTILS_HPP
+# define SYSTEM_UTILS_HPP
+
+char    *su_getenv_thread_safe(const char *name);
+int     su_setenv_thread_safe(const char *name, const char *value, int overwrite);
+int     su_putenv_thread_safe(char *string);
+void    su_assert(bool condition, const char *message);
+
+#endif

--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,6 @@
     - AABB, circle, sphere, OBB shapes
     - Collision detection and intersection math
 
-- Unit Testing / Assert Module
-    - ft_assert integrated with logger
+- Unit Testing / System Utils Module
     - Simple test runner framework
     - Auto-log failures with file and line


### PR DESCRIPTION
## Summary
- move assertion helper out of Logger and into new System_utils module
- consolidate assert and thread-safe environment helpers into `System_utils/system_utils.hpp`
- register System_utils in the build scripts and umbrella header
- provide thread-safe getenv, setenv and putenv backed by pt_mutex
- document System Utils and its logger-backed assert plus env helpers in the README
- prefix System Utils APIs with `su_` for clearer namespacing

## Testing
- `cd System_utils && make`
- `make` *(fails: ../Printf/internal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0679e92cc83319b9741c9b7f9b041