### PR TITLE
Add configurable allocation limit to CMA

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -31,6 +31,7 @@ char    *cma_strtrim(const char *string, const char *set)
             __attribute__ ((warn_unused_result));
 void    cma_free_double(char **content);
 void    cma_cleanup();
+void    cma_set_alloc_limit(std::size_t limit);
 
 template <int total_argument_count, typename... argument_types>
 char    *cma_strjoin_multiple_checked(const argument_types &... strings)

--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -19,7 +19,8 @@ SRCS := cma_calloc.cpp \
         cma_free_double.cpp \
         cma_utils.cpp \
         cma_cleanup.cpp \
-        cma_global_overloads.cpp
+        cma_global_overloads.cpp \
+        cma_set_alloc_limit.cpp
 
 HEADERS := CMA.hpp \
            cma_internal.hpp

--- a/CMA/cma_internal.hpp
+++ b/CMA/cma_internal.hpp
@@ -33,6 +33,7 @@
 #endif
 
 extern pt_mutex g_malloc_mutex;
+extern std::size_t    g_cma_alloc_limit;
 
 struct Block
 {

--- a/CMA/cma_malloc.cpp
+++ b/CMA/cma_malloc.cpp
@@ -22,6 +22,8 @@ void* cma_malloc(std::size_t size)
     }
     if (size <= 0)
         return (ft_nullptr);
+    if (g_cma_alloc_limit != 0 && size > g_cma_alloc_limit)
+        return (ft_nullptr);
     g_malloc_mutex.lock(THREAD_ID);
     size_t aligned_size = align16(size);
     Block *block = find_free_block(aligned_size);

--- a/CMA/cma_realloc.cpp
+++ b/CMA/cma_realloc.cpp
@@ -35,9 +35,9 @@ static int reallocate_block(void *ptr, size_t new_size)
 void *cma_realloc(void* ptr, size_t new_size)
 {
     if (OFFSWITCH == 1)
-    {
         return (std::realloc(ptr, new_size));
-    }
+    if (g_cma_alloc_limit != 0 && new_size > g_cma_alloc_limit)
+        return (ft_nullptr);
     g_malloc_mutex.lock(THREAD_ID);
     if (!ptr)
         return (cma_malloc(new_size));

--- a/CMA/cma_set_alloc_limit.cpp
+++ b/CMA/cma_set_alloc_limit.cpp
@@ -1,0 +1,9 @@
+#include <cstddef>
+#include "CMA.hpp"
+#include "cma_internal.hpp"
+
+void    cma_set_alloc_limit(std::size_t limit)
+{
+    g_cma_alloc_limit = limit;
+    return ;
+}

--- a/CMA/cma_utils.cpp
+++ b/CMA/cma_utils.cpp
@@ -11,6 +11,7 @@
 
 Page *page_list = ft_nullptr;
 pt_mutex g_malloc_mutex;
+std::size_t    g_cma_alloc_limit = 0;
 
 static size_t determine_page_size(size_t size)
 {

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ and string helpers. Aligned allocations round the block size up to the
 specified power-of-two (e.g., requesting 100 bytes with alignment 32
 returns a 128-byte block) and are released with `cma_free`.
 When allocation logging is enabled via the logger, the allocator emits debug messages for each `cma_malloc` and `cma_free`.
+The allocator enforces an optional global allocation limit that can be
+changed at runtime with `cma_set_alloc_limit`. A limit of `0` disables the
+check. Internally, `cma_realloc` has been simplified by removing redundant braces.
 
 ```
 void   *cma_malloc(std::size_t size);
@@ -152,6 +155,7 @@ char   *cma_substr(const char *s, unsigned int start, size_t len);
 char   *cma_strtrim(const char *s1, const char *set);
 void    cma_free_double(char **content);
 void    cma_cleanup();
+void    cma_set_alloc_limit(std::size_t limit);
 ```
 
 ### GetNextLine


### PR DESCRIPTION
## Summary
- allow programs to set a global maximum allocation size through `cma_set_alloc_limit`
- track the limit internally and enforce it in `cma_malloc` and `cma_realloc`
- document the new allocation limit feature
- remove unnecessary braces around OFFSWITCH check in `cma_realloc`

## Testing
- `make -C CMA`


------
https://chatgpt.com/codex/tasks/task_e_68c08d5ab32c833183e27f2266cc3a5f