### PR TITLE
Add signal wrappers to System_utils

### DIFF
--- a/CMA/cma_free.cpp
+++ b/CMA/cma_free.cpp
@@ -2,13 +2,13 @@
 #include <cstring>
 #include <cstdio>
 #include <cassert>
-#include <csignal>
 #include <pthread.h>
 #include "CMA.hpp"
 #include "cma_internal.hpp"
 #include "../PThread/mutex.hpp"
 #include "../Printf/printf.hpp"
 #include "../Logger/logger.hpp"
+#include "../System_utils/system_utils.hpp"
 
 void cma_free(void* ptr)
 {
@@ -28,7 +28,7 @@ void cma_free(void* ptr)
     {
         pf_printf_fd(2, "Invalid block detected in cma_free. \n");
         print_block_info(block);
-        raise(SIGABRT);
+        su_sigabrt();
     }
     block->free = true;
     block = merge_block(block);

--- a/README.md
+++ b/README.md
@@ -396,14 +396,22 @@ custom memory allocator can be toggled with `set_alloc_logging` and
 ### System Utils
 
 `System_utils/system_utils.hpp` provides a simple assertion helper that logs failures using the
-global logger before terminating the process. The header also offers thread-safe wrappers around
-common environment helpers. Each call locks a global mutex before touching the process environment.
+global logger before terminating the process. The header also offers direct helpers to abort or
+raise common signals and wrappers around environment helpers. Each call locks a global mutex before
+touching the process environment.
 
 ```
+void    su_abort(void);
+void    su_sigabrt(void);
+void    su_sigfpe(void);
+void    su_sigill(void);
+void    su_sigint(void);
+void    su_sigsegv(void);
+void    su_sigterm(void);
 void    su_assert(bool condition, const char *message);
-char    *su_getenv_thread_safe(const char *name);
-int     su_setenv_thread_safe(const char *name, const char *value, int overwrite);
-int     su_putenv_thread_safe(char *string);
+char    *su_getenv(const char *name);
+int     su_setenv(const char *name, const char *value, int overwrite);
+int     su_putenv(char *string);
 ```
 
 ### Template Utilities

--- a/System_utils/Makefile
+++ b/System_utils/Makefile
@@ -2,7 +2,14 @@ TARGET := System_utils.a
 DEBUG_TARGET := System_utils_debug.a
 
 SRCS := System_utils_assert.cpp \
-        System_utils_env.cpp
+        System_utils_env.cpp \
+        System_utils_abort.cpp \
+        System_utils_sigabrt.cpp \
+        System_utils_sigfpe.cpp \
+        System_utils_sigill.cpp \
+        System_utils_sigint.cpp \
+        System_utils_sigsegv.cpp \
+        System_utils_sigterm.cpp
 
 HEADERS := system_utils.hpp
 

--- a/System_utils/System_utils_abort.cpp
+++ b/System_utils/System_utils_abort.cpp
@@ -1,0 +1,8 @@
+#include "system_utils.hpp"
+#include <cstdlib>
+
+void    su_abort(void)
+{
+    std::abort();
+    return ;
+}

--- a/System_utils/System_utils_assert.cpp
+++ b/System_utils/System_utils_assert.cpp
@@ -1,7 +1,6 @@
 #include "../Logger/logger_internal.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "system_utils.hpp"
-#include <cstdlib>
 
 void su_assert(bool condition, const char *message)
 {
@@ -9,5 +8,5 @@ void su_assert(bool condition, const char *message)
         return ;
     if (g_logger != ft_nullptr)
         g_logger->error("Assertion failed: %s", message);
-    abort();
+    su_abort();
 }

--- a/System_utils/System_utils_env.cpp
+++ b/System_utils/System_utils_env.cpp
@@ -7,7 +7,7 @@
 
 static pt_mutex g_env_mutex;
 
-char    *su_getenv_thread_safe(const char *name)
+char    *su_getenv(const char *name)
 {
     char    *result;
 
@@ -19,7 +19,7 @@ char    *su_getenv_thread_safe(const char *name)
     return (result);
 }
 
-int su_setenv_thread_safe(const char *name, const char *value, int overwrite)
+int su_setenv(const char *name, const char *value, int overwrite)
 {
     int result;
 
@@ -31,7 +31,7 @@ int su_setenv_thread_safe(const char *name, const char *value, int overwrite)
     return (result);
 }
 
-int su_putenv_thread_safe(char *string)
+int su_putenv(char *string)
 {
     int result;
 

--- a/System_utils/System_utils_sigabrt.cpp
+++ b/System_utils/System_utils_sigabrt.cpp
@@ -1,0 +1,8 @@
+#include "system_utils.hpp"
+#include <csignal>
+
+void    su_sigabrt(void)
+{
+    std::raise(SIGABRT);
+    return ;
+}

--- a/System_utils/System_utils_sigfpe.cpp
+++ b/System_utils/System_utils_sigfpe.cpp
@@ -1,0 +1,8 @@
+#include "system_utils.hpp"
+#include <csignal>
+
+void    su_sigfpe(void)
+{
+    std::raise(SIGFPE);
+    return ;
+}

--- a/System_utils/System_utils_sigill.cpp
+++ b/System_utils/System_utils_sigill.cpp
@@ -1,0 +1,8 @@
+#include "system_utils.hpp"
+#include <csignal>
+
+void    su_sigill(void)
+{
+    std::raise(SIGILL);
+    return ;
+}

--- a/System_utils/System_utils_sigint.cpp
+++ b/System_utils/System_utils_sigint.cpp
@@ -1,0 +1,8 @@
+#include "system_utils.hpp"
+#include <csignal>
+
+void    su_sigint(void)
+{
+    std::raise(SIGINT);
+    return ;
+}

--- a/System_utils/System_utils_sigsegv.cpp
+++ b/System_utils/System_utils_sigsegv.cpp
@@ -1,0 +1,8 @@
+#include "system_utils.hpp"
+#include <csignal>
+
+void    su_sigsegv(void)
+{
+    std::raise(SIGSEGV);
+    return ;
+}

--- a/System_utils/System_utils_sigterm.cpp
+++ b/System_utils/System_utils_sigterm.cpp
@@ -1,0 +1,8 @@
+#include "system_utils.hpp"
+#include <csignal>
+
+void    su_sigterm(void)
+{
+    std::raise(SIGTERM);
+    return ;
+}

--- a/System_utils/system_utils.hpp
+++ b/System_utils/system_utils.hpp
@@ -1,9 +1,16 @@
 #ifndef SYSTEM_UTILS_HPP
 # define SYSTEM_UTILS_HPP
 
-char    *su_getenv_thread_safe(const char *name);
-int     su_setenv_thread_safe(const char *name, const char *value, int overwrite);
-int     su_putenv_thread_safe(char *string);
+char    *su_getenv(const char *name);
+int     su_setenv(const char *name, const char *value, int overwrite);
+int     su_putenv(char *string);
+void    su_abort(void);
+void    su_sigabrt(void);
+void    su_sigfpe(void);
+void    su_sigill(void);
+void    su_sigint(void);
+void    su_sigsegv(void);
+void    su_sigterm(void);
 void    su_assert(bool condition, const char *message);
 
 #endif


### PR DESCRIPTION
## Summary
- wrap std::abort in new `su_abort` helper
- provide helpers for SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, and SIGTERM
- route system utilities assert through new abort wrapper
- replace direct `raise(SIGABRT)` in allocator with `su_sigabrt`
- rename environment helpers to drop `thread_safe` suffix and add `su_sigsegv`

## Testing
- `cd System_utils && make && cd ..`
- `cd CMA && make && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68c16199e18083318f8ec259052934de