### PR TITLE
Add async HTTP callbacks with non-blocking sockets

### DIFF
--- a/API/api.hpp
+++ b/API/api.hpp
@@ -6,6 +6,18 @@
 #include <cstdint>
 #include <cstddef>
 
+typedef void (*api_callback)(char *body, int status, void *user_data);
+
+bool    api_request_string_async(const char *ip, uint16_t port,
+        const char *method, const char *path, api_callback callback,
+        void *user_data, json_group *payload = ft_nullptr,
+        const char *headers = ft_nullptr, int timeout = 60000);
+
+bool    api_request_string_tls_async(const char *host, uint16_t port,
+        const char *method, const char *path, api_callback callback,
+        void *user_data, json_group *payload = ft_nullptr,
+        const char *headers = ft_nullptr, int timeout = 60000);
+
 char    *api_request_string(const char *ip, uint16_t port,
         const char *method, const char *path, json_group *payload = ft_nullptr,
         const char *headers = ft_nullptr, int *status = ft_nullptr,

--- a/API/tls_client.hpp
+++ b/API/tls_client.hpp
@@ -7,6 +7,8 @@
 #include <openssl/ssl.h>
 #include <cstdint>
 
+typedef void (*api_callback)(char *body, int status, void *user_data);
+
 class api_tls_client
 {
     private:
@@ -27,6 +29,12 @@ class api_tls_client
         json_group *request_json(const char *method, const char *path,
                                  json_group *payload = ft_nullptr,
                                  const char *headers = ft_nullptr, int *status = ft_nullptr);
+
+        bool request_async(const char *method, const char *path,
+                           json_group *payload = ft_nullptr,
+                           const char *headers = ft_nullptr,
+                           api_callback callback = ft_nullptr,
+                           void *user_data = ft_nullptr);
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -654,6 +654,25 @@ json_group *api_request_json_host(const char *host, uint16_t port,
                                   int timeout = 60000);
 ```
 
+Callback based helpers run the request on a background thread and invoke
+the user supplied callback with the body and status code. The response body
+is allocated with `cma_malloc` and must be freed by the caller.
+
+```
+typedef void (*api_callback)(char *body, int status, void *user_data);
+
+bool api_request_string_async(const char *ip, uint16_t port,
+                              const char *method, const char *path,
+                              api_callback callback, void *user_data,
+                              json_group *payload = ft_nullptr,
+                              const char *headers = ft_nullptr, int timeout = 60000);
+bool api_request_string_tls_async(const char *host, uint16_t port,
+                                  const char *method, const char *path,
+                                  api_callback callback, void *user_data,
+                                  json_group *payload = ft_nullptr,
+                                  const char *headers = ft_nullptr, int timeout = 60000);
+```
+
 Asynchronous helpers in `promise.hpp` return `ft_promise` objects:
 
 ```
@@ -693,6 +712,12 @@ char *request(const char *method, const char *path, json_group *payload = ft_nul
 json_group *request_json(const char *method, const char *path,
                          json_group *payload = ft_nullptr,
                          const char *headers = ft_nullptr, int *status = ft_nullptr);
+
+bool request_async(const char *method, const char *path,
+                   json_group *payload = ft_nullptr,
+                   const char *headers = ft_nullptr,
+                   api_callback callback = ft_nullptr,
+                   void *user_data = ft_nullptr);
 ```
 
 #### HTML


### PR DESCRIPTION
## Summary
- add callback-based async API functions and typedef
- implement non-blocking socket handlers for HTTP and TLS requests
- extend TLS client with request_async helper and document usage

## Testing
- `cd API && make`


------
https://chatgpt.com/codex/tasks/task_e_68c1b6a1f8348331938a05bf4ec1e769