### PR TITLE
Track CMA allocations and frees

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -32,6 +32,7 @@ char    *cma_strtrim(const char *string, const char *set)
 void    cma_free_double(char **content);
 void    cma_cleanup();
 void    cma_set_alloc_limit(std::size_t limit);
+void    cma_get_stats(std::size_t *allocation_count, std::size_t *free_count);
 
 template <int total_argument_count, typename... argument_types>
 char    *cma_strjoin_multiple_checked(const argument_types &... strings)

--- a/CMA/cma_free.cpp
+++ b/CMA/cma_free.cpp
@@ -15,6 +15,7 @@ void cma_free(void* ptr)
     if (OFFSWITCH == 1)
     {
         std::free(ptr);
+        g_cma_free_count++;
         if (ft_log_get_alloc_logging())
             ft_log_debug("cma_free %p", ptr);
         return ;
@@ -35,6 +36,7 @@ void cma_free(void* ptr)
     Page *page = find_page_of_block(block);
     free_page_if_empty(page);
     g_malloc_mutex.unlock(THREAD_ID);
+    g_cma_free_count++;
     if (ft_log_get_alloc_logging())
         ft_log_debug("cma_free %p", ptr);
     return ;

--- a/CMA/cma_internal.hpp
+++ b/CMA/cma_internal.hpp
@@ -34,6 +34,8 @@
 
 extern pt_mutex g_malloc_mutex;
 extern std::size_t    g_cma_alloc_limit;
+extern std::size_t    g_cma_allocation_count;
+extern std::size_t    g_cma_free_count;
 
 struct Block
 {

--- a/CMA/cma_malloc.cpp
+++ b/CMA/cma_malloc.cpp
@@ -16,6 +16,8 @@ void* cma_malloc(std::size_t size)
     if (OFFSWITCH == 1)
     {
         void *ptr = malloc(size);
+        if (ptr)
+            g_cma_allocation_count++;
         if (ft_log_get_alloc_logging())
             ft_log_debug("cma_malloc %zu -> %p", size, ptr);
         return (ptr);
@@ -39,6 +41,7 @@ void* cma_malloc(std::size_t size)
     }
     block = split_block(block, aligned_size);
     block->free = false;
+    g_cma_allocation_count++;
     void *result = reinterpret_cast<char*>(block) + sizeof(Block);
     g_malloc_mutex.unlock(THREAD_ID);
     if (ft_log_get_alloc_logging())

--- a/CMA/cma_realloc.cpp
+++ b/CMA/cma_realloc.cpp
@@ -35,7 +35,14 @@ static int reallocate_block(void *ptr, size_t new_size)
 void *cma_realloc(void* ptr, size_t new_size)
 {
     if (OFFSWITCH == 1)
-        return (std::realloc(ptr, new_size));
+    {
+        void *result = std::realloc(ptr, new_size);
+        if (!ptr && result)
+            g_cma_allocation_count++;
+        else if (ptr && new_size == 0)
+            g_cma_free_count++;
+        return (result);
+    }
     if (g_cma_alloc_limit != 0 && new_size > g_cma_alloc_limit)
         return (ft_nullptr);
     g_malloc_mutex.lock(THREAD_ID);

--- a/CMA/cma_utils.cpp
+++ b/CMA/cma_utils.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <cassert>
 #include <csignal>
+#include "CMA.hpp"
 #include "cma_internal.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../Printf/printf.hpp"
@@ -12,6 +13,8 @@
 Page *page_list = ft_nullptr;
 pt_mutex g_malloc_mutex;
 std::size_t    g_cma_alloc_limit = 0;
+std::size_t    g_cma_allocation_count = 0;
+std::size_t    g_cma_free_count = 0;
 
 static size_t determine_page_size(size_t size)
 {
@@ -239,5 +242,14 @@ static inline void print_block_info_impl(Block *block)
 void print_block_info(Block *block)
 {
     print_block_info_impl(block);
+    return ;
+}
+
+void cma_get_stats(std::size_t *allocation_count, std::size_t *free_count)
+{
+    if (allocation_count != ft_nullptr)
+        *allocation_count = g_cma_allocation_count;
+    if (free_count != ft_nullptr)
+        *free_count = g_cma_free_count;
     return ;
 }

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ returns a 128-byte block) and are released with `cma_free`.
 When allocation logging is enabled via the logger, the allocator emits debug messages for each `cma_malloc` and `cma_free`.
 The allocator enforces an optional global allocation limit that can be
 changed at runtime with `cma_set_alloc_limit`. A limit of `0` disables the
-check. Internally, `cma_realloc` has been simplified by removing redundant braces.
+check. The allocator also tracks allocation and free counts, accessible
+through `cma_get_stats`. Internally, `cma_realloc` has been simplified by
+removing redundant braces.
 
 ```
 void   *cma_malloc(std::size_t size);
@@ -156,6 +158,7 @@ char   *cma_strtrim(const char *s1, const char *set);
 void    cma_free_double(char **content);
 void    cma_cleanup();
 void    cma_set_alloc_limit(std::size_t limit);
+void    cma_get_stats(std::size_t *allocation_count, std::size_t *free_count);
 ```
 
 ### GetNextLine


### PR DESCRIPTION
## Summary
- Track allocation and free counts in CMA internals
- Update malloc, free, and realloc to maintain counters
- Expose public `cma_get_stats` API and document usage

## Testing
- `make -C CMA`

------
https://chatgpt.com/codex/tasks/task_e_68c1ba5670e08331bfb4914323f89990