### PR TITLE
Implement deep copy support for DataBuffer and ft_string

### DIFF
--- a/CPP_class/class_data_buffer.hpp
+++ b/CPP_class/class_data_buffer.hpp
@@ -17,6 +17,11 @@ class DataBuffer
 
     public:
         DataBuffer();
+        DataBuffer(const DataBuffer& other);
+        DataBuffer(DataBuffer&& other) noexcept;
+        DataBuffer& operator=(const DataBuffer& other);
+        DataBuffer& operator=(DataBuffer&& other) noexcept;
+        ~DataBuffer();
         void clear() noexcept;
         size_t size() const noexcept;
         const std::vector<uint8_t>& data() const noexcept;

--- a/CPP_class/cpp_class_data_buffer.cpp
+++ b/CPP_class/cpp_class_data_buffer.cpp
@@ -1,7 +1,51 @@
 #include "class_data_buffer.hpp"
 #include "../Libft/libft.hpp"
+#include <utility>
 
 DataBuffer::DataBuffer() : _readPos(0), _ok(true)
+{
+    return ;
+}
+
+DataBuffer::DataBuffer(const DataBuffer& other)
+    : _buffer(other._buffer), _readPos(other._readPos), _ok(other._ok)
+{
+    return ;
+}
+
+DataBuffer::DataBuffer(DataBuffer&& other) noexcept
+    : _buffer(std::move(other._buffer)), _readPos(other._readPos), _ok(other._ok)
+{
+    other._readPos = 0;
+    other._ok = true;
+    return ;
+}
+
+DataBuffer& DataBuffer::operator=(const DataBuffer& other)
+{
+    if (this != &other)
+    {
+        this->_buffer = other._buffer;
+        this->_readPos = other._readPos;
+        this->_ok = other._ok;
+    }
+    return (*this);
+}
+
+DataBuffer& DataBuffer::operator=(DataBuffer&& other) noexcept
+{
+    if (this != &other)
+    {
+        this->_buffer = std::move(other._buffer);
+        this->_readPos = other._readPos;
+        this->_ok = other._ok;
+        other._readPos = 0;
+        other._ok = true;
+    }
+    return (*this);
+}
+
+DataBuffer::~DataBuffer()
 {
     return ;
 }

--- a/CPP_class/cpp_class_string_constructors.cpp
+++ b/CPP_class/cpp_class_string_constructors.cpp
@@ -84,11 +84,13 @@ ft_string& ft_string::operator=(const char*& other) noexcept
 {
     cma_free(this->_data);
     this->_data = ft_nullptr;
-    this->_length = ft_strlen(other);
-    this->_capacity = ft_strlen(other);
+    this->_length = 0;
+    this->_capacity = 0;
     this->_error_code = 0;
     if (other)
     {
+        this->_length = ft_strlen_size_t(other);
+        this->_capacity = this->_length;
         this->_data = static_cast<char*>(cma_calloc(this->_capacity + 1, sizeof(char)));
         if (!this->_data)
         {
@@ -104,7 +106,7 @@ ft_string& ft_string::operator=(ft_string&& other) noexcept
 {
     if (this != &other)
     {
-        delete[] this->_data;
+        cma_free(this->_data);
         this->_data = other._data;
         this->_length = other._length;
         this->_capacity = other._capacity;

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ Below is a brief list of the main classes and selected members.
 #### `DataBuffer`
 ```
 DataBuffer();
+DataBuffer(const DataBuffer& other);
+DataBuffer(DataBuffer&& other) noexcept;
+DataBuffer& operator=(const DataBuffer& other);
+DataBuffer& operator=(DataBuffer&& other) noexcept;
+~DataBuffer();
 void clear() noexcept;
 size_t size() const noexcept;
 const std::vector<uint8_t>& data() const noexcept;

--- a/Test/test_cpp_class.cpp
+++ b/Test/test_cpp_class.cpp
@@ -16,20 +16,49 @@ int test_ft_string_append(void)
 
 int test_ft_string_concat(void)
 {
-    ft_string a("Hello");
-    ft_string b("World");
-    ft_string c = a + " " + b;
-    return (c == "Hello World");
+    ft_string first_string("Hello");
+    ft_string second_string("World");
+    ft_string combined_string = first_string + " " + second_string;
+    ft_string copy_string(combined_string);
+    ft_string assigned_string;
+    assigned_string = combined_string;
+    combined_string.append('!');
+    ft_string moved_string(std::move(copy_string));
+    ft_string move_assigned_string;
+    move_assigned_string = std::move(assigned_string);
+    bool status = (combined_string == "Hello World!" &&
+        moved_string == "Hello World" &&
+        move_assigned_string == "Hello World" &&
+        copy_string.size() == 0 &&
+        assigned_string.size() == 0);
+    return (status);
 }
 
 int test_data_buffer_io(void)
 {
-    DataBuffer buf;
-    buf << 42 << std::string("abc");
-    int i = 0;
-    std::string s;
-    buf >> i >> s;
-    return (i == 42 && s == "abc" && buf.good());
+    DataBuffer source_buffer;
+    source_buffer << 42 << std::string("abc");
+    DataBuffer copy_buffer(source_buffer);
+    DataBuffer assigned_buffer;
+    assigned_buffer = source_buffer;
+    DataBuffer moved_buffer(std::move(source_buffer));
+    DataBuffer move_assigned_buffer;
+    move_assigned_buffer = std::move(assigned_buffer);
+    int number_copy = 0;
+    std::string string_copy;
+    int number_move = 0;
+    std::string string_move;
+    int number_move_assign = 0;
+    std::string string_move_assign;
+    copy_buffer >> number_copy >> string_copy;
+    moved_buffer >> number_move >> string_move;
+    move_assigned_buffer >> number_move_assign >> string_move_assign;
+    bool status = (number_copy == 42 && string_copy == "abc" &&
+        number_move == 42 && string_move == "abc" &&
+        number_move_assign == 42 && string_move_assign == "abc" &&
+        source_buffer.size() == 0 && assigned_buffer.size() == 0 &&
+        copy_buffer.good() && moved_buffer.good() && move_assigned_buffer.good());
+    return (status);
 }
 
 int test_ft_file_write_read(void)


### PR DESCRIPTION
## Summary
- add copy/move constructors and assignment operators to `DataBuffer`
- fix `ft_string` assignment operators for proper deep copies
- extend C++ class tests for copy and move semantics
- document new `DataBuffer` operations

## Testing
- `cd Test && make` *(fails: ../Printf/internal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bb8ed9d883318421fea2b2cfe89a