### PR TITLE
Make errno thread local and add concurrency test

### DIFF
--- a/Errno/Makefile
+++ b/Errno/Makefile
@@ -3,7 +3,8 @@ DEBUG_TARGET := errno_debug.a
 
 SRCS :=        errno_strerror.cpp \
         errno_perror.cpp \
-        errno_exit.cpp
+        errno_exit.cpp \
+        errno_code.cpp
 
 HEADERS := errno.hpp
 

--- a/Errno/errno.hpp
+++ b/Errno/errno.hpp
@@ -1,7 +1,8 @@
 #ifndef ERRNO_HPP
 # define ERRNO_HPP
 
-extern thread_local int ft_errno;
+extern thread_local int _error_code;
+#define ft_errno _error_code
 
 #define ERRNO_OFFSET 2000
 

--- a/Errno/errno_code.cpp
+++ b/Errno/errno_code.cpp
@@ -1,0 +1,3 @@
+#include "errno.hpp"
+
+thread_local int _error_code = ER_SUCCESS;

--- a/Errno/errno_exit.cpp
+++ b/Errno/errno_exit.cpp
@@ -4,12 +4,12 @@
 
 void    ft_exit(const char *error_msg, int exit_code)
 {
-    if (error_msg && ft_errno != ER_SUCCESS)
-        pf_printf_fd(2, "%s: %s\n", error_msg, ft_strerror(ft_errno));
+    if (error_msg && _error_code != ER_SUCCESS)
+        pf_printf_fd(2, "%s: %s\n", error_msg, ft_strerror(_error_code));
     else if (error_msg)
         pf_printf_fd(2, "%s\n", error_msg);
-    else if (ft_errno != ER_SUCCESS)
-        pf_printf_fd(2, "%s\n", ft_strerror(ft_errno));
+    else if (_error_code != ER_SUCCESS)
+        pf_printf_fd(2, "%s\n", ft_strerror(_error_code));
     std::exit(exit_code);
 }
 

--- a/Errno/errno_perror.cpp
+++ b/Errno/errno_perror.cpp
@@ -4,8 +4,8 @@
 void    ft_perror(const char *error_msg)
 {
     if (!error_msg)
-        pf_printf_fd(2, "%s", ft_strerror(ft_errno));
+        pf_printf_fd(2, "%s", ft_strerror(_error_code));
     else
-        pf_printf_fd(2, "%s: %s", error_msg, ft_strerror(ft_errno));
+        pf_printf_fd(2, "%s: %s", error_msg, ft_strerror(_error_code));
     return ;
 }

--- a/PThread/pthread_unlock_mutex.cpp
+++ b/PThread/pthread_unlock_mutex.cpp
@@ -2,7 +2,6 @@
 #include "../Errno/errno.hpp"
 #include "../Libft/libft.hpp"
 
-thread_local int ft_errno = 0;
 
 int pt_mutex::unlock(pthread_t thread_id)
 {

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ const char *get_error_str() const;
 
 
 #### Errno
-`Errno/errno.hpp` defines error codes and helpers for retrieving messages.
+`Errno/errno.hpp` defines a thread-local `_error_code` accessed through the `ft_errno` macro and helpers for retrieving messages.
 
 ```
 const char *ft_strerror(int err);

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -150,6 +150,7 @@ int test_ft_open_and_read_file(void);
 int test_cma_checked_free_basic(void);
 int test_cma_checked_free_offset(void);
 int test_cma_checked_free_invalid(void);
+int test_cma_thread_local(void);
 int test_game_simulation(void);
 int test_item_basic(void);
 int test_inventory_count(void);
@@ -365,6 +366,7 @@ int main(int argc, char **argv)
         { test_cma_checked_free_basic, "cma_checked_free basic" },
         { test_cma_checked_free_offset, "cma_checked_free offset" },
         { test_cma_checked_free_invalid, "cma_checked_free invalid" },
+        { test_cma_thread_local, "cma thread_local" },
         { test_game_simulation, "game simulation" },
         { test_item_basic, "item basic" },
         { test_inventory_count, "inventory count" },

--- a/Test/test_cma.cpp
+++ b/Test/test_cma.cpp
@@ -1,5 +1,6 @@
 #include "../CMA/CMA.hpp"
 #include "../Errno/errno.hpp"
+#include <thread>
 
 int test_cma_checked_free_basic(void)
 {
@@ -27,4 +28,43 @@ int test_cma_checked_free_invalid(void)
     ft_errno = 0;
     int r = cma_checked_free(&local);
     return (r == -1 && ft_errno == CMA_INVALID_PTR);
+}
+
+static void cma_thread_success(bool *thread_result)
+{
+    ft_errno = ER_SUCCESS;
+    void *memory_pointer = cma_malloc(32);
+    if (!memory_pointer)
+    {
+        *thread_result = false;
+        return ;
+    }
+    int free_result = cma_checked_free(memory_pointer);
+    if (free_result != 0)
+    {
+        *thread_result = false;
+        return ;
+    }
+    *thread_result = (ft_errno == ER_SUCCESS);
+    return ;
+}
+
+static void cma_thread_failure(bool *thread_result)
+{
+    int local_variable;
+    ft_errno = ER_SUCCESS;
+    int free_result = cma_checked_free(&local_variable);
+    *thread_result = (free_result == -1 && ft_errno == CMA_INVALID_PTR);
+    return ;
+}
+
+int test_cma_thread_local(void)
+{
+    bool success_result = false;
+    bool failure_result = false;
+    std::thread success_thread(cma_thread_success, &success_result);
+    std::thread failure_thread(cma_thread_failure, &failure_result);
+    success_thread.join();
+    failure_thread.join();
+    return (success_result && failure_result);
 }


### PR DESCRIPTION
## Summary
- Make errno error storage thread-local and expose it as `ft_errno`
- Update error handling helpers to read from the thread-local storage
- Add CMA concurrency test verifying thread-local errno handling

## Testing
- `cd Test && make` *(fails: ../Printf/internal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bd996e508331bb7814eb8095f8c9