### PR TITLE
Add portable CPU and memory helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,8 @@ custom memory allocator can be toggled with `set_alloc_logging` and
 `System_utils/system_utils.hpp` provides a simple assertion helper that logs failures using the
 global logger before terminating the process. The header also offers direct helpers to abort or
 raise common signals and wrappers around environment helpers. Each call locks a global mutex before
-touching the process environment.
+touching the process environment. It also exposes portable helpers to query CPU count and total
+physical memory.
 
 ```
 void    su_abort(void);
@@ -420,6 +421,8 @@ void    su_assert(bool condition, const char *message);
 char    *su_getenv(const char *name);
 int     su_setenv(const char *name, const char *value, int overwrite);
 int     su_putenv(char *string);
+unsigned int    su_get_cpu_count(void);
+unsigned long long su_get_total_memory(void);
 ```
 
 ### Template Utilities

--- a/System_utils/Makefile
+++ b/System_utils/Makefile
@@ -9,7 +9,8 @@ SRCS := System_utils_assert.cpp \
         System_utils_sigill.cpp \
         System_utils_sigint.cpp \
         System_utils_sigsegv.cpp \
-        System_utils_sigterm.cpp
+        System_utils_sigterm.cpp \
+        System_utils_sysinfo.cpp
 
 HEADERS := system_utils.hpp
 

--- a/System_utils/System_utils_sysinfo.cpp
+++ b/System_utils/System_utils_sysinfo.cpp
@@ -1,0 +1,68 @@
+#include "system_utils.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+# include <windows.h>
+#else
+# include <unistd.h>
+# if defined(__APPLE__) && defined(__MACH__)
+#  include <sys/types.h>
+#  include <sys/sysctl.h>
+# endif
+#endif
+
+unsigned int    su_get_cpu_count(void)
+{
+#if defined(_WIN32) || defined(_WIN64)
+    SYSTEM_INFO system_info;
+
+    GetSystemInfo(&system_info);
+    return (system_info.dwNumberOfProcessors);
+#elif defined(__APPLE__) && defined(__MACH__)
+    int cpu_count;
+    size_t size;
+
+    size = sizeof(cpu_count);
+    if (sysctlbyname("hw.ncpu", &cpu_count, &size, ft_nullptr, 0) != 0)
+        return (0);
+    return (static_cast<unsigned int>(cpu_count));
+#else
+    long cpu_count;
+
+    cpu_count = sysconf(_SC_NPROCESSORS_ONLN);
+    if (cpu_count < 0)
+        return (0);
+    return (static_cast<unsigned int>(cpu_count));
+#endif
+}
+
+unsigned long long su_get_total_memory(void)
+{
+#if defined(_WIN32) || defined(_WIN64)
+    MEMORYSTATUSEX memory_status;
+
+    memory_status.dwLength = sizeof(memory_status);
+    if (GlobalMemoryStatusEx(&memory_status) == 0)
+        return (0);
+    return (memory_status.ullTotalPhys);
+#elif defined(__APPLE__) && defined(__MACH__)
+    unsigned long long memory_size;
+    size_t size;
+
+    size = sizeof(memory_size);
+    if (sysctlbyname("hw.memsize", &memory_size, &size, ft_nullptr, 0) != 0)
+        return (0);
+    return (memory_size);
+#else
+    long pages;
+    long page_size;
+
+    pages = sysconf(_SC_PHYS_PAGES);
+    page_size = sysconf(_SC_PAGE_SIZE);
+    if (pages < 0 || page_size < 0)
+        return (0);
+    return (static_cast<unsigned long long>(pages) *
+            static_cast<unsigned long long>(page_size));
+#endif
+}
+

--- a/System_utils/system_utils.hpp
+++ b/System_utils/system_utils.hpp
@@ -4,6 +4,8 @@
 char    *su_getenv(const char *name);
 int     su_setenv(const char *name, const char *value, int overwrite);
 int     su_putenv(char *string);
+unsigned int    su_get_cpu_count(void);
+unsigned long long su_get_total_memory(void);
 void    su_abort(void);
 void    su_sigabrt(void);
 void    su_sigfpe(void);

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -116,6 +116,8 @@ int test_atol_longmax(void);
 int test_atol_longmin(void);
 int test_setenv_getenv_basic(void);
 int test_setenv_no_overwrite(void);
+int test_su_get_cpu_count(void);
+int test_su_get_total_memory(void);
 int test_ft_string_append(void);
 int test_ft_string_concat(void);
 int test_data_buffer_io(void);
@@ -313,6 +315,8 @@ int main(int argc, char **argv)
         { test_atol_longmin, "atol longmin" },
         { test_setenv_getenv_basic, "setenv/getenv basic" },
         { test_setenv_no_overwrite, "setenv no overwrite" },
+        { test_su_get_cpu_count, "su get cpu count" },
+        { test_su_get_total_memory, "su get total memory" },
         { test_strlen_size_t_empty, "strlen_size_t empty" },
         { test_bzero_zero, "bzero zero" },
         { test_memcpy_partial, "memcpy partial" },

--- a/Test/test_extra_libft.cpp
+++ b/Test/test_extra_libft.cpp
@@ -2,6 +2,7 @@
 #include "../Math/math.hpp"
 #include "../Libft/limits.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../System_utils/system_utils.hpp"
 #include <cstring>
 #include <string>
 
@@ -350,5 +351,15 @@ int test_setenv_no_overwrite(void)
     int ok = val != ft_nullptr && std::strcmp(val, "first") == 0;
     ft_unsetenv("LIBFT_TEST_VAR2");
     return (ok);
+}
+
+int test_su_get_cpu_count(void)
+{
+    return (su_get_cpu_count() > 0);
+}
+
+int test_su_get_total_memory(void)
+{
+    return (su_get_total_memory() > 0);
 }
 


### PR DESCRIPTION
## Summary
- add `su_get_cpu_count` and `su_get_total_memory` for cross-platform system info
- expose new helpers in `system_utils.hpp` and README
- test CPU/memory queries in `test_extra_libft` and integrate into test runner

## Testing
- `make -C System_utils`
- `make -C Test` *(fails: cpp_class_file.cpp:4:10: fatal error: ../Printf/internal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c0be5cdc8331bee57fd4d05a88f5