### PR TITLE
Add snprintf wrapper for formatted output

### DIFF
--- a/CPP_class/cpp_class_file.cpp
+++ b/CPP_class/cpp_class_file.cpp
@@ -1,7 +1,7 @@
 #include "class_file.hpp"
 #include "../Libft/libft.hpp"
 #include "../Errno/errno.hpp"
-#include "../Printf/internal.hpp"
+#include "../Printf/printf_internal.hpp"
 #include "../Printf/printf.hpp"
 #include "class_nullptr.hpp"
 #include <cerrno>

--- a/Printf/Makefile
+++ b/Printf/Makefile
@@ -4,7 +4,8 @@ DEBUG_TARGET := Printf_debug.a
 SRCS := printf_printf.cpp \
                 printf_format.cpp \
                 printf_print_args.cpp \
-                printf_ft_fprintf.cpp
+                printf_ft_fprintf.cpp \
+                printf_snprintf.cpp
 
 HEADERS := printf.hpp \
            printf_internal.hpp

--- a/Printf/printf.hpp
+++ b/Printf/printf.hpp
@@ -7,6 +7,7 @@
 
 int pf_printf(const char *format, ...) __attribute__((format(printf, 1, 2), hot));
 int pf_printf_fd(int fd, const char *format, ...) __attribute__((format(printf, 2, 3), hot));
+int pf_snprintf(char *string, size_t size, const char *format, ...) __attribute__((format(printf, 3, 4), hot));
 int ft_vfprintf(FILE *stream, const char *format, va_list args);
 int ft_fprintf(FILE *stream, const char *format, ...) __attribute__((format(printf, 2, 3), hot));
 

--- a/Printf/printf_snprintf.cpp
+++ b/Printf/printf_snprintf.cpp
@@ -1,0 +1,27 @@
+#include "printf.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int pf_snprintf(char *string, size_t size, const char *format, ...)
+{
+    if (string == ft_nullptr || format == ft_nullptr)
+        return (0);
+    va_list args;
+    char *buffer = ft_nullptr;
+    size_t buffer_size = 0;
+    FILE *stream = open_memstream(&buffer, &buffer_size);
+    if (stream == ft_nullptr)
+        return (0);
+    va_start(args, format);
+    int printed = ft_vfprintf(stream, format, args);
+    va_end(args);
+    fclose(stream);
+    if (buffer != ft_nullptr && size > 0)
+        ft_strlcpy(string, buffer, size);
+    free(buffer);
+    return (printed);
+}
+

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ char  **ft_open_and_read_file(const char *file_name);
 ```
 int pf_printf(const char *format, ...);
 int pf_printf_fd(int fd, const char *format, ...);
+int pf_snprintf(char *string, size_t size, const char *format, ...);
 ```
 
 ### PThread Wrappers
@@ -249,6 +250,8 @@ ssize_t read(char *buffer, int count) noexcept;
 int     printf(const char *format, ...) __attribute__((format(printf,2,3),hot));
 operator int() const;
 ```
+
+The `printf` helper forwards to the Printf module's `pf_printf_fd_v` to write formatted output directly to the file descriptor.
 
 #### `ft_string`
 ```

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -146,6 +146,7 @@ int test_pf_printf_misc(void);
 int test_pf_printf_bool(void);
 int test_pf_printf_nullptr(void);
 int test_pf_printf_modifiers(void);
+int test_pf_snprintf_basic(void);
 int test_get_next_line_basic(void);
 int test_get_next_line_empty(void);
 int test_ft_open_and_read_file(void);
@@ -364,6 +365,7 @@ int main(int argc, char **argv)
         { test_pf_printf_bool, "pf_printf bool" },
         { test_pf_printf_nullptr, "pf_printf nullptr" },
         { test_pf_printf_modifiers, "pf_printf modifiers" },
+        { test_pf_snprintf_basic, "pf_snprintf basic" },
         { test_get_next_line_basic, "get_next_line basic" },
         { test_get_next_line_empty, "get_next_line empty" },
         { test_ft_open_and_read_file, "open_and_read_file" },

--- a/Test/test_printf.cpp
+++ b/Test/test_printf.cpp
@@ -94,3 +94,10 @@ int test_pf_printf_modifiers(void)
     buf[r] = '\0';
     return (ft_strcmp(buf, "2147483648 2147483648 80000000 8589934591 1ffffffff") == 0);
 }
+
+int test_pf_snprintf_basic(void)
+{
+    char buffer[64];
+    pf_snprintf(buffer, sizeof(buffer), "%s %d", "number", 7);
+    return (ft_strcmp(buffer, "number 7") == 0);
+}


### PR DESCRIPTION
## Summary
- Add `pf_snprintf` to format strings into buffers using existing `ft_vfprintf` logic
- Expose `pf_snprintf` in `printf.hpp` and include it in the Printf build
- Extend printf tests with `pf_snprintf` coverage and document function in README
- Fix `ft_file` to include `printf_internal.hpp`, restoring successful build of the `CPP_class` module
- Note in README that `ft_file::printf` relies on `pf_printf_fd_v`

## Testing
- `make -C Printf`
- `make -C CPP_class`
- `make -C Test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c52457108331be5d016fab295206