### PR TITLE
Add sink-based logging

### DIFF
--- a/Logger/Makefile
+++ b/Logger/Makefile
@@ -8,6 +8,8 @@ SRCS := \
     logger_log_vwrite.cpp \
     logger_log_set_level.cpp \
     logger_log_set_file.cpp \
+    logger_log_add_sink.cpp \
+    logger_log_remove_sink.cpp \
     logger_log_set_alloc_logging.cpp \
     logger_log_get_alloc_logging.cpp \
     logger_log_set_api_logging.cpp \

--- a/Logger/logger.hpp
+++ b/Logger/logger.hpp
@@ -11,13 +11,19 @@ enum t_log_level {
     LOG_LEVEL_NONE
 };
 
-void ft_log_set_level(t_log_level level);
-int  ft_log_set_file(const char *path, size_t max_size);
-void ft_log_close();
-void ft_log_set_alloc_logging(bool enable);
-bool ft_log_get_alloc_logging();
-void ft_log_set_api_logging(bool enable);
-bool ft_log_get_api_logging();
+// Sink management. A sink receives a formatted message and an opaque
+// user pointer. Multiple sinks may be registered at once.
+typedef void (*t_log_sink)(const char *message, void *user_data);
+int     ft_log_add_sink(t_log_sink sink, void *user_data);
+void    ft_log_remove_sink(t_log_sink sink, void *user_data);
+
+void    ft_log_set_level(t_log_level level);
+int     ft_log_set_file(const char *path, size_t max_size);
+void    ft_log_close();
+void    ft_log_set_alloc_logging(bool enable);
+bool    ft_log_get_alloc_logging();
+void    ft_log_set_api_logging(bool enable);
+bool    ft_log_get_api_logging();
 
 void ft_log_debug(const char *fmt, ...);
 void ft_log_info(const char *fmt, ...);
@@ -26,6 +32,10 @@ void ft_log_error(const char *fmt, ...);
 
 class ft_logger
 {
+    private:
+        bool _alloc_logging;
+        bool _api_logging;
+
     public:
         ft_logger(const char *path = nullptr, size_t max_size = 0,
                   t_log_level level = LOG_LEVEL_INFO) noexcept;
@@ -37,6 +47,8 @@ class ft_logger
         void set_global() noexcept;
         void set_level(t_log_level level) noexcept;
         int  set_file(const char *path, size_t max_size) noexcept;
+        int  add_sink(t_log_sink sink, void *user_data) noexcept;
+        void remove_sink(t_log_sink sink, void *user_data) noexcept;
         void set_alloc_logging(bool enable) noexcept;
         bool get_alloc_logging() const noexcept;
         void set_api_logging(bool enable) noexcept;
@@ -47,10 +59,6 @@ class ft_logger
         void info(const char *fmt, ...) noexcept;
         void warn(const char *fmt, ...) noexcept;
         void error(const char *fmt, ...) noexcept;
-
-    private:
-        bool _alloc_logging;
-        bool _api_logging;
 };
 
 #endif

--- a/Logger/logger_internal.hpp
+++ b/Logger/logger_internal.hpp
@@ -3,15 +3,31 @@
 
 #include <cstdarg>
 #include <string>
+#include <vector>
 #include "logger.hpp"
 
 extern ft_logger *g_logger;
 extern t_log_level g_level;
-extern int g_fd;
-extern std::string g_path;
-extern size_t g_max_size;
 
-void ft_log_rotate();
+typedef void (*t_log_sink)(const char *message, void *user_data);
+
+struct s_log_sink
+{
+    t_log_sink function;
+    void      *user_data;
+};
+
+struct s_file_sink
+{
+    int         fd;
+    std::string path;
+    size_t      max_size;
+};
+
+extern std::vector<s_log_sink> g_sinks;
+
+void ft_log_rotate(s_file_sink *sink);
+void ft_file_sink(const char *message, void *user_data);
 const char *ft_level_to_str(t_log_level level);
 void ft_log_vwrite(t_log_level level, const char *fmt, va_list args);
 

--- a/Logger/logger_log_add_sink.cpp
+++ b/Logger/logger_log_add_sink.cpp
@@ -1,0 +1,12 @@
+#include "logger_internal.hpp"
+
+int ft_log_add_sink(t_log_sink sink, void *user_data)
+{
+    if (!sink)
+        return (-1);
+    s_log_sink entry;
+    entry.function = sink;
+    entry.user_data = user_data;
+    g_sinks.push_back(entry);
+    return (0);
+}

--- a/Logger/logger_log_close.cpp
+++ b/Logger/logger_log_close.cpp
@@ -3,9 +3,24 @@
 
 void ft_log_close()
 {
-    if (!g_path.empty())
-        close(g_fd);
-    g_fd = 1;
-    g_path.clear();
-    g_max_size = 0;
+    size_t index;
+
+    index = 0;
+    while (index < g_sinks.size())
+    {
+        if (g_sinks[index].function == ft_file_sink)
+        {
+            s_file_sink *sink;
+
+            sink = static_cast<s_file_sink *>(g_sinks[index].user_data);
+            if (sink)
+            {
+                close(sink->fd);
+                delete sink;
+            }
+        }
+        index++;
+    }
+    g_sinks.clear();
+    return ;
 }

--- a/Logger/logger_log_remove_sink.cpp
+++ b/Logger/logger_log_remove_sink.cpp
@@ -1,0 +1,18 @@
+#include "logger_internal.hpp"
+
+void ft_log_remove_sink(t_log_sink sink, void *user_data)
+{
+    size_t index;
+
+    index = 0;
+    while (index < g_sinks.size())
+    {
+        if (g_sinks[index].function == sink && g_sinks[index].user_data == user_data)
+        {
+            g_sinks.erase(g_sinks.begin() + index);
+            return ;
+        }
+        index++;
+    }
+    return ;
+}

--- a/Logger/logger_log_rotate.cpp
+++ b/Logger/logger_log_rotate.cpp
@@ -4,17 +4,22 @@
 #include <unistd.h>
 #include <cstdio>
 
-void ft_log_rotate()
+void ft_log_rotate(s_file_sink *sink)
 {
-    if (g_path.empty() || g_max_size == 0)
+    struct stat   st;
+    std::string   rotated;
+
+    if (!sink)
         return ;
-    struct stat st;
-    if (fstat(g_fd, &st) == -1)
+    if (sink->path.empty() || sink->max_size == 0)
         return ;
-    if (static_cast<size_t>(st.st_size) < g_max_size)
+    if (fstat(sink->fd, &st) == -1)
         return ;
-    close(g_fd);
-    std::string rotated = g_path + ".1";
-    std::rename(g_path.c_str(), rotated.c_str());
-    g_fd = open(g_path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (static_cast<size_t>(st.st_size) < sink->max_size)
+        return ;
+    close(sink->fd);
+    rotated = sink->path + ".1";
+    std::rename(sink->path.c_str(), rotated.c_str());
+    sink->fd = open(sink->path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    return ;
 }

--- a/Logger/logger_log_state.cpp
+++ b/Logger/logger_log_state.cpp
@@ -3,6 +3,4 @@
 // Global logger state
 
 t_log_level g_level = LOG_LEVEL_DEBUG;
-int g_fd = 1;
-std::string g_path;
-size_t g_max_size = 0;
+std::vector<s_log_sink> g_sinks;

--- a/Logger/logger_log_vwrite.cpp
+++ b/Logger/logger_log_vwrite.cpp
@@ -25,8 +25,26 @@ void ft_log_vwrite(t_log_level level, const char *fmt, va_list args)
     int len = std::snprintf(final_buf, sizeof(final_buf), "[%s] [%s] %s\n", time_buf, ft_level_to_str(level), msg_buf);
     if (len > 0)
     {
-        ssize_t write_result = write(g_fd, final_buf, static_cast<size_t>(len));
-        (void)write_result;
+        if (g_sinks.empty())
+        {
+            ssize_t write_result;
+
+            write_result = write(1, final_buf, static_cast<size_t>(len));
+            (void)write_result;
+        }
+        else
+        {
+            size_t index;
+
+            index = 0;
+            while (index < g_sinks.size())
+            {
+                g_sinks[index].function(final_buf, g_sinks[index].user_data);
+                if (g_sinks[index].function == ft_file_sink)
+                    ft_log_rotate(static_cast<s_file_sink *>(g_sinks[index].user_data));
+                index++;
+            }
+        }
     }
-    ft_log_rotate();
+    return ;
 }

--- a/Logger/logger_logger.cpp
+++ b/Logger/logger_logger.cpp
@@ -33,6 +33,17 @@ int ft_logger::set_file(const char *path, size_t max_size) noexcept
     return (ft_log_set_file(path, max_size));
 }
 
+int ft_logger::add_sink(t_log_sink sink, void *user_data) noexcept
+{
+    return (ft_log_add_sink(sink, user_data));
+}
+
+void ft_logger::remove_sink(t_log_sink sink, void *user_data) noexcept
+{
+    ft_log_remove_sink(sink, user_data);
+    return ;
+}
+
 void ft_logger::set_alloc_logging(bool enable) noexcept
 {
     this->_alloc_logging = enable;

--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ int         join_multicast_group(const SocketConfig &config);
 ### Logger
 
 `Logger/logger.hpp` provides leveled logging with timestamps, formatted output
-and optional file rotation. Logs are written to a configurable destination and
-filtered according to the active log level.
+and optional file rotation. Logs are written to one or more configurable
+destinations (sinks) and filtered according to the active log level.
 
 ```
 enum t_log_level {
@@ -377,6 +377,9 @@ enum t_log_level {
 
 void ft_log_set_level(t_log_level level);
 int  ft_log_set_file(const char *path, size_t max_size);
+typedef void (*t_log_sink)(const char *message, void *user_data);
+int  ft_log_add_sink(t_log_sink sink, void *user_data);
+void ft_log_remove_sink(t_log_sink sink, void *user_data);
 void ft_log_close();
 void ft_log_set_alloc_logging(bool enable);
 bool ft_log_get_alloc_logging();


### PR DESCRIPTION
## Summary
- support registering multiple log sinks and expose add/remove sink APIs
- route log writes through all sinks with rotation for file sinks
- document sink usage in README

## Testing
- `cd Logger && make clean >/tmp/make_clean.log && make >/tmp/make.log && tail -n 20 /tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_68c1c8ddbab083319db18358000e9b72