### PR TITLE
Add selector parsing for HTML search

### DIFF
--- a/HTML/document.hpp
+++ b/HTML/document.hpp
@@ -23,6 +23,7 @@ class html_document
         html_node   *find_by_tag(const char *tag_name) const noexcept;
         html_node   *find_by_attr(const char *key, const char *value) const noexcept;
         html_node   *find_by_text(const char *text_content) const noexcept;
+        html_node   *find_by_selector(const char *selector) const noexcept;
         size_t      count_nodes_by_tag(const char *tag_name) const noexcept;
         void        clear() noexcept;
 

--- a/HTML/html_document.cpp
+++ b/HTML/html_document.cpp
@@ -90,6 +90,11 @@ html_node *html_document::find_by_text(const char *text_content) const noexcept
     return (html_find_by_text(this->_root, text_content));
 }
 
+html_node *html_document::find_by_selector(const char *selector) const noexcept
+{
+    return (html_find_by_selector(this->_root, selector));
+}
+
 size_t html_document::count_nodes_by_tag(const char *tag_name) const noexcept
 {
     return (html_count_nodes_by_tag(this->_root, tag_name));

--- a/HTML/html_search.cpp
+++ b/HTML/html_search.cpp
@@ -1,6 +1,7 @@
 #include "parser.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../Libft/libft.hpp"
+#include "../CMA/CMA.hpp"
 
 html_node *html_find_by_tag(html_node *nodeList, const char *tagName)
 {
@@ -67,4 +68,44 @@ size_t html_count_nodes_by_tag(html_node *nodeList, const char *tagName)
         currentNode = currentNode->next;
     }
     return (count);
+}
+
+html_node *html_find_by_selector(html_node *node_list, const char *selector)
+{
+    const char *close_bracket;
+    const char *equal_sign;
+    char *key;
+    char *value;
+    html_node *result;
+
+    if (!selector)
+        return (ft_nullptr);
+    if (selector[0] == '#')
+        return (html_find_by_attr(node_list, "id", selector + 1));
+    if (selector[0] == '.')
+        return (html_find_by_attr(node_list, "class", selector + 1));
+    if (selector[0] == '[')
+    {
+        close_bracket = ft_strchr(selector + 1, ']');
+        if (!close_bracket)
+            return (ft_nullptr);
+        equal_sign = ft_strchr(selector + 1, '=');
+        if (equal_sign && equal_sign < close_bracket)
+        {
+            key = cma_substr(selector + 1, 0, static_cast<size_t>(equal_sign - selector - 1));
+            value = cma_substr(equal_sign + 1, 0, static_cast<size_t>(close_bracket - equal_sign - 1));
+            result = html_find_by_attr(node_list, key, value);
+            if (key)
+                cma_free(key);
+            if (value)
+                cma_free(value);
+            return (result);
+        }
+        key = cma_substr(selector + 1, 0, static_cast<size_t>(close_bracket - selector - 1));
+        result = html_find_by_attr(node_list, key, ft_nullptr);
+        if (key)
+            cma_free(key);
+        return (result);
+    }
+    return (html_find_by_tag(node_list, selector));
 }

--- a/HTML/parser.hpp
+++ b/HTML/parser.hpp
@@ -34,6 +34,7 @@ void        html_remove_nodes_by_text(html_node **nodeList, const char *textCont
 html_node   *html_find_by_tag(html_node *nodeList, const char *tagName);
 html_node   *html_find_by_attr(html_node *nodeList, const char *key, const char *value);
 html_node   *html_find_by_text(html_node *nodeList, const char *textContent);
+html_node   *html_find_by_selector(html_node *node_list, const char *selector);
 size_t      html_count_nodes_by_tag(html_node *nodeList, const char *tagName);
 
 #endif

--- a/Logger/logger_log_set_file.cpp
+++ b/Logger/logger_log_set_file.cpp
@@ -7,12 +7,14 @@ void ft_file_sink(const char *message, void *user_data)
 {
     s_file_sink *sink;
     size_t       length;
+    ssize_t      written;
 
     sink = static_cast<s_file_sink *>(user_data);
     if (!sink)
         return ;
     length = std::strlen(message);
-    write(sink->fd, message, length);
+    written = write(sink->fd, message, length);
+    (void)written;
     return ;
 }
 

--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ void       html_add_child(html_node *parentNode, html_node *childNode);
 void       html_add_attr(html_node *targetNode, html_attr *newAttribute);
 html_node *html_find_by_tag(html_node *nodeList, const char *tagName);
 html_node *html_find_by_attr(html_node *nodeList, const char *key, const char *value);
+html_node *html_find_by_selector(html_node *nodeList, const char *selector);
 ```
 
 The `html_document` class wraps these helpers and manages a root node list:
@@ -772,7 +773,18 @@ html_document();
 ~html_document();
 void        append_node(html_node *new_node) noexcept;
 html_node   *find_by_tag(const char *tag_name) const noexcept;
-``` 
+html_node   *find_by_selector(const char *selector) const noexcept;
+```
+
+Simple selectors allow searching by:
+
+```
+"tag"             - tag name
+"#id"             - attribute id equals value
+".class"          - attribute class equals value
+"[key=value]"     - attribute key equals value
+"[key]"           - presence of attribute key
+```
 
 #### Game
 Basic game related classes include `ft_character`, `ft_item`, `ft_inventory`,

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -60,6 +60,7 @@ int test_html_create_node(void);
 int test_html_find_by_tag(void);
 int test_html_write_to_string(void);
 int test_html_find_by_attr(void);
+int test_html_find_by_selector(void);
 int test_network_send_receive(void);
 int test_network_invalid_ip(void);
 int test_network_send_uninitialized(void);
@@ -279,6 +280,7 @@ int main(int argc, char **argv)
         { test_html_find_by_tag, "html find by tag" },
         { test_html_write_to_string, "html write to string" },
         { test_html_find_by_attr, "html find by attr" },
+        { test_html_find_by_selector, "html find by selector" },
         { test_network_send_receive, "network send/receive" },
         { test_network_invalid_ip, "network invalid ip" },
         { test_network_send_uninitialized, "network send uninitialized" },

--- a/Test/test_html.cpp
+++ b/Test/test_html.cpp
@@ -50,3 +50,21 @@ int test_html_find_by_attr(void)
     return (ok);
 }
 
+int test_html_find_by_selector(void)
+{
+    html_node *root = html_create_node("div", ft_nullptr);
+    html_node *child_id = html_create_node("p", ft_nullptr);
+    html_attr *id_attr = html_create_attr("id", "main");
+    html_add_attr(child_id, id_attr);
+    html_add_child(root, child_id);
+    html_node *child_class = html_create_node("span", ft_nullptr);
+    html_attr *class_attr = html_create_attr("class", "highlight");
+    html_add_attr(child_class, class_attr);
+    html_add_child(root, child_class);
+    html_node *found_id = html_find_by_selector(root, "#main");
+    html_node *found_class = html_find_by_selector(root, ".highlight");
+    int ok = (found_id == child_id) && (found_class == child_class);
+    html_free_nodes(root);
+    return (ok);
+}
+


### PR DESCRIPTION
## Summary
- add `html_find_by_selector` to parse tag, id, class and attribute selectors
- expose selector search on `html_document`
- document selector syntax and cover with tests

## Testing
- `make` in `Test`
- `./libft_tests` run all tests (139/139 passed)


------
https://chatgpt.com/codex/tasks/task_e_68c1daeadf008331bf4ff1461c913d1d