### PR TITLE
feat: allow environment override for config

### DIFF
--- a/Config/config.hpp
+++ b/Config/config.hpp
@@ -17,6 +17,12 @@ struct cnfg_config
     size_t           entry_count;
 };
 
+/*
+** cnfg_parse reads a configuration file and fills a cnfg_config
+** structure. For each key, the parser first checks the environment
+** using ft_getenv. If an environment variable with the same key is
+** found, its value overrides the one from the file.
+*/
 cnfg_config   *cnfg_parse(const char *filename);
 void        cnfg_free(cnfg_config *config);
 char       *cnfg_parse_flags(int argument_count, char **argument_values);

--- a/Config/config_parse.cpp
+++ b/Config/config_parse.cpp
@@ -135,12 +135,36 @@ cnfg_config *cnfg_parse(const char *filename)
         else
             entry.section = ft_nullptr;
         entry.key = key;
-        entry.value = value;
+        char *environment_value = ft_nullptr;
+        if (key)
+            environment_value = ft_getenv(key);
+        if (environment_value)
+        {
+            if (value)
+            {
+                cma_free(value);
+                value = ft_nullptr;
+            }
+            entry.value = cma_strdup(environment_value);
+            if (!entry.value)
+            {
+                ft_errno = FT_EALLOC;
+                cma_free(entry.section);
+                cma_free(entry.key);
+                cnfg_free(config);
+                if (current_section)
+                    cma_free(current_section);
+                ft_fclose(file);
+                return (ft_nullptr);
+            }
+        }
+        else
+            entry.value = value;
         if (current_section && !entry.section)
         {
             ft_errno = FT_EALLOC;
             cma_free(key);
-            cma_free(value);
+            cma_free(entry.value);
             cnfg_free(config);
             if (current_section)
                 cma_free(current_section);

--- a/README.md
+++ b/README.md
@@ -628,6 +628,10 @@ char       *cnfg_parse_flags(int argument_count, char **argument_values);
 void       cnfg_free(cnfg_config *config);
 ```
 
+`cnfg_parse` gives precedence to environment variables. Before using a
+value from the file, the parser checks `getenv` with the key name and
+uses the environment value if it exists.
+
 `flag_parser.hpp` wraps flag parsing in a class:
 
 ```

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -177,6 +177,7 @@ int test_ft_promise_set_get(void);
 int test_ft_promise_not_ready(void);
 int test_config_basic(void);
 int test_config_missing_value(void);
+int test_config_env_override(void);
 int test_pt_async_basic(void);
 int test_math_eval_basic(void);
 int test_math_eval_parentheses(void);
@@ -398,6 +399,7 @@ int main(int argc, char **argv)
         { test_ft_promise_not_ready, "ft_promise not ready" },
         { test_config_basic, "config basic" },
         { test_config_missing_value, "config missing value" },
+        { test_config_env_override, "config env override" },
         { test_pt_async_basic, "pt_async basic" },
         { test_math_eval_basic, "math_eval basic" },
         { test_math_eval_parentheses, "math_eval parentheses" },

--- a/Test/test_config.cpp
+++ b/Test/test_config.cpp
@@ -1,5 +1,6 @@
 #include "../Config/config.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Libft/libft.hpp"
 #include <cstdio>
 #include <cstring>
 
@@ -40,5 +41,27 @@ int test_config_missing_value(void)
         cnfg_free(cfg);
     std::remove(filename);
     return (ok);
+}
+
+int test_config_env_override(void)
+{
+    const char *filename = "test_config_env.ini";
+    FILE *file = std::fopen(filename, "w");
+    if (!file)
+        return (0);
+    std::fprintf(file, "key=file\n");
+    std::fclose(file);
+    if (ft_setenv("key", "env", 1) != 0)
+    {
+        std::remove(filename);
+        return (0);
+    }
+    cnfg_config *config = cnfg_parse(filename);
+    int is_ok = config && config->entry_count == 1 &&
+                config->entries[0].value && std::strcmp(config->entries[0].value, "env") == 0;
+    if (config)
+        cnfg_free(config);
+    std::remove(filename);
+    return (is_ok);
 }
 


### PR DESCRIPTION
## Summary
- have `cnfg_parse` prefer environment variables to file entries
- document env precedence in config headers and README
- test config parser environment overrides

## Testing
- `make -C Test`
- `./Test/libft_tests` -> `141/141 tests passed`

------
https://chatgpt.com/codex/tasks/task_e_68c1eb4194c4833189a462feb1c4a59d