### PR TITLE
Add game serialization and persistence

### DIFF
--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -11,6 +11,8 @@
 #include "inventory.hpp"
 #include "experience_table.hpp"
 
+struct json_group;
+
 struct ft_resistance
 {
     int dr_percent;
@@ -156,5 +158,8 @@ class ft_character
         int get_error() const noexcept;
         const char *get_error_str() const noexcept;
 };
+
+json_group *serialize_character(const ft_character &character);
+int deserialize_character(ft_character &character, json_group *group);
 
 #endif

--- a/Game/game_character.cpp
+++ b/Game/game_character.cpp
@@ -1,5 +1,160 @@
 #include "character.hpp"
 #include "../Errno/errno.hpp"
+#include "../JSon/json.hpp"
+#include "../Libft/libft.hpp"
+
+json_group *serialize_character(const ft_character &character)
+{
+    json_group *group = json_create_json_group("character");
+    if (!group)
+        return (ft_nullptr);
+    json_item *item = json_create_item("hit_points", character.get_hit_points());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("armor", character.get_armor());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("might", character.get_might());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("agility", character.get_agility());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("endurance", character.get_endurance());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("reason", character.get_reason());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("insigh", character.get_insigh());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("presence", character.get_presence());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("coins", character.get_coins());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("valor", character.get_valor());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("experience", character.get_experience());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("x", character.get_x());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("y", character.get_y());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    item = json_create_item("z", character.get_z());
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    return (group);
+}
+
+int deserialize_character(ft_character &character, json_group *group)
+{
+    json_item *item = json_find_item(group, "hit_points");
+    if (item)
+        character.set_hit_points(ft_atoi(item->value));
+    item = json_find_item(group, "armor");
+    if (item)
+        character.set_armor(ft_atoi(item->value));
+    item = json_find_item(group, "might");
+    if (item)
+        character.set_might(ft_atoi(item->value));
+    item = json_find_item(group, "agility");
+    if (item)
+        character.set_agility(ft_atoi(item->value));
+    item = json_find_item(group, "endurance");
+    if (item)
+        character.set_endurance(ft_atoi(item->value));
+    item = json_find_item(group, "reason");
+    if (item)
+        character.set_reason(ft_atoi(item->value));
+    item = json_find_item(group, "insigh");
+    if (item)
+        character.set_insigh(ft_atoi(item->value));
+    item = json_find_item(group, "presence");
+    if (item)
+        character.set_presence(ft_atoi(item->value));
+    item = json_find_item(group, "coins");
+    if (item)
+        character.set_coins(ft_atoi(item->value));
+    item = json_find_item(group, "valor");
+    if (item)
+        character.set_valor(ft_atoi(item->value));
+    item = json_find_item(group, "experience");
+    if (item)
+        character.set_experience(ft_atoi(item->value));
+    item = json_find_item(group, "x");
+    if (item)
+        character.set_x(ft_atoi(item->value));
+    item = json_find_item(group, "y");
+    if (item)
+        character.set_y(ft_atoi(item->value));
+    item = json_find_item(group, "z");
+    if (item)
+        character.set_z(ft_atoi(item->value));
+    return (ER_SUCCESS);
+}
 
 ft_character::ft_character() noexcept
     : _hit_points(0), _armor(0), _might(0), _agility(0),

--- a/Game/game_world.cpp
+++ b/Game/game_world.cpp
@@ -1,4 +1,99 @@
 #include "world.hpp"
+#include "character.hpp"
+#include "../JSon/json.hpp"
+#include "../Libft/libft.hpp"
+#include "../CMA/CMA.hpp"
+#include "../CPP_class/class_string_class.hpp"
+
+json_group *serialize_character(const ft_character &character);
+int deserialize_character(ft_character &character, json_group *group);
+
+static json_group *serialize_world(const ft_world &world)
+{
+    json_group *group = json_create_json_group("world");
+    if (!group)
+        return (ft_nullptr);
+    json_item *count_item = json_create_item("event_count", static_cast<int>(world.get_events().size()));
+    if (!count_item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, count_item);
+    size_t index = 0;
+    size_t events_size = world.get_events().size();
+    const Pair<int, ft_event> *start = world.get_events().end() - events_size;
+    while (index < events_size)
+    {
+        char *index_string = cma_itoa(static_cast<int>(index));
+        if (!index_string)
+        {
+            json_free_groups(group);
+            return (ft_nullptr);
+        }
+        ft_string key_id = "event_";
+        key_id += index_string;
+        key_id += "_id";
+        ft_string key_duration = "event_";
+        key_duration += index_string;
+        key_duration += "_duration";
+        cma_free(index_string);
+        json_item *item_id = json_create_item(key_id.c_str(), start[index].value.get_id());
+        if (!item_id)
+        {
+            json_free_groups(group);
+            return (ft_nullptr);
+        }
+        json_item *item_duration = json_create_item(key_duration.c_str(), start[index].value.get_duration());
+        if (!item_duration)
+        {
+            json_free_groups(group);
+            return (ft_nullptr);
+        }
+        json_add_item_to_group(group, item_id);
+        json_add_item_to_group(group, item_duration);
+        index++;
+    }
+    return (group);
+}
+
+static int deserialize_world(ft_world &world, json_group *group)
+{
+    json_item *count_item = json_find_item(group, "event_count");
+    if (!count_item)
+    {
+        ft_errno = GAME_GENERAL_ERROR;
+        return (GAME_GENERAL_ERROR);
+    }
+    int event_count = ft_atoi(count_item->value);
+    int index = 0;
+    while (index < event_count)
+    {
+        char *index_string = cma_itoa(index);
+        if (!index_string)
+            return (JSON_MALLOC_FAIL);
+        ft_string key_id = "event_";
+        key_id += index_string;
+        key_id += "_id";
+        ft_string key_duration = "event_";
+        key_duration += index_string;
+        key_duration += "_duration";
+        cma_free(index_string);
+        json_item *id_item = json_find_item(group, key_id.c_str());
+        json_item *duration_item = json_find_item(group, key_duration.c_str());
+        if (!id_item || !duration_item)
+        {
+            ft_errno = GAME_GENERAL_ERROR;
+            return (GAME_GENERAL_ERROR);
+        }
+        ft_event event;
+        event.set_id(ft_atoi(id_item->value));
+        event.set_duration(ft_atoi(duration_item->value));
+        world.get_events().insert(event.get_id(), event);
+        index++;
+    }
+    return (ER_SUCCESS);
+}
 
 ft_world::ft_world() noexcept
     : _events(), _error(ER_SUCCESS)
@@ -16,6 +111,64 @@ ft_map<int, ft_event> &ft_world::get_events() noexcept
 const ft_map<int, ft_event> &ft_world::get_events() const noexcept
 {
     return (this->_events);
+}
+
+int ft_world::save_game(const char *file_path, const ft_character &character) const noexcept
+{
+    json_group *groups = ft_nullptr;
+    json_group *world_group = serialize_world(*this);
+    if (!world_group)
+    {
+        this->set_error(ft_errno);
+        return (this->_error);
+    }
+    json_append_group(&groups, world_group);
+    json_group *character_group = serialize_character(character);
+    if (!character_group)
+    {
+        json_free_groups(groups);
+        this->set_error(ft_errno);
+        return (this->_error);
+    }
+    json_append_group(&groups, character_group);
+    if (json_write_to_file(file_path, groups) != 0)
+    {
+        json_free_groups(groups);
+        this->set_error(GAME_GENERAL_ERROR);
+        return (this->_error);
+    }
+    json_free_groups(groups);
+    this->set_error(ER_SUCCESS);
+    return (ER_SUCCESS);
+}
+
+int ft_world::load_game(const char *file_path, ft_character &character) noexcept
+{
+    json_group *groups = json_read_from_file(file_path);
+    if (!groups)
+    {
+        this->set_error(GAME_GENERAL_ERROR);
+        return (this->_error);
+    }
+    json_group *world_group = json_find_group(groups, "world");
+    json_group *character_group = json_find_group(groups, "character");
+    if (!world_group || !character_group)
+    {
+        json_free_groups(groups);
+        this->set_error(GAME_GENERAL_ERROR);
+        return (this->_error);
+    }
+    this->_events.clear();
+    if (deserialize_world(*this, world_group) != ER_SUCCESS ||
+        deserialize_character(character, character_group) != ER_SUCCESS)
+    {
+        json_free_groups(groups);
+        this->set_error(ft_errno);
+        return (this->_error);
+    }
+    json_free_groups(groups);
+    this->set_error(ER_SUCCESS);
+    return (ER_SUCCESS);
 }
 
 int ft_world::get_error() const noexcept

--- a/Game/world.hpp
+++ b/Game/world.hpp
@@ -5,6 +5,8 @@
 #include "event.hpp"
 #include "../Errno/errno.hpp"
 
+class ft_character;
+
 class ft_world
 {
     private:
@@ -19,6 +21,9 @@ class ft_world
 
         ft_map<int, ft_event>       &get_events() noexcept;
         const ft_map<int, ft_event> &get_events() const noexcept;
+
+        int save_game(const char *file_path, const ft_character &character) const noexcept;
+        int load_game(const char *file_path, ft_character &character) noexcept;
 
         int get_error() const noexcept;
         const char *get_error_str() const noexcept;

--- a/README.md
+++ b/README.md
@@ -981,6 +981,8 @@ void sub_modifier4(int mod) noexcept;
 ```
 ft_map<int, ft_event>       &get_events() noexcept;
 const ft_map<int, ft_event> &get_events() const noexcept;
+int save_game(const char *file_path, const ft_character &character) const noexcept;
+int load_game(const char *file_path, ft_character &character) noexcept;
 int get_error() const noexcept;
 const char *get_error_str() const noexcept;
 ```

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -163,6 +163,7 @@ int test_inventory_full(void);
 int test_character_valor(void);
 int test_character_add_sub_coins(void);
 int test_character_add_sub_valor(void);
+int test_game_save_load(void);
 int test_buff_subtracters(void);
 int test_debuff_subtracters(void);
 int test_event_subtracters(void);
@@ -385,6 +386,7 @@ int main(int argc, char **argv)
         { test_character_valor, "character valor" },
         { test_character_add_sub_coins, "character coin add/sub" },
         { test_character_add_sub_valor, "character valor add/sub" },
+        { test_game_save_load, "game save/load" },
         { test_buff_subtracters, "buff subtracters" },
         { test_debuff_subtracters, "debuff subtracters" },
         { test_event_subtracters, "event subtracters" },

--- a/Test/test_game.cpp
+++ b/Test/test_game.cpp
@@ -10,6 +10,7 @@
 #include "../Game/event.hpp"
 #include "../Game/inventory.hpp"
 #include "../Errno/errno.hpp"
+#include <cstdio>
 
 int test_game_simulation(void)
 {
@@ -174,6 +175,32 @@ int test_character_add_sub_valor(void)
     hero.add_valor(5);
     hero.sub_valor(2);
     return (hero.get_valor() == 3);
+}
+
+int test_game_save_load(void)
+{
+    ft_character hero;
+    hero.set_hit_points(42);
+    ft_world world;
+    ft_event event;
+    event.set_id(1);
+    event.set_duration(5);
+    world.get_events().insert(event.get_id(), event);
+    if (world.save_game("test_save.json", hero) != ER_SUCCESS)
+        return (0);
+    ft_character loaded_hero;
+    ft_world loaded_world;
+    if (loaded_world.load_game("test_save.json", loaded_hero) != ER_SUCCESS)
+        return (0);
+    Pair<int, ft_event> *event_entry = loaded_world.get_events().find(1);
+    remove("test_save.json");
+    if (!event_entry)
+        return (0);
+    if (event_entry->value.get_duration() != 5)
+        return (0);
+    if (loaded_hero.get_hit_points() != 42)
+        return (0);
+    return (1);
 }
 
 int test_buff_subtracters(void)


### PR DESCRIPTION
## Summary
- implement JSON serialization helpers for characters and the world
- add ft_world::save_game and ft_world::load_game APIs
- exercise save/load with a new test

## Testing
- `make`
- `make -C Test`
- `./Test/libft_tests` run all tests

------
https://chatgpt.com/codex/tasks/task_e_68c25b67c6c8833197f6d884c4487d8a