### PR TITLE
Add monotonic time helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ parser.get_error_str();
 ```
 time_t  time_now(void);
 long    time_now_ms(void);
+long    time_monotonic(void);
 void    time_local(time_t time_value, struct tm *out);
 void    time_sleep(unsigned int seconds);
 void    time_sleep_ms(unsigned int milliseconds);

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -119,6 +119,7 @@ int test_setenv_getenv_basic(void);
 int test_setenv_no_overwrite(void);
 int test_su_get_cpu_count(void);
 int test_su_get_total_memory(void);
+int test_time_monotonic_increases(void);
 int test_ft_string_append(void);
 int test_ft_string_concat(void);
 int test_data_buffer_io(void);
@@ -325,6 +326,7 @@ int main(int argc, char **argv)
         { test_setenv_no_overwrite, "setenv no overwrite" },
         { test_su_get_cpu_count, "su get cpu count" },
         { test_su_get_total_memory, "su get total memory" },
+        { test_time_monotonic_increases, "time_monotonic increases" },
         { test_strlen_size_t_empty, "strlen_size_t empty" },
         { test_bzero_zero, "bzero zero" },
         { test_memcpy_partial, "memcpy partial" },

--- a/Test/test_extra_libft.cpp
+++ b/Test/test_extra_libft.cpp
@@ -3,6 +3,7 @@
 #include "../Libft/limits.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../System_utils/system_utils.hpp"
+#include "../Time/time.hpp"
 #include <cstring>
 #include <string>
 
@@ -361,5 +362,16 @@ int test_su_get_cpu_count(void)
 int test_su_get_total_memory(void)
 {
     return (su_get_total_memory() > 0);
+}
+
+int test_time_monotonic_increases(void)
+{
+    long first_time;
+    long second_time;
+
+    first_time = time_monotonic();
+    time_sleep_ms(1);
+    second_time = time_monotonic();
+    return (second_time >= first_time);
 }
 

--- a/Time/Makefile
+++ b/Time/Makefile
@@ -3,6 +3,7 @@ DEBUG_TARGET   := time_debug.a
 
 SRCS := time_now.cpp \
         time_now_ms.cpp \
+        time_monotonic.cpp \
         time_local.cpp \
         time_sleep.cpp \
         time_sleep_ms.cpp \

--- a/Time/time.hpp
+++ b/Time/time.hpp
@@ -5,6 +5,7 @@
 
 time_t  time_now(void);
 long    time_now_ms(void);
+long    time_monotonic(void);
 void    time_local(time_t time_value, struct tm *out);
 void    time_sleep(unsigned int seconds);
 void    time_sleep_ms(unsigned int milliseconds);

--- a/Time/time_monotonic.cpp
+++ b/Time/time_monotonic.cpp
@@ -1,0 +1,10 @@
+#include "time.hpp"
+#include <chrono>
+
+long    time_monotonic(void)
+{
+    std::chrono::steady_clock::time_point time_now = std::chrono::steady_clock::now();
+    std::chrono::milliseconds milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(time_now.time_since_epoch());
+    return (milliseconds.count());
+}
+


### PR DESCRIPTION
## Summary
- add `time_monotonic` using `std::chrono::steady_clock`
- expose `time_monotonic` in public header and build
- test monotonic behavior and document the helper

## Testing
- `make -C Test`
- `./Test/libft_tests --all`


------
https://chatgpt.com/codex/tasks/task_e_68c265070bfc8331b51725c62531a849