### PR TITLE
Add pthread condition variable wrappers and tests

### DIFF
--- a/PThread/Makefile
+++ b/PThread/Makefile
@@ -16,9 +16,10 @@ SRCS := pthread_lock_mutex.cpp \
         pthread_atomic_load.cpp \
         pthread_atomic_store.cpp \
         pthread_atomic_fetch_add.cpp \
-        pthread_atomic_compare_exchange.cpp
+        pthread_atomic_compare_exchange.cpp \
+        pthread_condition.cpp
 
-HEADERS := pthread.hpp mutex.hpp
+HEADERS := pthread.hpp mutex.hpp condition.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/PThread/condition.hpp
+++ b/PThread/condition.hpp
@@ -1,0 +1,12 @@
+#ifndef CONDITION_HPP
+# define CONDITION_HPP
+
+#include <pthread.h>
+
+int pt_cond_init(pthread_cond_t *condition, const pthread_condattr_t *attributes);
+int pt_cond_destroy(pthread_cond_t *condition);
+int pt_cond_wait(pthread_cond_t *condition, pthread_mutex_t *mutex);
+int pt_cond_signal(pthread_cond_t *condition);
+int pt_cond_broadcast(pthread_cond_t *condition);
+
+#endif

--- a/PThread/pthread.hpp
+++ b/PThread/pthread.hpp
@@ -6,6 +6,7 @@
 #include "../CPP_class/class_nullptr.hpp"
 #include <utility>
 #include <atomic>
+#include "condition.hpp"
 
 int pt_thread_join(pthread_t thread, void **retval);
 int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,

--- a/PThread/pthread_condition.cpp
+++ b/PThread/pthread_condition.cpp
@@ -1,0 +1,45 @@
+#include <cerrno>
+#include <pthread.h>
+#include "condition.hpp"
+#include "../Errno/errno.hpp"
+
+int pt_cond_init(pthread_cond_t *condition, const pthread_condattr_t *attributes)
+{
+    int return_value = pthread_cond_init(condition, attributes);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+
+int pt_cond_destroy(pthread_cond_t *condition)
+{
+    int return_value = pthread_cond_destroy(condition);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+
+int pt_cond_wait(pthread_cond_t *condition, pthread_mutex_t *mutex)
+{
+    int return_value = pthread_cond_wait(condition, mutex);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+
+int pt_cond_signal(pthread_cond_t *condition)
+{
+    int return_value = pthread_cond_signal(condition);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+
+int pt_cond_broadcast(pthread_cond_t *condition)
+{
+    int return_value = pthread_cond_broadcast(condition);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ int pf_snprintf(char *string, size_t size, const char *format, ...);
 
 ### PThread Wrappers
 
-`PThread/pthread.hpp` wraps a few `pthread` calls and provides basic atomic operations.
+`PThread/pthread.hpp` wraps a few `pthread` calls, condition variables, and provides basic atomic operations.
 
 ```
 int pt_thread_join(pthread_t thread, void **retval);
@@ -204,6 +204,11 @@ int pt_atomic_load(const std::atomic<int>& atomic_variable);
 void pt_atomic_store(std::atomic<int>& atomic_variable, int desired_value);
 int pt_atomic_fetch_add(std::atomic<int>& atomic_variable, int increment_value);
 bool pt_atomic_compare_exchange(std::atomic<int>& atomic_variable, int& expected_value, int desired_value);
+int pt_cond_init(pthread_cond_t *condition, const pthread_condattr_t *attributes);
+int pt_cond_destroy(pthread_cond_t *condition);
+int pt_cond_wait(pthread_cond_t *condition, pthread_mutex_t *mutex);
+int pt_cond_signal(pthread_cond_t *condition);
+int pt_cond_broadcast(pthread_cond_t *condition);
 ```
 
 ### C++ Classes (`CPP_class`)

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -181,6 +181,7 @@ int test_config_basic(void);
 int test_config_missing_value(void);
 int test_config_env_override(void);
 int test_pt_async_basic(void);
+int test_pt_cond_wait_signal(void);
 int test_math_eval_basic(void);
 int test_math_eval_parentheses(void);
 int test_math_eval_dice_rejected(void);
@@ -407,6 +408,7 @@ int main(int argc, char **argv)
         { test_config_missing_value, "config missing value" },
         { test_config_env_override, "config env override" },
         { test_pt_async_basic, "pt_async basic" },
+        { test_pt_cond_wait_signal, "pt_cond_wait and pt_cond_signal" },
         { test_math_eval_basic, "math_eval basic" },
         { test_math_eval_parentheses, "math_eval parentheses" },
         { test_math_eval_dice_rejected, "math_eval dice rejected" },


### PR DESCRIPTION
## Summary
- add condition variable wrappers `pt_cond_init`, `pt_cond_destroy`, `pt_cond_wait`, `pt_cond_signal`, and `pt_cond_broadcast`
- expose condition functions through `pthread.hpp` and integrate into build system
- test condition variable signaling with new unit test

## Testing
- `cd Test && make`
- `./libft_tests --all`

------
https://chatgpt.com/codex/tasks/task_e_68c266b440888331933a6c2de28cb21e