### PR TITLE
Add JSON writer and round-trip tests

### DIFF
--- a/JSon/Makefile
+++ b/JSon/Makefile
@@ -4,6 +4,7 @@ DEBUG_TARGET := JSon_debug.a
 SRCS :=         json_parsing.cpp \
                 json_create_item.cpp \
                 json_reader.cpp \
+                json_writer.cpp \
                 json_utils.cpp \
                 json_document.cpp
 

--- a/JSon/json.hpp
+++ b/JSon/json.hpp
@@ -15,6 +15,8 @@ typedef struct json_group
     struct json_group *next;
 } json_group;
 
+class json_document;
+
 json_item    *json_create_item(const char *key, const char *value);
 void         json_add_item_to_group(json_group *group, json_item *item);
 json_group    *json_create_json_group(const char *name);
@@ -23,6 +25,8 @@ json_item    *json_create_item(const char *key, const bool value);
 void         json_append_group(json_group **head, json_group *new_group);
 int         json_write_to_file(const char *filename, json_group *groups);
 char        *json_write_to_string(json_group *groups);
+int         json_document_write_to_file(const char *file_path, const json_document &document);
+char        *json_document_write_to_string(const json_document &document);
 json_group  *json_read_from_file(const char *filename);
 json_group  *json_read_from_string(const char *content);
 void         json_free_items(json_item *item);

--- a/JSon/json_parsing.cpp
+++ b/JSon/json_parsing.cpp
@@ -1,14 +1,6 @@
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <fcntl.h>
-#include <unistd.h>
-#include <cstdarg>
 #include <new>
 #include "json.hpp"
 #include "../Errno/errno.hpp"
-#include "../Printf/printf.hpp"
-#include "../System_utils/system_utils.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../CMA/CMA.hpp"
 
@@ -55,111 +47,6 @@ void json_append_group(json_group **head, json_group *new_group)
         current_group->next = new_group;
     }
     return ;
-}
-
-int json_write_to_file(const char *filename, json_group *groups)
-{
-    int file_descriptor = su_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    if (file_descriptor < 0)
-        return (-1);
-    pf_printf_fd(file_descriptor, "{\n");
-    json_group *group_ptr = groups;
-    while (group_ptr)
-    {
-        pf_printf_fd(file_descriptor, "  \"%s\": {\n", group_ptr->name);
-        json_item *item_ptr = group_ptr->items;
-        while (item_ptr)
-        {
-            if (item_ptr->next)
-                pf_printf_fd(file_descriptor,
-                        "    \"%s\": \"%s\",\n", item_ptr->key, item_ptr->value);
-            else
-                pf_printf_fd(file_descriptor,
-                        "    \"%s\": \"%s\"\n", item_ptr->key, item_ptr->value);
-            item_ptr = item_ptr->next;
-        }
-        if (group_ptr->next)
-            pf_printf_fd(file_descriptor, "  },\n");
-        else
-            pf_printf_fd(file_descriptor, "  }");
-        pf_printf_fd(file_descriptor, "\n");
-        group_ptr = group_ptr->next;
-    }
-    pf_printf_fd(file_descriptor, "}\n");
-    ft_close(file_descriptor);
-    return (0);
-}
-
-char *json_write_to_string(json_group *groups)
-{
-    char *result = cma_strdup("{\n");
-    if (!result)
-        return (ft_nullptr);
-    json_group *group_ptr = groups;
-    while (group_ptr)
-    {
-        char *line = cma_strjoin_multiple(3, "  \"", group_ptr->name, "\": {\n");
-        if (!line)
-        {
-            cma_free(result);
-            return (ft_nullptr);
-        }
-        char *tmp = cma_strjoin(result, line);
-        cma_free(result);
-        cma_free(line);
-        if (!tmp)
-            return (ft_nullptr);
-        result = tmp;
-        json_item *item_ptr = group_ptr->items;
-        while (item_ptr)
-        {
-            if (item_ptr->next)
-                line = cma_strjoin_multiple(5, "    \"", item_ptr->key, "\": \"", item_ptr->value, "\",\n");
-            else
-                line = cma_strjoin_multiple(5, "    \"", item_ptr->key, "\": \"", item_ptr->value, "\"\n");
-            if (!line)
-            {
-                cma_free(result);
-                return (ft_nullptr);
-            }
-            tmp = cma_strjoin(result, line);
-            cma_free(result);
-            cma_free(line);
-            if (!tmp)
-                return (ft_nullptr);
-            result = tmp;
-            item_ptr = item_ptr->next;
-        }
-        if (group_ptr->next)
-            line = cma_strdup("  },\n");
-        else
-            line = cma_strdup("  }\n");
-        if (!line)
-        {
-            cma_free(result);
-            return (ft_nullptr);
-        }
-        tmp = cma_strjoin(result, line);
-        cma_free(result);
-        cma_free(line);
-        if (!tmp)
-            return (ft_nullptr);
-        result = tmp;
-        group_ptr = group_ptr->next;
-    }
-    char *end = cma_strdup("}\n");
-    if (!end)
-    {
-        cma_free(result);
-        return (ft_nullptr);
-    }
-    char *tmp = cma_strjoin(result, end);
-    cma_free(result);
-    cma_free(end);
-    if (!tmp)
-        return (ft_nullptr);
-    result = tmp;
-    return (result);
 }
 
 void json_free_items(json_item *item)

--- a/JSon/json_writer.cpp
+++ b/JSon/json_writer.cpp
@@ -1,0 +1,126 @@
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include <new>
+#include "json.hpp"
+#include "document.hpp"
+#include "../Printf/printf.hpp"
+#include "../System_utils/system_utils.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../CMA/CMA.hpp"
+
+int json_write_to_file(const char *file_path, json_group *groups)
+{
+    int file_descriptor = su_open(file_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (file_descriptor < 0)
+        return (-1);
+    pf_printf_fd(file_descriptor, "{\n");
+    json_group *group_iterator = groups;
+    while (group_iterator)
+    {
+        pf_printf_fd(file_descriptor, "  \"%s\": {\n", group_iterator->name);
+        json_item *item_iterator = group_iterator->items;
+        while (item_iterator)
+        {
+            if (item_iterator->next)
+                pf_printf_fd(file_descriptor,
+                        "    \"%s\": \"%s\",\n", item_iterator->key, item_iterator->value);
+            else
+                pf_printf_fd(file_descriptor,
+                        "    \"%s\": \"%s\"\n", item_iterator->key, item_iterator->value);
+            item_iterator = item_iterator->next;
+        }
+        if (group_iterator->next)
+            pf_printf_fd(file_descriptor, "  },\n");
+        else
+            pf_printf_fd(file_descriptor, "  }\n");
+        group_iterator = group_iterator->next;
+    }
+    pf_printf_fd(file_descriptor, "}\n");
+    ft_close(file_descriptor);
+    return (0);
+}
+
+char *json_write_to_string(json_group *groups)
+{
+    char *result = cma_strdup("{\n");
+    if (!result)
+        return (ft_nullptr);
+    json_group *group_iterator = groups;
+    while (group_iterator)
+    {
+        char *line = cma_strjoin_multiple(3, "  \"", group_iterator->name, "\": {\n");
+        if (!line)
+        {
+            cma_free(result);
+            return (ft_nullptr);
+        }
+        char *temporary = cma_strjoin(result, line);
+        cma_free(result);
+        cma_free(line);
+        if (!temporary)
+            return (ft_nullptr);
+        result = temporary;
+        json_item *item_iterator = group_iterator->items;
+        while (item_iterator)
+        {
+            if (item_iterator->next)
+                line = cma_strjoin_multiple(5, "    \"", item_iterator->key, "\": \"", item_iterator->value, "\",\n");
+            else
+                line = cma_strjoin_multiple(5, "    \"", item_iterator->key, "\": \"", item_iterator->value, "\"\n");
+            if (!line)
+            {
+                cma_free(result);
+                return (ft_nullptr);
+            }
+            temporary = cma_strjoin(result, line);
+            cma_free(result);
+            cma_free(line);
+            if (!temporary)
+                return (ft_nullptr);
+            result = temporary;
+            item_iterator = item_iterator->next;
+        }
+        if (group_iterator->next)
+            line = cma_strdup("  },\n");
+        else
+            line = cma_strdup("  }\n");
+        if (!line)
+        {
+            cma_free(result);
+            return (ft_nullptr);
+        }
+        temporary = cma_strjoin(result, line);
+        cma_free(result);
+        cma_free(line);
+        if (!temporary)
+            return (ft_nullptr);
+        result = temporary;
+        group_iterator = group_iterator->next;
+    }
+    char *end_line = cma_strdup("}\n");
+    if (!end_line)
+    {
+        cma_free(result);
+        return (ft_nullptr);
+    }
+    char *temporary = cma_strjoin(result, end_line);
+    cma_free(result);
+    cma_free(end_line);
+    if (!temporary)
+        return (ft_nullptr);
+    result = temporary;
+    return (result);
+}
+
+int json_document_write_to_file(const char *file_path, const json_document &document)
+{
+    return (document.write_to_file(file_path));
+}
+
+char *json_document_write_to_string(const json_document &document)
+{
+    return (document.write_to_string());
+}
+

--- a/README.md
+++ b/README.md
@@ -586,6 +586,8 @@ json_group  *json_create_json_group(const char *name);
 void         json_add_item_to_group(json_group *group, json_item *item);
 int          json_write_to_file(const char *filename, json_group *groups);
 char        *json_write_to_string(json_group *groups);
+int          json_document_write_to_file(const char *file_path, const json_document &document);
+char        *json_document_write_to_string(const json_document &document);
 json_group  *json_read_from_file(const char *filename);
 json_group  *json_read_from_string(const char *content);
 json_group  *json_find_group(json_group *head, const char *name);

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -187,6 +187,8 @@ int test_math_eval_parentheses(void);
 int test_math_eval_dice_rejected(void);
 int test_rng_random_normal(void);
 int test_rng_random_exponential(void);
+int test_json_roundtrip_string(void);
+int test_json_roundtrip_file(void);
 
 int test_efficiency_strlen(void);
 int test_efficiency_memcpy(void);
@@ -413,7 +415,9 @@ int main(int argc, char **argv)
         { test_math_eval_parentheses, "math_eval parentheses" },
         { test_math_eval_dice_rejected, "math_eval dice rejected" },
         { test_rng_random_normal, "rng random normal" },
-        { test_rng_random_exponential, "rng random exponential" }
+        { test_rng_random_exponential, "rng random exponential" },
+        { test_json_roundtrip_string, "json roundtrip string" },
+        { test_json_roundtrip_file, "json roundtrip file" }
     };
 
     const s_perf_test perf_tests[] = {

--- a/Test/test_template.cpp
+++ b/Test/test_template.cpp
@@ -3,7 +3,10 @@
 #include "../Template/shared_ptr.hpp"
 #include "../Template/unique_ptr.hpp"
 #include "../Errno/errno.hpp"
+#include "../JSon/document.hpp"
+#include "../CMA/CMA.hpp"
 #include <cstring>
+#include <cstdio>
 #include <vector>
 
 int test_ft_vector_push_back(void)
@@ -223,6 +226,55 @@ int test_ft_unique_ptr_swap(void)
     ft_uniqueptr<int> b(new int(2));
     a.swap(b);
     return (*a == 2 && *b == 1);
+}
+
+int test_json_roundtrip_string(void)
+{
+    json_document document_one;
+    json_group *group = document_one.create_group("group");
+    json_item *item = document_one.create_item("key", "value");
+    document_one.add_item(group, item);
+    document_one.append_group(group);
+    char *output = document_one.write_to_string();
+    if (!output)
+        return (0);
+    json_document document_two;
+    if (document_two.read_from_string(output) != 0)
+    {
+        cma_free(output);
+        return (0);
+    }
+    cma_free(output);
+    json_group *group_two = document_two.find_group("group");
+    if (!group_two)
+        return (0);
+    json_item *item_two = document_two.find_item(group_two, "key");
+    if (!item_two)
+        return (0);
+    return (std::strcmp(item_two->value, "value") == 0);
+}
+
+int test_json_roundtrip_file(void)
+{
+    const char *file_path = "Test_roundtrip.json";
+    json_document document_one;
+    json_group *group = document_one.create_group("group");
+    json_item *item = document_one.create_item("key", "value");
+    document_one.add_item(group, item);
+    document_one.append_group(group);
+    if (document_one.write_to_file(file_path) != 0)
+        return (0);
+    json_document document_two;
+    if (document_two.read_from_file(file_path) != 0)
+        return (0);
+    std::remove(file_path);
+    json_group *group_two = document_two.find_group("group");
+    if (!group_two)
+        return (0);
+    json_item *item_two = document_two.find_item(group_two, "key");
+    if (!item_two)
+        return (0);
+    return (std::strcmp(item_two->value, "value") == 0);
 }
 
 


### PR DESCRIPTION
## Summary
- implement json_document serialization in new `json_writer.cpp`
- expose json_document writer helpers in `json.hpp` and README
- add JSON round-trip tests for string and file outputs

## Testing
- `cd Test && make`
- `./libft_tests --all`

------
https://chatgpt.com/codex/tasks/task_e_68c268a6115883318cb375c406ae023e