### PR TITLE
Add configurable thread safety to CMA

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -32,6 +32,7 @@ char    *cma_strtrim(const char *string, const char *set)
 void    cma_free_double(char **content);
 void    cma_cleanup();
 void    cma_set_alloc_limit(std::size_t limit);
+void    cma_set_thread_safety(bool enable);
 void    cma_get_stats(std::size_t *allocation_count, std::size_t *free_count);
 
 template <int total_argument_count, typename... argument_types>

--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -20,7 +20,8 @@ SRCS := cma_calloc.cpp \
         cma_utils.cpp \
         cma_cleanup.cpp \
         cma_global_overloads.cpp \
-        cma_set_alloc_limit.cpp
+        cma_set_alloc_limit.cpp \
+        cma_set_thread_safety.cpp
 
 HEADERS := CMA.hpp \
            cma_internal.hpp

--- a/CMA/cma_alloc_size.cpp
+++ b/CMA/cma_alloc_size.cpp
@@ -6,9 +6,18 @@ std::size_t cma_alloc_size(const void *ptr)
 {
     if (!ptr)
         return (0);
+    if (g_cma_thread_safe)
+        g_malloc_mutex.lock(THREAD_ID);
     const Block *block = reinterpret_cast<const Block*>(
         static_cast<const char*>(ptr) - sizeof(Block));
     if (block->magic != MAGIC_NUMBER)
+    {
+        if (g_cma_thread_safe)
+            g_malloc_mutex.unlock(THREAD_ID);
         return (0);
-    return (block->size);
+    }
+    std::size_t result = block->size;
+    if (g_cma_thread_safe)
+        g_malloc_mutex.unlock(THREAD_ID);
+    return (result);
 }

--- a/CMA/cma_cleanup.cpp
+++ b/CMA/cma_cleanup.cpp
@@ -12,6 +12,8 @@ void cma_cleanup()
         pf_printf("calling cleanup\n");
     if (OFFSWITCH)
         return ;
+    if (g_cma_thread_safe)
+        g_malloc_mutex.lock(THREAD_ID);
     Page* current_page = page_list;
     while (current_page)
     {
@@ -28,5 +30,7 @@ void cma_cleanup()
         current_page = next_page;
     }
     page_list = ft_nullptr;
+    if (g_cma_thread_safe)
+        g_malloc_mutex.unlock(THREAD_ID);
     return ;
 }

--- a/CMA/cma_free_checked.cpp
+++ b/CMA/cma_free_checked.cpp
@@ -14,7 +14,8 @@ int cma_checked_free(void* ptr)
     }
     if (!ptr)
         return (0);
-    g_malloc_mutex.lock(THREAD_ID);
+    if (g_cma_thread_safe)
+        g_malloc_mutex.lock(THREAD_ID);
     Page* page = page_list;
     Block* found = ft_nullptr;
     while (page && !found)
@@ -36,7 +37,8 @@ int cma_checked_free(void* ptr)
     }
     if (!found)
     {
-        g_malloc_mutex.unlock(THREAD_ID);
+        if (g_cma_thread_safe)
+            g_malloc_mutex.unlock(THREAD_ID);
         ft_errno = CMA_INVALID_PTR;
         return (-1);
     }
@@ -44,6 +46,7 @@ int cma_checked_free(void* ptr)
     found = merge_block(found);
     Page *pg = find_page_of_block(found);
     free_page_if_empty(pg);
-    g_malloc_mutex.unlock(THREAD_ID);
+    if (g_cma_thread_safe)
+        g_malloc_mutex.unlock(THREAD_ID);
     return (0);
 }

--- a/CMA/cma_internal.hpp
+++ b/CMA/cma_internal.hpp
@@ -33,6 +33,7 @@
 #endif
 
 extern pt_mutex g_malloc_mutex;
+extern bool g_cma_thread_safe;
 extern std::size_t    g_cma_alloc_limit;
 extern std::size_t    g_cma_allocation_count;
 extern std::size_t    g_cma_free_count;

--- a/CMA/cma_malloc.cpp
+++ b/CMA/cma_malloc.cpp
@@ -26,7 +26,8 @@ void* cma_malloc(std::size_t size)
         return (ft_nullptr);
     if (g_cma_alloc_limit != 0 && size > g_cma_alloc_limit)
         return (ft_nullptr);
-    g_malloc_mutex.lock(THREAD_ID);
+    if (g_cma_thread_safe)
+        g_malloc_mutex.lock(THREAD_ID);
     size_t aligned_size = align16(size);
     Block *block = find_free_block(aligned_size);
     if (!block)
@@ -34,7 +35,8 @@ void* cma_malloc(std::size_t size)
         Page* page = create_page(aligned_size);
         if (!page)
         {
-            g_malloc_mutex.unlock(THREAD_ID);
+            if (g_cma_thread_safe)
+                g_malloc_mutex.unlock(THREAD_ID);
             return (ft_nullptr);
         }
         block = page->blocks;
@@ -43,7 +45,8 @@ void* cma_malloc(std::size_t size)
     block->free = false;
     g_cma_allocation_count++;
     void *result = reinterpret_cast<char*>(block) + sizeof(Block);
-    g_malloc_mutex.unlock(THREAD_ID);
+    if (g_cma_thread_safe)
+        g_malloc_mutex.unlock(THREAD_ID);
     if (ft_log_get_alloc_logging())
         ft_log_debug("cma_malloc %zu -> %p", aligned_size, result);
     return (result);

--- a/CMA/cma_set_alloc_limit.cpp
+++ b/CMA/cma_set_alloc_limit.cpp
@@ -4,6 +4,10 @@
 
 void    cma_set_alloc_limit(std::size_t limit)
 {
+    if (g_cma_thread_safe)
+        g_malloc_mutex.lock(THREAD_ID);
     g_cma_alloc_limit = limit;
+    if (g_cma_thread_safe)
+        g_malloc_mutex.unlock(THREAD_ID);
     return ;
 }

--- a/CMA/cma_set_thread_safety.cpp
+++ b/CMA/cma_set_thread_safety.cpp
@@ -1,0 +1,9 @@
+#include "CMA.hpp"
+#include "cma_internal.hpp"
+
+void    cma_set_thread_safety(bool enable)
+{
+    g_cma_thread_safe = enable;
+    return ;
+}
+

--- a/CMA/cma_utils.cpp
+++ b/CMA/cma_utils.cpp
@@ -12,6 +12,7 @@
 
 Page *page_list = ft_nullptr;
 pt_mutex g_malloc_mutex;
+bool g_cma_thread_safe = true;
 std::size_t    g_cma_alloc_limit = 0;
 std::size_t    g_cma_allocation_count = 0;
 std::size_t    g_cma_free_count = 0;
@@ -247,9 +248,13 @@ void print_block_info(Block *block)
 
 void cma_get_stats(std::size_t *allocation_count, std::size_t *free_count)
 {
+    if (g_cma_thread_safe)
+        g_malloc_mutex.lock(THREAD_ID);
     if (allocation_count != ft_nullptr)
         *allocation_count = g_cma_allocation_count;
     if (free_count != ft_nullptr)
         *free_count = g_cma_free_count;
+    if (g_cma_thread_safe)
+        g_malloc_mutex.unlock(THREAD_ID);
     return ;
 }

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ changed at runtime with `cma_set_alloc_limit`. A limit of `0` disables the
 check. The allocator also tracks allocation and free counts, accessible
 through `cma_get_stats`. Internally, `cma_realloc` has been simplified by
 removing redundant braces.
+Thread safety can be enabled or disabled with `cma_set_thread_safety`.
 
 ```
 void   *cma_malloc(std::size_t size);
@@ -160,6 +161,7 @@ char   *cma_strtrim(const char *s1, const char *set);
 void    cma_free_double(char **content);
 void    cma_cleanup();
 void    cma_set_alloc_limit(std::size_t limit);
+void    cma_set_thread_safety(bool enable);
 void    cma_get_stats(std::size_t *allocation_count, std::size_t *free_count);
 ```
 

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -159,6 +159,7 @@ int test_cma_checked_free_basic(void);
 int test_cma_checked_free_offset(void);
 int test_cma_checked_free_invalid(void);
 int test_cma_thread_local(void);
+int test_cma_thread_alloc(void);
 int test_game_simulation(void);
 int test_item_basic(void);
 int test_inventory_count(void);
@@ -390,6 +391,7 @@ int main(int argc, char **argv)
         { test_cma_checked_free_offset, "cma_checked_free offset" },
         { test_cma_checked_free_invalid, "cma_checked_free invalid" },
         { test_cma_thread_local, "cma thread_local" },
+        { test_cma_thread_alloc, "cma thread_alloc" },
         { test_game_simulation, "game simulation" },
         { test_item_basic, "item basic" },
         { test_inventory_count, "inventory count" },


### PR DESCRIPTION
## Summary
- Add global thread safety flag and setter to CMA
- Guard allocator operations with optional mutex locking
- Test concurrent CMA allocations across threads

## Testing
- `make`
- `make -C Test`
- `./Test/libft_tests --all`


------
https://chatgpt.com/codex/tasks/task_e_68c27baa07748331a7e9c75abdfc881f