### PR TITLE
refactor: use thread local errno

### DIFF
--- a/Errno/errno.hpp
+++ b/Errno/errno.hpp
@@ -1,8 +1,7 @@
 #ifndef ERRNO_HPP
 # define ERRNO_HPP
 
-extern thread_local int _error_code;
-#define ft_errno _error_code
+extern thread_local int ft_errno;
 
 #define ERRNO_OFFSET 2000
 

--- a/Errno/errno_code.cpp
+++ b/Errno/errno_code.cpp
@@ -1,3 +1,3 @@
 #include "errno.hpp"
 
-thread_local int _error_code = ER_SUCCESS;
+thread_local int ft_errno = ER_SUCCESS;

--- a/Errno/errno_exit.cpp
+++ b/Errno/errno_exit.cpp
@@ -4,12 +4,13 @@
 
 void    ft_exit(const char *error_msg, int exit_code)
 {
-    if (error_msg && _error_code != ER_SUCCESS)
-        pf_printf_fd(2, "%s: %s\n", error_msg, ft_strerror(_error_code));
+    if (error_msg && ft_errno != ER_SUCCESS)
+        pf_printf_fd(2, "%s: %s\n", error_msg, ft_strerror(ft_errno));
     else if (error_msg)
         pf_printf_fd(2, "%s\n", error_msg);
-    else if (_error_code != ER_SUCCESS)
-        pf_printf_fd(2, "%s\n", ft_strerror(_error_code));
+    else if (ft_errno != ER_SUCCESS)
+        pf_printf_fd(2, "%s\n", ft_strerror(ft_errno));
     std::exit(exit_code);
+    return ;
 }
 

--- a/Errno/errno_perror.cpp
+++ b/Errno/errno_perror.cpp
@@ -4,8 +4,8 @@
 void    ft_perror(const char *error_msg)
 {
     if (!error_msg)
-        pf_printf_fd(2, "%s", ft_strerror(_error_code));
+        pf_printf_fd(2, "%s", ft_strerror(ft_errno));
     else
-        pf_printf_fd(2, "%s: %s", error_msg, ft_strerror(_error_code));
+        pf_printf_fd(2, "%s: %s", error_msg, ft_strerror(ft_errno));
     return ;
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This document briefly lists the main headers and the interfaces they expose. The
 summaries below only outline the available functions and classes. See the header
 files for detailed information.
 
-All classes report errors through a mutable `_error_code` member with `get_error` and `get_error_str` accessors so `const` methods can update the error state.
+All classes report errors through a mutable `_error_code` member with `get_error` and `get_error_str` accessors so `const` methods can update the error state. A thread-local `ft_errno` variable mirrors the last error for cross-module access.
 
 ## Building
 
@@ -517,7 +517,7 @@ int get_error() const;
 
 `Template/promise.hpp` implements a minimal promise type for passing values
 between threads. A promise stores a value set by a worker thread and reports
-errors through the shared `ft_errno` system.
+errors through the thread-local `ft_errno` system.
 
 ```
 ft_promise();
@@ -533,7 +533,7 @@ const char *get_error_str() const;
 
 
 #### Errno
-`Errno/errno.hpp` defines a thread-local `_error_code` accessed through the `ft_errno` macro and helpers for retrieving messages.
+`Errno/errno.hpp` defines a thread-local `ft_errno` variable and helpers for retrieving messages.
 
 ```
 const char *ft_strerror(int err);


### PR DESCRIPTION
## Summary
- replace macro-based ft_errno with real thread-local variable
- update errno helpers and documentation for thread-local error handling

## Testing
- `make -C Errno`
- `make -C Test`
- `./Test/libft_tests` *(interactive; requires input)*

------
https://chatgpt.com/codex/tasks/task_e_68c280c990488331b3be8802fce72015