### PR TITLE
Use OS entropy for encryption key generation

### DIFF
--- a/Encryption/README
+++ b/Encryption/README
@@ -1,0 +1,11 @@
+# Encryption
+
+## Security Rationale
+
+`be_getEncryptionKey` reads entropy from the operating system to avoid
+predictable keys. On Unix systems the function pulls random bytes from
+`/dev/urandom`; on Windows it uses `CryptGenRandom`. If these sources are
+unavailable, it falls back to `ft_random_seed` to preserve variability.
+Mapping bytes to alphabetic characters maintains compatibility with the
+existing interface while ensuring keys differ across runs.
+

--- a/Encryption/encryption_key.cpp
+++ b/Encryption/encryption_key.cpp
@@ -1,42 +1,16 @@
-#include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <fcntl.h>
+#ifndef _WIN32
+# include <unistd.h>
+#else
+# include <windows.h>
+# include <wincrypt.h>
+#endif
+#include "../RNG/rng.hpp"
 #include "../CMA/CMA.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "basic_encryption.hpp"
-
-static void decoy_unusedFunction1(void)
-{
-    volatile int dummy = 0;
-    int index = 0;
-    while (index < 10)
-    {
-        dummy += index;
-        ++index;
-    }
-    return ;
-}
-
-static uint32_t decoy_unusedFunction2(uint32_t value)
-{
-    value ^= 0xAAAAAAAA;
-    value ^= 0xAAAAAAAA;
-    return (value);
-}
-
-static int decoy_unusedFunction3(const char* input_string)
-{
-    (void)input_string;
-    return (42);
-}
-
-static uint32_t obfuscate_seed(uint32_t seed_value)
-{
-    decoy_unusedFunction1();
-    seed_value = decoy_unusedFunction2(seed_value);
-    return (seed_value);
-}
 
 const char *be_getEncryptionKey(void)
 {
@@ -44,17 +18,57 @@ const char *be_getEncryptionKey(void)
     char *key = static_cast<char *>(cma_malloc(key_length + 1));
     if (!key)
         return (ft_nullptr);
-    uint32_t seed_value = 0xDEADBEEF;
-    seed_value = obfuscate_seed(seed_value);
+
+#ifdef _WIN32
+    HCRYPTPROV crypto_provider;
+    if (CryptAcquireContext(&crypto_provider, ft_nullptr, ft_nullptr,
+            PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+    {
+        if (CryptGenRandom(crypto_provider, static_cast<DWORD>(key_length),
+                reinterpret_cast<BYTE *>(key)))
+        {
+            CryptReleaseContext(crypto_provider, 0);
+            size_t index = 0;
+            while (index < key_length)
+            {
+                key[index] = static_cast<char>('A'
+                    + (static_cast<unsigned char>(key[index]) % 26));
+                index++;
+            }
+            key[key_length] = '\0';
+            return (key);
+        }
+        CryptReleaseContext(crypto_provider, 0);
+    }
+#else
+    int file_descriptor = open("/dev/urandom", O_RDONLY);
+    if (file_descriptor != -1)
+    {
+        ssize_t read_result = read(file_descriptor, key, key_length);
+        close(file_descriptor);
+        if (read_result == static_cast<ssize_t>(key_length))
+        {
+            size_t index = 0;
+            while (index < key_length)
+            {
+                key[index] = static_cast<char>('A'
+                    + (static_cast<unsigned char>(key[index]) % 26));
+                index++;
+            }
+            key[key_length] = '\0';
+            return (key);
+        }
+    }
+#endif
+    unsigned int seed_value = static_cast<unsigned int>(ft_random_seed(ft_nullptr));
     size_t index = 0;
     while (index < key_length)
     {
-        decoy_unusedFunction3(key);
-        seed_value = seed_value * 1103515245 + 12345;
-        key[index] = static_cast<char>('A' + (seed_value % 26));
-        ++index;
+        seed_value = seed_value * 1103515245u + 12345u;
+        key[index] = static_cast<char>('A' + (seed_value % 26u));
+        index++;
     }
     key[key_length] = '\0';
-    decoy_unusedFunction1();
     return (key);
 }
+

--- a/README.md
+++ b/README.md
@@ -581,6 +581,10 @@ void        aes_encrypt(uint8_t *block, const uint8_t *key);
 void        aes_decrypt(uint8_t *block, const uint8_t *key);
 ```
 
+`be_getEncryptionKey` sources entropy from `/dev/urandom` on Unix or
+`CryptGenRandom` on Windows with a fallback to `ft_random_seed`, ensuring
+that generated keys vary across runs.
+
 Example:
 
 ```

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -27,7 +27,7 @@ SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp 
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \
        test_cpp_class.cpp test_template.cpp test_printf.cpp test_get_next_line.cpp \
        test_cma.cpp test_game.cpp test_queue.cpp test_queue_class.cpp \
-       test_promise.cpp test_config.cpp test_math_eval.cpp test_rng.cpp $(EFF_SRCS)
+       test_promise.cpp test_config.cpp test_math_eval.cpp test_encryption_key.cpp test_rng.cpp $(EFF_SRCS)
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -188,6 +188,7 @@ int test_pt_cond_wait_signal(void);
 int test_math_eval_basic(void);
 int test_math_eval_parentheses(void);
 int test_math_eval_dice_rejected(void);
+int test_encryption_key_random(void);
 int test_rng_random_normal(void);
 int test_rng_random_exponential(void);
 int test_json_roundtrip_string(void);
@@ -420,6 +421,7 @@ int main(int argc, char **argv)
         { test_math_eval_basic, "math_eval basic" },
         { test_math_eval_parentheses, "math_eval parentheses" },
         { test_math_eval_dice_rejected, "math_eval dice rejected" },
+        { test_encryption_key_random, "encryption key random" },
         { test_rng_random_normal, "rng random normal" },
         { test_rng_random_exponential, "rng random exponential" },
         { test_json_roundtrip_string, "json roundtrip string" },

--- a/Test/test_encryption_key.cpp
+++ b/Test/test_encryption_key.cpp
@@ -1,0 +1,23 @@
+#include "../Encryption/basic_encryption.hpp"
+#include "../CMA/CMA.hpp"
+#include <cstring>
+
+int test_encryption_key_random(void)
+{
+    const char *first_key = be_getEncryptionKey();
+    if (!first_key)
+        return (0);
+    const char *second_key = be_getEncryptionKey();
+    if (!second_key)
+    {
+        cma_free(const_cast<char *>(first_key));
+        return (0);
+    }
+    int result = 1;
+    if (std::strcmp(first_key, second_key) == 0)
+        result = 0;
+    cma_free(const_cast<char *>(first_key));
+    cma_free(const_cast<char *>(second_key));
+    return (result);
+}
+


### PR DESCRIPTION
## Summary
- Replace predictable LCG in `be_getEncryptionKey` with `/dev/urandom` or `CryptGenRandom` and fallback to `ft_random_seed`
- Document security rationale for using OS entropy
- Add unit test verifying distinct keys across calls

## Testing
- `cd Test && make`
- `./libft_tests --all`


------
https://chatgpt.com/codex/tasks/task_e_68c28628cc3083318d4afed5ea5bc1bb