### PR TITLE
Add simple HTML query selector and tests

### DIFF
--- a/HTML/html_search.cpp
+++ b/HTML/html_search.cpp
@@ -109,3 +109,14 @@ html_node *html_find_by_selector(html_node *node_list, const char *selector)
     }
     return (html_find_by_tag(node_list, selector));
 }
+
+html_node *html_query_selector(html_node *node_list, const char *selector)
+{
+    if (!selector)
+        return (ft_nullptr);
+    if (selector[0] == '#')
+        return (html_find_by_attr(node_list, "id", selector + 1));
+    if (selector[0] == '.')
+        return (html_find_by_attr(node_list, "class", selector + 1));
+    return (html_find_by_tag(node_list, selector));
+}

--- a/HTML/parser.hpp
+++ b/HTML/parser.hpp
@@ -35,6 +35,12 @@ html_node   *html_find_by_tag(html_node *nodeList, const char *tagName);
 html_node   *html_find_by_attr(html_node *nodeList, const char *key, const char *value);
 html_node   *html_find_by_text(html_node *nodeList, const char *textContent);
 html_node   *html_find_by_selector(html_node *node_list, const char *selector);
+/*
+ * Search node_list for the first element that matches a simple selector.
+ * Supports tag names, .class, and #id selectors. Combinators are not
+ * implemented.
+ */
+html_node   *html_query_selector(html_node *node_list, const char *selector);
 size_t      html_count_nodes_by_tag(html_node *nodeList, const char *tagName);
 
 #endif

--- a/README.md
+++ b/README.md
@@ -834,6 +834,7 @@ void       html_add_attr(html_node *targetNode, html_attr *newAttribute);
 html_node *html_find_by_tag(html_node *nodeList, const char *tagName);
 html_node *html_find_by_attr(html_node *nodeList, const char *key, const char *value);
 html_node *html_find_by_selector(html_node *nodeList, const char *selector);
+html_node *html_query_selector(html_node *nodeList, const char *selector);
 ```
 
 The `html_document` class wraps these helpers and manages a root node list:
@@ -855,6 +856,15 @@ Simple selectors allow searching by:
 "[key=value]"     - attribute key equals value
 "[key]"           - presence of attribute key
 ```
+
+Example:
+
+```
+html_node *highlight = html_query_selector(root, ".highlight");
+```
+
+`html_query_selector` supports only tag names, `.class`, and `#id` selectors.
+Combinators like descendant or child selectors are not implemented.
 
 #### Game
 Basic game related classes include `ft_character`, `ft_item`, `ft_inventory`,

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -61,6 +61,7 @@ int test_html_find_by_tag(void);
 int test_html_write_to_string(void);
 int test_html_find_by_attr(void);
 int test_html_find_by_selector(void);
+int test_html_query_selector(void);
 int test_network_send_receive(void);
 int test_network_invalid_ip(void);
 int test_network_send_uninitialized(void);
@@ -294,6 +295,7 @@ int main(int argc, char **argv)
         { test_html_write_to_string, "html write to string" },
         { test_html_find_by_attr, "html find by attr" },
         { test_html_find_by_selector, "html find by selector" },
+        { test_html_query_selector, "html query selector" },
         { test_network_send_receive, "network send/receive" },
         { test_network_invalid_ip, "network invalid ip" },
         { test_network_send_uninitialized, "network send uninitialized" },

--- a/Test/test_html.cpp
+++ b/Test/test_html.cpp
@@ -68,3 +68,24 @@ int test_html_find_by_selector(void)
     return (ok);
 }
 
+int test_html_query_selector(void)
+{
+    html_node *root = html_create_node("div", ft_nullptr);
+    html_node *child_tag = html_create_node("p", ft_nullptr);
+    html_node *child_class = html_create_node("span", ft_nullptr);
+    html_attr *class_attr = html_create_attr("class", "note");
+    html_add_attr(child_class, class_attr);
+    html_node *child_id = html_create_node("a", ft_nullptr);
+    html_attr *id_attr = html_create_attr("id", "link");
+    html_add_attr(child_id, id_attr);
+    html_add_child(root, child_tag);
+    html_add_child(root, child_class);
+    html_add_child(root, child_id);
+    html_node *found_tag = html_query_selector(root, "p");
+    html_node *found_class = html_query_selector(root, ".note");
+    html_node *found_id = html_query_selector(root, "#link");
+    int is_ok = (found_tag == child_tag) && (found_class == child_class) && (found_id == child_id);
+    html_free_nodes(root);
+    return (is_ok);
+}
+


### PR DESCRIPTION
## Summary
- add `html_query_selector` for basic tag, class, and id lookups
- document selector usage and limitations
- test query selector and note lack of combinators in README

## Testing
- `make -C Test`
- `./Test/libft_tests --all`

------
https://chatgpt.com/codex/tasks/task_e_68c28928ffec8331ab6fa077eff2057b