### PR TITLE
Add minimal JSON schema validation

### DIFF
--- a/JSon/Makefile
+++ b/JSon/Makefile
@@ -6,7 +6,8 @@ SRCS :=         json_parsing.cpp \
                 json_reader.cpp \
                 json_writer.cpp \
                 json_utils.cpp \
-                json_document.cpp
+                json_document.cpp \
+                json_validate.cpp
 
 HEADERS := json.hpp document.hpp
 

--- a/JSon/json.hpp
+++ b/JSon/json.hpp
@@ -39,4 +39,26 @@ void        json_update_item(json_group *group, const char *key, const char *val
 void        json_update_item(json_group *group, const char *key, const int value);
 void        json_update_item(json_group *group, const char *key, const bool value);
 
+typedef enum json_type
+{
+    JSON_STRING,
+    JSON_NUMBER,
+    JSON_BOOL
+} json_type;
+
+typedef struct json_schema_field
+{
+    const char *key;
+    json_type   type;
+    bool        required;
+    struct json_schema_field *next;
+} json_schema_field;
+
+typedef struct json_schema
+{
+    json_schema_field *fields;
+} json_schema;
+
+bool        json_validate(json_group *group, const json_schema &schema);
+
 #endif

--- a/JSon/json_validate.cpp
+++ b/JSon/json_validate.cpp
@@ -1,0 +1,58 @@
+#include "json.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+static bool json_is_number(const char *string)
+{
+    if (!string || !(*string))
+        return (false);
+    char *end_pointer = ft_nullptr;
+    ft_strtol(string, &end_pointer, 10);
+    if (end_pointer == string)
+        return (false);
+    if (end_pointer && *end_pointer == '\0')
+        return (true);
+    return (false);
+}
+
+static bool json_is_bool(const char *string)
+{
+    if (ft_strcmp(string, "true") == 0)
+        return (true);
+    if (ft_strcmp(string, "false") == 0)
+        return (true);
+    return (false);
+}
+
+bool json_validate(json_group *group, const json_schema &schema)
+{
+    if (!group)
+        return (false);
+    json_schema_field *field = schema.fields;
+    while (field)
+    {
+        json_item *item = json_find_item(group, field->key);
+        if (!item)
+        {
+            if (field->required == true)
+                return (false);
+            field = field->next;
+            continue;
+        }
+        if (field->type == JSON_NUMBER)
+        {
+            if (json_is_number(item->value) == false)
+                return (false);
+        }
+        else
+        {
+            if (field->type == JSON_BOOL)
+            {
+                if (json_is_bool(item->value) == false)
+                    return (false);
+            }
+        }
+        field = field->next;
+    }
+    return (true);
+}

--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ void         json_remove_item(json_group *group, const char *key);
 void         json_update_item(json_group *group, const char *key, const char *value);
 void         json_update_item(json_group *group, const char *key, const int value);
 void         json_update_item(json_group *group, const char *key, const bool value);
+bool         json_validate(json_group *group, const json_schema &schema);
 ```
 
 The `json_document` class wraps these helpers and manages a group list:
@@ -623,6 +624,36 @@ json_document();
 ~json_document();
 void         append_group(json_group *group) noexcept;
 json_group   *find_group(const char *name) const noexcept;
+```
+
+Schemas describe expected fields and types:
+
+```
+typedef enum json_type
+{
+    JSON_STRING,
+    JSON_NUMBER,
+    JSON_BOOL
+} json_type;
+
+typedef struct json_schema_field
+{
+    const char *key;
+    json_type   type;
+    bool        required;
+    json_schema_field *next;
+} json_schema_field;
+
+typedef struct json_schema
+{
+    json_schema_field *fields;
+} json_schema;
+
+json_schema_field name_field = { "name", JSON_STRING, true, ft_nullptr };
+json_schema_field age_field = { "age", JSON_NUMBER, true, ft_nullptr };
+name_field.next = &age_field;
+json_schema schema = { &name_field };
+bool valid = json_validate(group, schema);
 ```
 
 #### File

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -27,7 +27,8 @@ SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp 
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \
        test_cpp_class.cpp test_template.cpp test_printf.cpp test_get_next_line.cpp \
        test_cma.cpp test_game.cpp test_queue.cpp test_queue_class.cpp \
-       test_promise.cpp test_config.cpp test_math_eval.cpp test_encryption_key.cpp test_rng.cpp $(EFF_SRCS)
+       test_promise.cpp test_config.cpp test_math_eval.cpp test_encryption_key.cpp \
+       test_rng.cpp test_json_validate.cpp $(EFF_SRCS)
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -194,6 +194,8 @@ int test_rng_random_normal(void);
 int test_rng_random_exponential(void);
 int test_json_roundtrip_string(void);
 int test_json_roundtrip_file(void);
+int test_json_validate_success(void);
+int test_json_validate_missing_field(void);
 
 int test_efficiency_strlen(void);
 int test_efficiency_memcpy(void);
@@ -427,7 +429,9 @@ int main(int argc, char **argv)
         { test_rng_random_normal, "rng random normal" },
         { test_rng_random_exponential, "rng random exponential" },
         { test_json_roundtrip_string, "json roundtrip string" },
-        { test_json_roundtrip_file, "json roundtrip file" }
+        { test_json_roundtrip_file, "json roundtrip file" },
+        { test_json_validate_success, "json validate success" },
+        { test_json_validate_missing_field, "json validate missing field" }
     };
 
     const s_perf_test perf_tests[] = {

--- a/Test/test_json_validate.cpp
+++ b/Test/test_json_validate.cpp
@@ -1,0 +1,55 @@
+#include "../JSon/json.hpp"
+#include "../JSon/document.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+int test_json_validate_success(void)
+{
+    json_document document;
+    json_group *group = document.create_group("user");
+    json_item *item_name = document.create_item("name", "Alice");
+    json_item *item_age = document.create_item("age", 30);
+    document.add_item(group, item_name);
+    document.add_item(group, item_age);
+    document.append_group(group);
+    json_schema_field name_field;
+    name_field.key = "name";
+    name_field.type = JSON_STRING;
+    name_field.required = true;
+    name_field.next = ft_nullptr;
+    json_schema_field age_field;
+    age_field.key = "age";
+    age_field.type = JSON_NUMBER;
+    age_field.required = true;
+    age_field.next = ft_nullptr;
+    name_field.next = &age_field;
+    json_schema schema;
+    schema.fields = &name_field;
+    if (json_validate(group, schema) == true)
+        return (1);
+    return (0);
+}
+
+int test_json_validate_missing_field(void)
+{
+    json_document document;
+    json_group *group = document.create_group("user");
+    json_item *item_name = document.create_item("name", "Alice");
+    document.add_item(group, item_name);
+    document.append_group(group);
+    json_schema_field name_field;
+    name_field.key = "name";
+    name_field.type = JSON_STRING;
+    name_field.required = true;
+    name_field.next = ft_nullptr;
+    json_schema_field age_field;
+    age_field.key = "age";
+    age_field.type = JSON_NUMBER;
+    age_field.required = true;
+    age_field.next = ft_nullptr;
+    name_field.next = &age_field;
+    json_schema schema;
+    schema.fields = &name_field;
+    if (json_validate(group, schema) == false)
+        return (1);
+    return (0);
+}


### PR DESCRIPTION
## Summary
- define simple JSON schema structures and validation API
- implement `json_validate` for type and required field checks
- document schema usage and add validation unit tests

## Testing
- `make -C JSon`
- `make -C Test` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c28b3b030c833187419f461af0c80d