### PR TITLE
Add asynchronous logging with background queue

### DIFF
--- a/Logger/Makefile
+++ b/Logger/Makefile
@@ -45,7 +45,7 @@ DEBUG_OBJDIR   := objs_debug
 OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
 DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
 
-CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17 -pthread
 
 all: $(TARGET)
 

--- a/Logger/logger.hpp
+++ b/Logger/logger.hpp
@@ -29,6 +29,8 @@ void ft_log_debug(const char *fmt, ...);
 void ft_log_info(const char *fmt, ...);
 void ft_log_warn(const char *fmt, ...);
 void ft_log_error(const char *fmt, ...);
+void ft_log_start_async();
+void ft_log_stop_async();
 
 class ft_logger
 {

--- a/Logger/logger_internal.hpp
+++ b/Logger/logger_internal.hpp
@@ -9,6 +9,7 @@
 
 extern ft_logger *g_logger;
 extern t_log_level g_level;
+extern bool g_async_running;
 
 typedef void (*t_log_sink)(const char *message, void *user_data);
 
@@ -31,5 +32,6 @@ void ft_log_rotate(s_file_sink *sink);
 void ft_file_sink(const char *message, void *user_data);
 const char *ft_level_to_str(t_log_level level);
 void ft_log_vwrite(t_log_level level, const char *fmt, va_list args);
+void ft_log_enqueue(t_log_level level, const char *fmt, va_list args);
 
 #endif

--- a/Logger/logger_log_debug.cpp
+++ b/Logger/logger_log_debug.cpp
@@ -4,6 +4,9 @@ void ft_log_debug(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    ft_log_vwrite(LOG_LEVEL_DEBUG, fmt, args);
+    if (g_async_running)
+        ft_log_enqueue(LOG_LEVEL_DEBUG, fmt, args);
+    else
+        ft_log_vwrite(LOG_LEVEL_DEBUG, fmt, args);
     va_end(args);
 }

--- a/Logger/logger_log_error.cpp
+++ b/Logger/logger_log_error.cpp
@@ -4,6 +4,9 @@ void ft_log_error(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    ft_log_vwrite(LOG_LEVEL_ERROR, fmt, args);
+    if (g_async_running)
+        ft_log_enqueue(LOG_LEVEL_ERROR, fmt, args);
+    else
+        ft_log_vwrite(LOG_LEVEL_ERROR, fmt, args);
     va_end(args);
 }

--- a/Logger/logger_log_info.cpp
+++ b/Logger/logger_log_info.cpp
@@ -4,6 +4,9 @@ void ft_log_info(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    ft_log_vwrite(LOG_LEVEL_INFO, fmt, args);
+    if (g_async_running)
+        ft_log_enqueue(LOG_LEVEL_INFO, fmt, args);
+    else
+        ft_log_vwrite(LOG_LEVEL_INFO, fmt, args);
     va_end(args);
 }

--- a/Logger/logger_log_warn.cpp
+++ b/Logger/logger_log_warn.cpp
@@ -4,6 +4,9 @@ void ft_log_warn(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    ft_log_vwrite(LOG_LEVEL_WARN, fmt, args);
+    if (g_async_running)
+        ft_log_enqueue(LOG_LEVEL_WARN, fmt, args);
+    else
+        ft_log_vwrite(LOG_LEVEL_WARN, fmt, args);
     va_end(args);
 }

--- a/Logger/logger_logger.cpp
+++ b/Logger/logger_logger.cpp
@@ -1,7 +1,119 @@
 #include "logger_internal.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <string>
+#include <ctime>
+#include <cstdio>
+#include <unistd.h>
 
 ft_logger *g_logger = ft_nullptr;
+bool g_async_running = false;
+static std::queue<std::string> g_log_queue;
+static std::mutex g_queue_mutex;
+static std::condition_variable g_queue_cv;
+static std::thread g_log_thread;
+
+static void ft_log_process_message(const std::string &message)
+{
+    if (g_sinks.empty())
+    {
+        ssize_t write_result;
+
+        write_result = write(1, message.c_str(), message.size());
+        (void)write_result;
+    }
+    else
+    {
+        size_t index;
+
+        index = 0;
+        while (index < g_sinks.size())
+        {
+            g_sinks[index].function(message.c_str(), g_sinks[index].user_data);
+            if (g_sinks[index].function == ft_file_sink)
+                ft_log_rotate(static_cast<s_file_sink *>(g_sinks[index].user_data));
+            index++;
+        }
+    }
+    return ;
+}
+
+static void ft_log_worker()
+{
+    std::unique_lock<std::mutex> queue_lock(g_queue_mutex);
+    while (g_async_running || !g_log_queue.empty())
+    {
+        if (g_log_queue.empty())
+            g_queue_cv.wait(queue_lock);
+        else
+        {
+            std::string message;
+
+            message = g_log_queue.front();
+            g_log_queue.pop();
+            queue_lock.unlock();
+            ft_log_process_message(message);
+            queue_lock.lock();
+        }
+    }
+    return ;
+}
+
+void ft_log_start_async()
+{
+    if (g_async_running)
+        return ;
+    g_async_running = true;
+    g_log_thread = std::thread(ft_log_worker);
+    return ;
+}
+
+void ft_log_stop_async()
+{
+    if (!g_async_running)
+        return ;
+    {
+        std::lock_guard<std::mutex> lock_guard(g_queue_mutex);
+        g_async_running = false;
+    }
+    g_queue_cv.notify_one();
+    if (g_log_thread.joinable())
+        g_log_thread.join();
+    return ;
+}
+
+void ft_log_enqueue(t_log_level level, const char *fmt, va_list args)
+{
+    if (level < g_level || !fmt)
+        return ;
+    char message_buffer[1024];
+    std::vsnprintf(message_buffer, sizeof(message_buffer), fmt, args);
+
+    char time_buffer[32];
+    std::time_t current_time;
+    std::tm time_info;
+
+    current_time = std::time(NULL);
+#if defined(_WIN32) || defined(_WIN64)
+    localtime_s(&time_info, &current_time);
+#else
+    localtime_r(&current_time, &time_info);
+#endif
+    std::strftime(time_buffer, sizeof(time_buffer), "%Y-%m-%d %H:%M:%S", &time_info);
+
+    char final_buffer[1200];
+    std::snprintf(final_buffer, sizeof(final_buffer), "[%s] [%s] %s\n", time_buffer, ft_level_to_str(level), message_buffer);
+
+    {
+        std::lock_guard<std::mutex> lock_guard(g_queue_mutex);
+        g_log_queue.push(final_buffer);
+    }
+    g_queue_cv.notify_one();
+    return ;
+}
 
 ft_logger::ft_logger(const char *path, size_t max_size, t_log_level level) noexcept
     : _alloc_logging(false), _api_logging(false)
@@ -73,7 +185,10 @@ void ft_logger::debug(const char *fmt, ...) noexcept
 {
     va_list args;
     va_start(args, fmt);
-    ft_log_vwrite(LOG_LEVEL_DEBUG, fmt, args);
+    if (g_async_running)
+        ft_log_enqueue(LOG_LEVEL_DEBUG, fmt, args);
+    else
+        ft_log_vwrite(LOG_LEVEL_DEBUG, fmt, args);
     va_end(args);
 }
 
@@ -81,7 +196,10 @@ void ft_logger::info(const char *fmt, ...) noexcept
 {
     va_list args;
     va_start(args, fmt);
-    ft_log_vwrite(LOG_LEVEL_INFO, fmt, args);
+    if (g_async_running)
+        ft_log_enqueue(LOG_LEVEL_INFO, fmt, args);
+    else
+        ft_log_vwrite(LOG_LEVEL_INFO, fmt, args);
     va_end(args);
 }
 
@@ -89,7 +207,10 @@ void ft_logger::warn(const char *fmt, ...) noexcept
 {
     va_list args;
     va_start(args, fmt);
-    ft_log_vwrite(LOG_LEVEL_WARN, fmt, args);
+    if (g_async_running)
+        ft_log_enqueue(LOG_LEVEL_WARN, fmt, args);
+    else
+        ft_log_vwrite(LOG_LEVEL_WARN, fmt, args);
     va_end(args);
 }
 
@@ -97,7 +218,10 @@ void ft_logger::error(const char *fmt, ...) noexcept
 {
     va_list args;
     va_start(args, fmt);
-    ft_log_vwrite(LOG_LEVEL_ERROR, fmt, args);
+    if (g_async_running)
+        ft_log_enqueue(LOG_LEVEL_ERROR, fmt, args);
+    else
+        ft_log_vwrite(LOG_LEVEL_ERROR, fmt, args);
     va_end(args);
 }
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,12 @@ int         join_multicast_group(const SocketConfig &config);
 and optional file rotation. Logs are written to one or more configurable
 destinations (sinks) and filtered according to the active log level.
 
+An asynchronous mode is available via `ft_log_start_async()` and
+`ft_log_stop_async()`. This uses a background thread that pulls messages from a
+thread-safe queue. While it can reduce latency in performance-critical paths,
+it introduces synchronization overhead and requires a stop call to flush
+pending messages.
+
 ```
 enum t_log_level {
     LOG_LEVEL_DEBUG,


### PR DESCRIPTION
## Summary
- introduce background logging thread pulling from thread-safe queue
- add start/stop async logging API and enqueue in existing log helpers
- document performance considerations for async logging

## Testing
- `make -C Logger`


------
https://chatgpt.com/codex/tasks/task_e_68c29212887c833196d2958b19c63d02