### PR TITLE
Add JSON save/load for game state

### DIFF
--- a/Game/Makefile
+++ b/Game/Makefile
@@ -2,7 +2,7 @@ TARGET := Game.a
 DEBUG_TARGET := Game_debug.a
 
 SRCS := game_map3d.cpp game_character.cpp game_quest.cpp game_achievement.cpp game_reputation.cpp game_buff.cpp game_debuff.cpp \
-game_upgrade.cpp game_event.cpp game_world.cpp game_item.cpp game_inventory.cpp \
+game_upgrade.cpp game_event.cpp game_world.cpp game_item.cpp game_inventory.cpp game_save.cpp game_load.cpp \
 game_experience_table.cpp
 
 HEADERS := map3d.hpp character.hpp quest.hpp achievement.hpp reputation.hpp buff.hpp debuff.hpp \

--- a/Game/README
+++ b/Game/README
@@ -1,0 +1,13 @@
+# Game Module
+
+The `ft_world` class can persist game state using JSON files.
+
+```
+ft_world world;
+ft_character character;
+ft_inventory inventory;
+world.save_to_file("save.json", character, inventory);
+world.load_from_file("save.json", character, inventory);
+```
+
+Both helpers use the JSon module to read and write the `world`, `character`, and `inventory` groups.

--- a/Game/game_load.cpp
+++ b/Game/game_load.cpp
@@ -1,0 +1,158 @@
+#include "world.hpp"
+#include "character.hpp"
+#include "inventory.hpp"
+#include "item.hpp"
+#include "../JSon/json.hpp"
+#include "../Libft/libft.hpp"
+#include "../CMA/CMA.hpp"
+#include "../CPP_class/class_string_class.hpp"
+
+int deserialize_character(ft_character &character, json_group *group);
+
+static int parse_item_field(json_group *group, const ft_string &key, int &out_value)
+{
+    json_item *json_item_ptr = json_find_item(group, key.c_str());
+    if (!json_item_ptr)
+    {
+        ft_errno = GAME_GENERAL_ERROR;
+        return (GAME_GENERAL_ERROR);
+    }
+    out_value = ft_atoi(json_item_ptr->value);
+    return (ER_SUCCESS);
+}
+
+int deserialize_world(ft_world &world, json_group *group)
+{
+    json_item *count_item = json_find_item(group, "event_count");
+    if (!count_item)
+    {
+        ft_errno = GAME_GENERAL_ERROR;
+        return (GAME_GENERAL_ERROR);
+    }
+    int event_count = ft_atoi(count_item->value);
+    int event_index = 0;
+    while (event_index < event_count)
+    {
+        char *event_index_string = cma_itoa(event_index);
+        if (!event_index_string)
+            return (JSON_MALLOC_FAIL);
+        ft_string key_id = "event_";
+        key_id += event_index_string;
+        key_id += "_id";
+        ft_string key_duration = "event_";
+        key_duration += event_index_string;
+        key_duration += "_duration";
+        cma_free(event_index_string);
+        json_item *id_item = json_find_item(group, key_id.c_str());
+        json_item *duration_item = json_find_item(group, key_duration.c_str());
+        if (!id_item || !duration_item)
+        {
+            ft_errno = GAME_GENERAL_ERROR;
+            return (GAME_GENERAL_ERROR);
+        }
+        ft_event event;
+        event.set_id(ft_atoi(id_item->value));
+        event.set_duration(ft_atoi(duration_item->value));
+        world.get_events().insert(event.get_id(), event);
+        event_index++;
+    }
+    return (ER_SUCCESS);
+}
+
+static int build_item_from_group(ft_item &item, json_group *group, const ft_string &item_prefix)
+{
+    int value;
+    ft_string key_max = item_prefix;
+    key_max += "_max_stack";
+    if (parse_item_field(group, key_max, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_max_stack(value);
+    ft_string key_current = item_prefix;
+    key_current += "_current_stack";
+    if (parse_item_field(group, key_current, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_current_stack(value);
+    ft_string key_id = item_prefix;
+    key_id += "_id";
+    if (parse_item_field(group, key_id, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_item_id(value);
+    ft_string key_mod1_id = item_prefix;
+    key_mod1_id += "_mod1_id";
+    if (parse_item_field(group, key_mod1_id, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_modifier1_id(value);
+    ft_string key_mod1_value = item_prefix;
+    key_mod1_value += "_mod1_value";
+    if (parse_item_field(group, key_mod1_value, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_modifier1_value(value);
+    ft_string key_mod2_id = item_prefix;
+    key_mod2_id += "_mod2_id";
+    if (parse_item_field(group, key_mod2_id, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_modifier2_id(value);
+    ft_string key_mod2_value = item_prefix;
+    key_mod2_value += "_mod2_value";
+    if (parse_item_field(group, key_mod2_value, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_modifier2_value(value);
+    ft_string key_mod3_id = item_prefix;
+    key_mod3_id += "_mod3_id";
+    if (parse_item_field(group, key_mod3_id, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_modifier3_id(value);
+    ft_string key_mod3_value = item_prefix;
+    key_mod3_value += "_mod3_value";
+    if (parse_item_field(group, key_mod3_value, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_modifier3_value(value);
+    ft_string key_mod4_id = item_prefix;
+    key_mod4_id += "_mod4_id";
+    if (parse_item_field(group, key_mod4_id, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_modifier4_id(value);
+    ft_string key_mod4_value = item_prefix;
+    key_mod4_value += "_mod4_value";
+    if (parse_item_field(group, key_mod4_value, value) != ER_SUCCESS)
+        return (GAME_GENERAL_ERROR);
+    item.set_modifier4_value(value);
+    return (ER_SUCCESS);
+}
+
+int deserialize_inventory(ft_inventory &inventory, json_group *group)
+{
+    json_item *capacity_item = json_find_item(group, "capacity");
+    if (!capacity_item)
+    {
+        ft_errno = GAME_GENERAL_ERROR;
+        return (GAME_GENERAL_ERROR);
+    }
+    inventory.resize(ft_atoi(capacity_item->value));
+    inventory.get_items().clear();
+    json_item *count_item = json_find_item(group, "item_count");
+    if (!count_item)
+    {
+        ft_errno = GAME_GENERAL_ERROR;
+        return (GAME_GENERAL_ERROR);
+    }
+    int item_count = ft_atoi(count_item->value);
+    int item_index = 0;
+    while (item_index < item_count)
+    {
+        char *item_index_string = cma_itoa(item_index);
+        if (!item_index_string)
+            return (JSON_MALLOC_FAIL);
+        ft_string item_prefix = "item_";
+        item_prefix += item_index_string;
+        cma_free(item_index_string);
+        ft_item item;
+        if (build_item_from_group(item, group, item_prefix) != ER_SUCCESS)
+            return (GAME_GENERAL_ERROR);
+        if (inventory.add_item(item) != ER_SUCCESS)
+            return (inventory.get_error());
+        item_index++;
+    }
+    return (ER_SUCCESS);
+}
+

--- a/Game/game_save.cpp
+++ b/Game/game_save.cpp
@@ -1,0 +1,150 @@
+#include "world.hpp"
+#include "character.hpp"
+#include "inventory.hpp"
+#include "item.hpp"
+#include "../JSon/json.hpp"
+#include "../Libft/libft.hpp"
+#include "../CMA/CMA.hpp"
+#include "../CPP_class/class_string_class.hpp"
+
+json_group *serialize_character(const ft_character &character);
+
+static int add_item_field(json_group *group, const ft_string &key, int value)
+{
+    json_item *json_item_ptr = json_create_item(key.c_str(), value);
+    if (!json_item_ptr)
+    {
+        json_free_groups(group);
+        return (JSON_MALLOC_FAIL);
+    }
+    json_add_item_to_group(group, json_item_ptr);
+    return (ER_SUCCESS);
+}
+
+json_group *serialize_world(const ft_world &world)
+{
+    json_group *group = json_create_json_group("world");
+    if (!group)
+        return (ft_nullptr);
+    json_item *count_item = json_create_item("event_count", static_cast<int>(world.get_events().size()));
+    if (!count_item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, count_item);
+    size_t event_index = 0;
+    size_t event_count = world.get_events().size();
+    const Pair<int, ft_event> *event_start = world.get_events().end() - event_count;
+    while (event_index < event_count)
+    {
+        char *event_index_string = cma_itoa(static_cast<int>(event_index));
+        if (!event_index_string)
+        {
+            json_free_groups(group);
+            return (ft_nullptr);
+        }
+        ft_string key_id = "event_";
+        key_id += event_index_string;
+        key_id += "_id";
+        ft_string key_duration = "event_";
+        key_duration += event_index_string;
+        key_duration += "_duration";
+        cma_free(event_index_string);
+        if (add_item_field(group, key_id, event_start[event_index].value.get_id()) != ER_SUCCESS ||
+            add_item_field(group, key_duration, event_start[event_index].value.get_duration()) != ER_SUCCESS)
+            return (ft_nullptr);
+        event_index++;
+    }
+    return (group);
+}
+
+static int serialize_item_fields(json_group *group, const ft_item &item, const ft_string &item_prefix)
+{
+    ft_string key_max = item_prefix;
+    key_max += "_max_stack";
+    if (add_item_field(group, key_max, item.get_max_stack()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_current = item_prefix;
+    key_current += "_current_stack";
+    if (add_item_field(group, key_current, item.get_current_stack()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_id = item_prefix;
+    key_id += "_id";
+    if (add_item_field(group, key_id, item.get_item_id()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_mod1_id = item_prefix;
+    key_mod1_id += "_mod1_id";
+    if (add_item_field(group, key_mod1_id, item.get_modifier1_id()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_mod1_value = item_prefix;
+    key_mod1_value += "_mod1_value";
+    if (add_item_field(group, key_mod1_value, item.get_modifier1_value()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_mod2_id = item_prefix;
+    key_mod2_id += "_mod2_id";
+    if (add_item_field(group, key_mod2_id, item.get_modifier2_id()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_mod2_value = item_prefix;
+    key_mod2_value += "_mod2_value";
+    if (add_item_field(group, key_mod2_value, item.get_modifier2_value()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_mod3_id = item_prefix;
+    key_mod3_id += "_mod3_id";
+    if (add_item_field(group, key_mod3_id, item.get_modifier3_id()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_mod3_value = item_prefix;
+    key_mod3_value += "_mod3_value";
+    if (add_item_field(group, key_mod3_value, item.get_modifier3_value()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_mod4_id = item_prefix;
+    key_mod4_id += "_mod4_id";
+    if (add_item_field(group, key_mod4_id, item.get_modifier4_id()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    ft_string key_mod4_value = item_prefix;
+    key_mod4_value += "_mod4_value";
+    if (add_item_field(group, key_mod4_value, item.get_modifier4_value()) != ER_SUCCESS)
+        return (JSON_MALLOC_FAIL);
+    return (ER_SUCCESS);
+}
+
+json_group *serialize_inventory(const ft_inventory &inventory)
+{
+    json_group *group = json_create_json_group("inventory");
+    if (!group)
+        return (ft_nullptr);
+    json_item *capacity_item = json_create_item("capacity", static_cast<int>(inventory.get_capacity()));
+    if (!capacity_item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, capacity_item);
+    size_t item_count = inventory.get_items().size();
+    json_item *count_item = json_create_item("item_count", static_cast<int>(item_count));
+    if (!count_item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, count_item);
+    size_t item_index = 0;
+    const Pair<int, ft_item> *item_start = inventory.get_items().end() - item_count;
+    while (item_index < item_count)
+    {
+        char *item_index_string = cma_itoa(static_cast<int>(item_index));
+        if (!item_index_string)
+        {
+            json_free_groups(group);
+            return (ft_nullptr);
+        }
+        ft_string item_prefix = "item_";
+        item_prefix += item_index_string;
+        cma_free(item_index_string);
+        if (serialize_item_fields(group, item_start[item_index].value, item_prefix) != ER_SUCCESS)
+            return (ft_nullptr);
+        item_index++;
+    }
+    return (group);
+}
+

--- a/Game/game_world.cpp
+++ b/Game/game_world.cpp
@@ -1,5 +1,6 @@
 #include "world.hpp"
 #include "character.hpp"
+#include "inventory.hpp"
 #include "../JSon/json.hpp"
 #include "../Libft/libft.hpp"
 #include "../CMA/CMA.hpp"
@@ -7,93 +8,10 @@
 
 json_group *serialize_character(const ft_character &character);
 int deserialize_character(ft_character &character, json_group *group);
-
-static json_group *serialize_world(const ft_world &world)
-{
-    json_group *group = json_create_json_group("world");
-    if (!group)
-        return (ft_nullptr);
-    json_item *count_item = json_create_item("event_count", static_cast<int>(world.get_events().size()));
-    if (!count_item)
-    {
-        json_free_groups(group);
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, count_item);
-    size_t index = 0;
-    size_t events_size = world.get_events().size();
-    const Pair<int, ft_event> *start = world.get_events().end() - events_size;
-    while (index < events_size)
-    {
-        char *index_string = cma_itoa(static_cast<int>(index));
-        if (!index_string)
-        {
-            json_free_groups(group);
-            return (ft_nullptr);
-        }
-        ft_string key_id = "event_";
-        key_id += index_string;
-        key_id += "_id";
-        ft_string key_duration = "event_";
-        key_duration += index_string;
-        key_duration += "_duration";
-        cma_free(index_string);
-        json_item *item_id = json_create_item(key_id.c_str(), start[index].value.get_id());
-        if (!item_id)
-        {
-            json_free_groups(group);
-            return (ft_nullptr);
-        }
-        json_item *item_duration = json_create_item(key_duration.c_str(), start[index].value.get_duration());
-        if (!item_duration)
-        {
-            json_free_groups(group);
-            return (ft_nullptr);
-        }
-        json_add_item_to_group(group, item_id);
-        json_add_item_to_group(group, item_duration);
-        index++;
-    }
-    return (group);
-}
-
-static int deserialize_world(ft_world &world, json_group *group)
-{
-    json_item *count_item = json_find_item(group, "event_count");
-    if (!count_item)
-    {
-        ft_errno = GAME_GENERAL_ERROR;
-        return (GAME_GENERAL_ERROR);
-    }
-    int event_count = ft_atoi(count_item->value);
-    int index = 0;
-    while (index < event_count)
-    {
-        char *index_string = cma_itoa(index);
-        if (!index_string)
-            return (JSON_MALLOC_FAIL);
-        ft_string key_id = "event_";
-        key_id += index_string;
-        key_id += "_id";
-        ft_string key_duration = "event_";
-        key_duration += index_string;
-        key_duration += "_duration";
-        cma_free(index_string);
-        json_item *id_item = json_find_item(group, key_id.c_str());
-        json_item *duration_item = json_find_item(group, key_duration.c_str());
-        if (!id_item || !duration_item)
-        {
-            ft_errno = GAME_GENERAL_ERROR;
-            return (GAME_GENERAL_ERROR);
-        }
-        ft_event event;
-        event.set_id(ft_atoi(id_item->value));
-        event.set_duration(ft_atoi(duration_item->value));
-        world.get_events().insert(event.get_id(), event);
-        index++;
-    }
-    return (ER_SUCCESS);
-}
+json_group *serialize_world(const ft_world &world);
+int deserialize_world(ft_world &world, json_group *group);
+json_group *serialize_inventory(const ft_inventory &inventory);
+int deserialize_inventory(ft_inventory &inventory, json_group *group);
 
 ft_world::ft_world() noexcept
     : _events(), _error(ER_SUCCESS)
@@ -113,7 +31,7 @@ const ft_map<int, ft_event> &ft_world::get_events() const noexcept
     return (this->_events);
 }
 
-int ft_world::save_game(const char *file_path, const ft_character &character) const noexcept
+int ft_world::save_to_file(const char *file_path, const ft_character &character, const ft_inventory &inventory) const noexcept
 {
     json_group *groups = ft_nullptr;
     json_group *world_group = serialize_world(*this);
@@ -131,6 +49,14 @@ int ft_world::save_game(const char *file_path, const ft_character &character) co
         return (this->_error);
     }
     json_append_group(&groups, character_group);
+    json_group *inventory_group = serialize_inventory(inventory);
+    if (!inventory_group)
+    {
+        json_free_groups(groups);
+        this->set_error(ft_errno);
+        return (this->_error);
+    }
+    json_append_group(&groups, inventory_group);
     if (json_write_to_file(file_path, groups) != 0)
     {
         json_free_groups(groups);
@@ -142,7 +68,7 @@ int ft_world::save_game(const char *file_path, const ft_character &character) co
     return (ER_SUCCESS);
 }
 
-int ft_world::load_game(const char *file_path, ft_character &character) noexcept
+int ft_world::load_from_file(const char *file_path, ft_character &character, ft_inventory &inventory) noexcept
 {
     json_group *groups = json_read_from_file(file_path);
     if (!groups)
@@ -152,15 +78,18 @@ int ft_world::load_game(const char *file_path, ft_character &character) noexcept
     }
     json_group *world_group = json_find_group(groups, "world");
     json_group *character_group = json_find_group(groups, "character");
-    if (!world_group || !character_group)
+    json_group *inventory_group = json_find_group(groups, "inventory");
+    if (!world_group || !character_group || !inventory_group)
     {
         json_free_groups(groups);
         this->set_error(GAME_GENERAL_ERROR);
         return (this->_error);
     }
     this->_events.clear();
+    inventory.get_items().clear();
     if (deserialize_world(*this, world_group) != ER_SUCCESS ||
-        deserialize_character(character, character_group) != ER_SUCCESS)
+        deserialize_character(character, character_group) != ER_SUCCESS ||
+        deserialize_inventory(inventory, inventory_group) != ER_SUCCESS)
     {
         json_free_groups(groups);
         this->set_error(ft_errno);

--- a/Game/world.hpp
+++ b/Game/world.hpp
@@ -6,6 +6,7 @@
 #include "../Errno/errno.hpp"
 
 class ft_character;
+class ft_inventory;
 
 class ft_world
 {
@@ -22,8 +23,8 @@ class ft_world
         ft_map<int, ft_event>       &get_events() noexcept;
         const ft_map<int, ft_event> &get_events() const noexcept;
 
-        int save_game(const char *file_path, const ft_character &character) const noexcept;
-        int load_game(const char *file_path, ft_character &character) noexcept;
+        int save_to_file(const char *file_path, const ft_character &character, const ft_inventory &inventory) const noexcept;
+        int load_from_file(const char *file_path, ft_character &character, ft_inventory &inventory) noexcept;
 
         int get_error() const noexcept;
         const char *get_error_str() const noexcept;

--- a/README.md
+++ b/README.md
@@ -1082,8 +1082,8 @@ void sub_modifier4(int mod) noexcept;
 ```
 ft_map<int, ft_event>       &get_events() noexcept;
 const ft_map<int, ft_event> &get_events() const noexcept;
-int save_game(const char *file_path, const ft_character &character) const noexcept;
-int load_game(const char *file_path, ft_character &character) noexcept;
+int save_to_file(const char *file_path, const ft_character &character, const ft_inventory &inventory) const noexcept;
+int load_from_file(const char *file_path, ft_character &character, ft_inventory &inventory) noexcept;
 int get_error() const noexcept;
 const char *get_error_str() const noexcept;
 ```

--- a/Test/test_game.cpp
+++ b/Test/test_game.cpp
@@ -186,11 +186,13 @@ int test_game_save_load(void)
     event.set_id(1);
     event.set_duration(5);
     world.get_events().insert(event.get_id(), event);
-    if (world.save_game("test_save.json", hero) != ER_SUCCESS)
+    ft_inventory inventory;
+    if (world.save_to_file("test_save.json", hero, inventory) != ER_SUCCESS)
         return (0);
     ft_character loaded_hero;
     ft_world loaded_world;
-    if (loaded_world.load_game("test_save.json", loaded_hero) != ER_SUCCESS)
+    ft_inventory loaded_inventory;
+    if (loaded_world.load_from_file("test_save.json", loaded_hero, loaded_inventory) != ER_SUCCESS)
         return (0);
     Pair<int, ft_event> *event_entry = loaded_world.get_events().find(1);
     remove("test_save.json");


### PR DESCRIPTION
## Summary
- add Game::game_save and game_load helpers to serialize world and inventory
- expose ft_world::save_to_file and load_from_file
- document save/load usage in Game/README and update README

## Testing
- `make -C Game`

------
https://chatgpt.com/codex/tasks/task_e_68c2cbaad25883318c66643de3f4ac8a