### PR TITLE
Add pthread rwlock wrappers and tests

### DIFF
--- a/PThread/Makefile
+++ b/PThread/Makefile
@@ -17,7 +17,8 @@ SRCS := pthread_lock_mutex.cpp \
         pthread_atomic_store.cpp \
         pthread_atomic_fetch_add.cpp \
         pthread_atomic_compare_exchange.cpp \
-        pthread_condition.cpp
+        pthread_condition.cpp \
+        pthread_rwlock.cpp
 
 HEADERS := pthread.hpp mutex.hpp condition.hpp
 

--- a/PThread/pthread.hpp
+++ b/PThread/pthread.hpp
@@ -22,6 +22,12 @@ void pt_atomic_store(std::atomic<int>& atomic_variable, int desired_value);
 int pt_atomic_fetch_add(std::atomic<int>& atomic_variable, int increment_value);
 bool pt_atomic_compare_exchange(std::atomic<int>& atomic_variable, int& expected_value, int desired_value);
 
+int pt_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attributes);
+int pt_rwlock_rdlock(pthread_rwlock_t *rwlock);
+int pt_rwlock_wrlock(pthread_rwlock_t *rwlock);
+int pt_rwlock_unlock(pthread_rwlock_t *rwlock);
+int pt_rwlock_destroy(pthread_rwlock_t *rwlock);
+
 #define SLEEP_TIME 100
 #define MAX_SLEEP 10000
 #define MAX_QUEUE 128

--- a/PThread/pthread_rwlock.cpp
+++ b/PThread/pthread_rwlock.cpp
@@ -1,0 +1,45 @@
+#include <cerrno>
+#include <pthread.h>
+#include "pthread.hpp"
+#include "../Errno/errno.hpp"
+
+int pt_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attributes)
+{
+    int return_value = pthread_rwlock_init(rwlock, attributes);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+
+int pt_rwlock_rdlock(pthread_rwlock_t *rwlock)
+{
+    int return_value = pthread_rwlock_rdlock(rwlock);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+
+int pt_rwlock_wrlock(pthread_rwlock_t *rwlock)
+{
+    int return_value = pthread_rwlock_wrlock(rwlock);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+
+int pt_rwlock_unlock(pthread_rwlock_t *rwlock)
+{
+    int return_value = pthread_rwlock_unlock(rwlock);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+
+int pt_rwlock_destroy(pthread_rwlock_t *rwlock)
+{
+    int return_value = pthread_rwlock_destroy(rwlock);
+    if (return_value != 0)
+        ft_errno = errno + ERRNO_OFFSET;
+    return (return_value);
+}
+

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ int pf_vsnprintf(char *string, size_t size, const char *format, va_list args);
 
 ### PThread Wrappers
 
-`PThread/pthread.hpp` wraps a few `pthread` calls, condition variables, and provides basic atomic operations.
+`PThread/pthread.hpp` wraps a few `pthread` calls, condition variables, read-write locks, and provides basic atomic operations.
 
 ```
 int pt_thread_join(pthread_t thread, void **retval);
@@ -212,6 +212,11 @@ int pt_cond_destroy(pthread_cond_t *condition);
 int pt_cond_wait(pthread_cond_t *condition, pthread_mutex_t *mutex);
 int pt_cond_signal(pthread_cond_t *condition);
 int pt_cond_broadcast(pthread_cond_t *condition);
+int pt_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attributes);
+int pt_rwlock_rdlock(pthread_rwlock_t *rwlock);
+int pt_rwlock_wrlock(pthread_rwlock_t *rwlock);
+int pt_rwlock_unlock(pthread_rwlock_t *rwlock);
+int pt_rwlock_destroy(pthread_rwlock_t *rwlock);
 ```
 
 ### C++ Classes (`CPP_class`)

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -27,7 +27,7 @@ SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp 
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \
        test_cpp_class.cpp test_template.cpp test_printf.cpp test_get_next_line.cpp \
        test_cma.cpp test_game.cpp test_queue.cpp test_queue_class.cpp \
-       test_promise.cpp test_config.cpp test_math_eval.cpp test_encryption_key.cpp \
+       test_promise.cpp test_config.cpp test_pthread_rwlock.cpp test_math_eval.cpp test_encryption_key.cpp \
        test_rng.cpp test_json_validate.cpp $(EFF_SRCS)
 
 ifeq ($(OS),Windows_NT)

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -186,6 +186,7 @@ int test_config_missing_value(void);
 int test_config_env_override(void);
 int test_pt_async_basic(void);
 int test_pt_cond_wait_signal(void);
+int test_pt_rwlock_readers_writers(void);
 int test_math_eval_basic(void);
 int test_math_eval_parentheses(void);
 int test_math_eval_dice_rejected(void);
@@ -422,6 +423,7 @@ int main(int argc, char **argv)
         { test_config_env_override, "config env override" },
         { test_pt_async_basic, "pt_async basic" },
         { test_pt_cond_wait_signal, "pt_cond_wait and pt_cond_signal" },
+        { test_pt_rwlock_readers_writers, "pt_rwlock readers writers" },
         { test_math_eval_basic, "math_eval basic" },
         { test_math_eval_parentheses, "math_eval parentheses" },
         { test_math_eval_dice_rejected, "math_eval dice rejected" },

--- a/Test/test_pthread_rwlock.cpp
+++ b/Test/test_pthread_rwlock.cpp
@@ -1,0 +1,80 @@
+#include "../PThread/pthread.hpp"
+#include "../Errno/errno.hpp"
+
+struct reader_data
+{
+    pthread_rwlock_t *lock;
+    int *started;
+};
+
+struct writer_data
+{
+    pthread_rwlock_t *lock;
+    int *acquired;
+    int *shared;
+};
+
+static void *reader_routine(void *arg)
+{
+    reader_data *data = static_cast<reader_data*>(arg);
+    pt_rwlock_rdlock(data->lock);
+    *(data->started) = 1;
+    pt_thread_sleep(200);
+    pt_rwlock_unlock(data->lock);
+    return (ft_nullptr);
+}
+
+static void *writer_routine(void *arg)
+{
+    writer_data *data = static_cast<writer_data*>(arg);
+    pt_rwlock_wrlock(data->lock);
+    *(data->shared) = 1;
+    *(data->acquired) = 1;
+    pt_rwlock_unlock(data->lock);
+    return (ft_nullptr);
+}
+
+int test_pt_rwlock_readers_writers(void)
+{
+    pthread_rwlock_t rwlock;
+    if (pt_rwlock_init(&rwlock, ft_nullptr) != 0)
+        return (0);
+    int shared_value = 0;
+    int reader_one_started = 0;
+    int reader_two_started = 0;
+    int writer_acquired = 0;
+    reader_data data_one = { &rwlock, &reader_one_started };
+    reader_data data_two = { &rwlock, &reader_two_started };
+    pthread_t reader_one;
+    pthread_t reader_two;
+    if (pt_thread_create(&reader_one, ft_nullptr, reader_routine, &data_one) != 0)
+    {
+        pt_rwlock_destroy(&rwlock);
+        return (0);
+    }
+    if (pt_thread_create(&reader_two, ft_nullptr, reader_routine, &data_two) != 0)
+    {
+        pt_thread_join(reader_one, ft_nullptr);
+        pt_rwlock_destroy(&rwlock);
+        return (0);
+    }
+    while (reader_one_started == 0 || reader_two_started == 0)
+        pt_thread_sleep(10);
+    writer_data wdata = { &rwlock, &writer_acquired, &shared_value };
+    pthread_t writer_thread;
+    if (pt_thread_create(&writer_thread, ft_nullptr, writer_routine, &wdata) != 0)
+    {
+        pt_thread_join(reader_one, ft_nullptr);
+        pt_thread_join(reader_two, ft_nullptr);
+        pt_rwlock_destroy(&rwlock);
+        return (0);
+    }
+    pt_thread_sleep(100);
+    int writer_acquired_early = writer_acquired;
+    pt_thread_join(reader_one, ft_nullptr);
+    pt_thread_join(reader_two, ft_nullptr);
+    pt_thread_join(writer_thread, ft_nullptr);
+    pt_rwlock_destroy(&rwlock);
+    return (writer_acquired == 1 && writer_acquired_early == 0 && shared_value == 1);
+}
+


### PR DESCRIPTION
## Summary
- add wrappers for pthread read-write locks
- document new rwlock helpers
- add test covering concurrent reader/writer behavior

## Testing
- `make -C PThread`
- `make -C Test`
- `./Test/libft_tests --all`


------
https://chatgpt.com/codex/tasks/task_e_68c2d008b4808331b8f4b05c7ad86e5a