### PR TITLE
Add %f precision support to printf

### DIFF
--- a/Printf/printf.hpp
+++ b/Printf/printf.hpp
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
+// wrappers support %c %s %d %i %u %x %X %o %p %b and %f with precision
 int pf_printf(const char *format, ...) __attribute__((format(printf, 1, 2), hot));
 int pf_printf_fd(int fd, const char *format, ...) __attribute__((format(printf, 2, 3), hot));
 int pf_snprintf(char *string, size_t size, const char *format, ...) __attribute__((format(printf, 3, 4), hot));

--- a/Printf/printf_format.cpp
+++ b/Printf/printf_format.cpp
@@ -20,15 +20,31 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
             if (format[index] == '\0')
                 break ;
             LengthModifier len_mod = LEN_NONE;
-            if (format[index] == 'l')
+            int precision = 6;
+            while (true)
             {
-                len_mod = LEN_L;
-                index++;
-            }
-            else if (format[index] == 'z')
-            {
-                len_mod = LEN_Z;
-                index++;
+                if (format[index] == '.')
+                {
+                    index++;
+                    precision = 0;
+                    while (format[index] >= '0' && format[index] <= '9')
+                    {
+                        precision = precision * 10 + (format[index] - '0');
+                        index++;
+                    }
+                }
+                else if (format[index] == 'l')
+                {
+                    len_mod = LEN_L;
+                    index++;
+                }
+                else if (format[index] == 'z')
+                {
+                    len_mod = LEN_Z;
+                    index++;
+                }
+                else
+                    break ;
             }
             char spec = format[index];
             if (spec == '\0')
@@ -114,7 +130,7 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
             else if (spec == 'f')
             {
                 double number = va_arg(args, double);
-                ft_putfloat_fd(number, fd, &count);
+                ft_putfloat_fd(number, fd, &count, precision);
             }
             else if (spec == 'e' || spec == 'E')
             {

--- a/Printf/printf_internal.hpp
+++ b/Printf/printf_internal.hpp
@@ -28,7 +28,8 @@ void ft_puthex_fd(uintmax_t number, int fd, bool uppercase, size_t *count);
 void ft_putoctal_fd_recursive(uintmax_t number, int fd, size_t *count);
 void ft_putoctal_fd(uintmax_t number, int fd, size_t *count);
 void ft_putptr_fd(void *pointer, int fd, size_t *count);
-void ft_putfloat_fd(double number, int fd, size_t *count);
+// writes floating point number with the given precision
+void ft_putfloat_fd(double number, int fd, size_t *count, int precision);
 void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count);
 void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count);
 int pf_printf_fd_v(int fd, const char *format, va_list args);

--- a/Printf/printf_print_args.cpp
+++ b/Printf/printf_print_args.cpp
@@ -141,7 +141,7 @@ void ft_putptr_fd(void *pointer, int fd, size_t *count)
     return ;
 }
 
-void ft_putfloat_fd(double number, int fd, size_t *count)
+void ft_putfloat_fd(double number, int fd, size_t *count, int precision)
 {
     if (number < 0)
     {
@@ -150,16 +150,19 @@ void ft_putfloat_fd(double number, int fd, size_t *count)
     }
     long integer_part = static_cast<long>(number);
     ft_putnbr_fd(integer_part, fd, count);
-    ft_putchar_fd('.', fd, count);
-    double fractional = number - static_cast<double>(integer_part);
-    int index_fraction = 0;
-    while (index_fraction < 6)
+    if (precision > 0)
     {
-        fractional *= 10;
-        int digit = static_cast<int>(fractional);
-        ft_putchar_fd(static_cast<char>('0' + digit), fd, count);
-        fractional -= digit;
-        index_fraction++;
+        ft_putchar_fd('.', fd, count);
+        double fractional = number - static_cast<double>(integer_part);
+        int index_fraction = 0;
+        while (index_fraction < precision)
+        {
+            fractional *= 10;
+            int digit = static_cast<int>(fractional);
+            ft_putchar_fd(static_cast<char>('0' + digit), fd, count);
+            fractional -= digit;
+            index_fraction++;
+        }
     }
     return ;
 }
@@ -230,7 +233,7 @@ void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count)
 {
     if (math_fabs(number) <= DBL_EPSILON)
     {
-        ft_putfloat_fd(0.0, fd, count);
+        ft_putfloat_fd(0.0, fd, count, 6);
         return ;
     }
     double temp = number;
@@ -250,6 +253,6 @@ void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count)
     if (exponent < -4 || exponent >= 6)
         ft_putscientific_fd(number, uppercase, fd, count);
     else
-        ft_putfloat_fd(number, fd, count);
+        ft_putfloat_fd(number, fd, count, 6);
     return ;
 }

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ int pf_snprintf(char *string, size_t size, const char *format, ...);
 int pf_vsnprintf(char *string, size_t size, const char *format, va_list args);
 ```
 
+`%f` supports precision using the `%.Nf` syntax.
+
 ### PThread Wrappers
 
 `PThread/pthread.hpp` wraps a few `pthread` calls, condition variables, read-write locks, and provides basic atomic operations.

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -151,6 +151,9 @@ int test_pf_printf_misc(void);
 int test_pf_printf_bool(void);
 int test_pf_printf_nullptr(void);
 int test_pf_printf_modifiers(void);
+int test_pf_printf_float_positive(void);
+int test_pf_printf_float_negative(void);
+int test_pf_printf_float_zero(void);
 int test_pf_snprintf_basic(void);
 int test_get_next_line_basic(void);
 int test_get_next_line_empty(void);
@@ -388,6 +391,9 @@ int main(int argc, char **argv)
         { test_pf_printf_bool, "pf_printf bool" },
         { test_pf_printf_nullptr, "pf_printf nullptr" },
         { test_pf_printf_modifiers, "pf_printf modifiers" },
+        { test_pf_printf_float_positive, "pf_printf float positive" },
+        { test_pf_printf_float_negative, "pf_printf float negative" },
+        { test_pf_printf_float_zero, "pf_printf float zero" },
         { test_pf_snprintf_basic, "pf_snprintf basic" },
         { test_get_next_line_basic, "get_next_line basic" },
         { test_get_next_line_empty, "get_next_line empty" },

--- a/Test/test_printf.cpp
+++ b/Test/test_printf.cpp
@@ -95,6 +95,60 @@ int test_pf_printf_modifiers(void)
     return (ft_strcmp(buf, "2147483648 2147483648 80000000 8589934591 1ffffffff") == 0);
 }
 
+int test_pf_printf_float_positive(void)
+{
+    const char *file_name = "tmp_pf_printf_float_positive.txt";
+    int file_descriptor = ::open(file_name, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (file_descriptor < 0)
+        return (0);
+    pf_printf_fd(file_descriptor, "%.2f", 3.14159);
+    ::lseek(file_descriptor, 0, SEEK_SET);
+    char buffer[64];
+    ssize_t read_bytes = ::read(file_descriptor, buffer, sizeof(buffer) - 1);
+    ::close(file_descriptor);
+    ::unlink(file_name);
+    if (read_bytes < 0)
+        return (0);
+    buffer[read_bytes] = '\0';
+    return (ft_strcmp(buffer, "3.14") == 0);
+}
+
+int test_pf_printf_float_negative(void)
+{
+    const char *file_name = "tmp_pf_printf_float_negative.txt";
+    int file_descriptor = ::open(file_name, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (file_descriptor < 0)
+        return (0);
+    pf_printf_fd(file_descriptor, "%.3f", -2.71828);
+    ::lseek(file_descriptor, 0, SEEK_SET);
+    char buffer[64];
+    ssize_t read_bytes = ::read(file_descriptor, buffer, sizeof(buffer) - 1);
+    ::close(file_descriptor);
+    ::unlink(file_name);
+    if (read_bytes < 0)
+        return (0);
+    buffer[read_bytes] = '\0';
+    return (ft_strcmp(buffer, "-2.718") == 0);
+}
+
+int test_pf_printf_float_zero(void)
+{
+    const char *file_name = "tmp_pf_printf_float_zero.txt";
+    int file_descriptor = ::open(file_name, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (file_descriptor < 0)
+        return (0);
+    pf_printf_fd(file_descriptor, "%.4f", 0.0);
+    ::lseek(file_descriptor, 0, SEEK_SET);
+    char buffer[64];
+    ssize_t read_bytes = ::read(file_descriptor, buffer, sizeof(buffer) - 1);
+    ::close(file_descriptor);
+    ::unlink(file_name);
+    if (read_bytes < 0)
+        return (0);
+    buffer[read_bytes] = '\0';
+    return (ft_strcmp(buffer, "0.0000") == 0);
+}
+
 int test_pf_snprintf_basic(void)
 {
     char buffer[64];


### PR DESCRIPTION
## Summary
- support `%f` precision parsing and printing in printf
- document `%f` precision and mention in README
- test positive, negative and zero float formatting

## Testing
- `make -C Test`
- `./Test/libft_tests --all`

------
https://chatgpt.com/codex/tasks/task_e_68c2d3763c2c83318d52b17bbce2062d