### PR TITLE
Add sine and tangent math functions with tests

### DIFF
--- a/Math/Makefile
+++ b/Math/Makefile
@@ -20,6 +20,8 @@ SRCS := math_abs.cpp \
         math_exp.cpp \
         math_log.cpp \
         math_cos.cpp \
+        math_sin.cpp \
+        math_tan.cpp \
         math_deg2rad.cpp \
         math_rad2deg.cpp \
         math_roll.cpp \

--- a/Math/math.hpp
+++ b/Math/math.hpp
@@ -40,6 +40,8 @@ double      math_sqrt(double number);
 double      math_exp(double value);
 double      math_log(double value);
 double      math_cos(double value);
+double      ft_sin(double value);
+double      ft_tan(double value);
 double      math_deg2rad(double degrees);
 double      math_rad2deg(double radians);
 

--- a/Math/math_sin.cpp
+++ b/Math/math_sin.cpp
@@ -1,0 +1,28 @@
+#include "math.hpp"
+
+double ft_sin(double value)
+{
+    double angle;
+    double term;
+    double result;
+    int    iteration;
+    double sign;
+
+    angle = value;
+    while (angle > 3.14159265358979323846)
+        angle -= 6.28318530717958647692;
+    while (angle < -3.14159265358979323846)
+        angle += 6.28318530717958647692;
+    term = angle;
+    result = angle;
+    iteration = 1;
+    sign = -1.0;
+    while (math_fabs(term) > 0.0000000001)
+    {
+        term = term * angle * angle / ((2.0 * iteration) * (2.0 * iteration + 1.0));
+        result = result + sign * term;
+        sign = -sign;
+        iteration = iteration + 1;
+    }
+    return (result);
+}

--- a/Math/math_tan.cpp
+++ b/Math/math_tan.cpp
@@ -1,0 +1,11 @@
+#include "math.hpp"
+
+double ft_tan(double value)
+{
+    double sin_value;
+    double cos_value;
+
+    sin_value = ft_sin(value);
+    cos_value = math_cos(value);
+    return (sin_value / cos_value);
+}

--- a/README.md
+++ b/README.md
@@ -111,8 +111,17 @@ double      math_sqrt(double number);
 double      math_exp(double value);
 double      math_log(double value);
 double      math_cos(double value);
+double      ft_sin(double value);
+double      ft_tan(double value);
 double      math_deg2rad(double degrees);
 double      math_rad2deg(double radians);
+```
+
+Example usage:
+
+```
+double sine = ft_sin(math_deg2rad(90.0));
+double tangent = ft_tan(math_deg2rad(45.0));
 ```
 
 Additional helpers for parsing expressions are available. They allocate a

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -28,7 +28,7 @@ SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp 
        test_cpp_class.cpp test_template.cpp test_printf.cpp test_get_next_line.cpp \
        test_cma.cpp test_game.cpp test_queue.cpp test_queue_class.cpp \
        test_promise.cpp test_config.cpp test_pthread_rwlock.cpp test_math_eval.cpp test_encryption_key.cpp \
-       test_rng.cpp test_json_validate.cpp $(EFF_SRCS)
+       test_math_trig.cpp test_rng.cpp test_json_validate.cpp $(EFF_SRCS)
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -114,6 +114,10 @@ int test_abs_int_min(void);
 int test_abs_llong_min(void);
 int test_fabs_negative_zero(void);
 int test_fabs_nan(void);
+int test_ft_sin_zero(void);
+int test_ft_sin_ninety(void);
+int test_ft_tan_zero(void);
+int test_ft_tan_forty_five(void);
 int test_atol_basic(void);
 int test_atol_whitespace(void);
 int test_atol_longmax(void);
@@ -335,6 +339,10 @@ int main(int argc, char **argv)
         { test_abs_llong_min, "abs LLONG_MIN" },
         { test_fabs_negative_zero, "fabs negative zero" },
         { test_fabs_nan, "fabs NaN" },
+        { test_ft_sin_zero, "ft_sin zero" },
+        { test_ft_sin_ninety, "ft_sin ninety" },
+        { test_ft_tan_zero, "ft_tan zero" },
+        { test_ft_tan_forty_five, "ft_tan forty five" },
         { test_atol_basic, "atol basic" },
         { test_atol_whitespace, "atol whitespace" },
         { test_atol_longmax, "atol longmax" },

--- a/Test/test_math_trig.cpp
+++ b/Test/test_math_trig.cpp
@@ -1,0 +1,41 @@
+#include "../Math/math.hpp"
+
+int test_ft_sin_zero(void)
+{
+    double result;
+
+    result = ft_sin(0.0);
+    if (math_fabs(result) < 0.000001)
+        return (1);
+    return (0);
+}
+
+int test_ft_sin_ninety(void)
+{
+    double result;
+
+    result = ft_sin(math_deg2rad(90.0));
+    if (math_fabs(result - 1.0) < 0.000001)
+        return (1);
+    return (0);
+}
+
+int test_ft_tan_zero(void)
+{
+    double result;
+
+    result = ft_tan(0.0);
+    if (math_fabs(result) < 0.000001)
+        return (1);
+    return (0);
+}
+
+int test_ft_tan_forty_five(void)
+{
+    double result;
+
+    result = ft_tan(math_deg2rad(45.0));
+    if (math_fabs(result - 1.0) < 0.000001)
+        return (1);
+    return (0);
+}


### PR DESCRIPTION
## Summary
- implement `ft_sin` using a Taylor series and `ft_tan` as a sine/cosine ratio
- expose new functions in the math header and build system
- document trigonometric helpers with examples and test common angles

## Testing
- `make -C Math`
- `make -C Test`
- `printf "tests\nall\nexit\n" | ./libft_tests` *(no output - interactive test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d7f7b7248331a84f7e61f9ba73ce