### PR TITLE
Add ISO8601 time formatter and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,9 +746,17 @@ void    time_local(t_time time_value, t_time_info *out);
 void    time_sleep(unsigned int seconds);
 void    time_sleep_ms(unsigned int milliseconds);
 size_t  time_strftime(char *buffer, size_t size, const char *format, const t_time_info *time_info);
+ft_string    time_format_iso8601(t_time time_value);
 ```
 
 `t_time` stores seconds since the Unix epoch and `t_time_info` holds the broken-down components.
+
+Example:
+
+```
+ft_string timestamp = time_format_iso8601(0);
+// timestamp == "1970-01-01T00:00:00Z"
+```
 
 `timer.hpp` defines a small timer class:
 

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -127,6 +127,8 @@ int test_setenv_no_overwrite(void);
 int test_su_get_cpu_count(void);
 int test_su_get_total_memory(void);
 int test_time_monotonic_increases(void);
+int test_time_format_iso8601_epoch(void);
+int test_time_format_iso8601_20210101(void);
 int test_ft_string_append(void);
 int test_ft_string_concat(void);
 int test_data_buffer_io(void);
@@ -352,6 +354,8 @@ int main(int argc, char **argv)
         { test_su_get_cpu_count, "su get cpu count" },
         { test_su_get_total_memory, "su get total memory" },
         { test_time_monotonic_increases, "time_monotonic increases" },
+        { test_time_format_iso8601_epoch, "time_format_iso8601 epoch" },
+        { test_time_format_iso8601_20210101, "time_format_iso8601 2021-01-01" },
         { test_strlen_size_t_empty, "strlen_size_t empty" },
         { test_bzero_zero, "bzero zero" },
         { test_memcpy_partial, "memcpy partial" },

--- a/Test/test_extra_libft.cpp
+++ b/Test/test_extra_libft.cpp
@@ -4,6 +4,7 @@
 #include "../CPP_class/class_nullptr.hpp"
 #include "../System_utils/system_utils.hpp"
 #include "../Time/time.hpp"
+#include "../CPP_class/class_string_class.hpp"
 #include <cstring>
 #include <string>
 
@@ -373,5 +374,21 @@ int test_time_monotonic_increases(void)
     time_sleep_ms(1);
     second_time = time_monotonic();
     return (second_time >= first_time);
+}
+
+int test_time_format_iso8601_epoch(void)
+{
+    ft_string formatted;
+
+    formatted = time_format_iso8601(0);
+    return (std::strcmp(formatted.c_str(), "1970-01-01T00:00:00Z") == 0);
+}
+
+int test_time_format_iso8601_20210101(void)
+{
+    ft_string formatted;
+
+    formatted = time_format_iso8601(1609459200);
+    return (std::strcmp(formatted.c_str(), "2021-01-01T00:00:00Z") == 0);
 }
 

--- a/Time/Makefile
+++ b/Time/Makefile
@@ -9,7 +9,8 @@ SRCS := time_now.cpp \
         time_sleep_ms.cpp \
         time_fps.cpp \
         time_timer.cpp \
-        time_strftime.cpp
+        time_strftime.cpp \
+        time_format.cpp
 
 HEADERS := time.hpp \
            fps.hpp \

--- a/Time/time.hpp
+++ b/Time/time.hpp
@@ -2,6 +2,7 @@
 # define TIME_HPP
 
 #include <cstddef>
+#include "../CPP_class/class_string_class.hpp"
 
 typedef long t_time;
 
@@ -25,5 +26,6 @@ void    time_local(t_time time_value, t_time_info *out);
 void    time_sleep(unsigned int seconds);
 void    time_sleep_ms(unsigned int milliseconds);
 size_t  time_strftime(char *buffer, size_t size, const char *format, const t_time_info *time_info);
+ft_string    time_format_iso8601(t_time time_value);
 
 #endif

--- a/Time/time_format.cpp
+++ b/Time/time_format.cpp
@@ -1,0 +1,21 @@
+#include "time.hpp"
+#include "../CPP_class/class_string_class.hpp"
+#include <ctime>
+
+ft_string    time_format_iso8601(t_time time_value)
+{
+    std::time_t standard_time;
+    std::tm *time_pointer;
+    char buffer[21];
+    ft_string formatted;
+
+    standard_time = static_cast<std::time_t>(time_value);
+    time_pointer = std::gmtime(&standard_time);
+    if (!time_pointer)
+        return (ft_string());
+    if (std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", time_pointer) == 0)
+        return (ft_string());
+    formatted = ft_string(buffer);
+    return (formatted);
+}
+


### PR DESCRIPTION
## Summary
- implement `time_format_iso8601` to produce ISO8601 UTC strings
- declare the helper in `time.hpp` and include in build
- document usage and add tests for known timestamps

## Testing
- `make -C Time`
- `make -C Test`
- `./Test/libft_tests --all`

------
https://chatgpt.com/codex/tasks/task_e_68c2dd7373fc8331a2a5489b765d11da