### PR TITLE
Add home directory helper to System_utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,8 +490,8 @@ custom memory allocator can be toggled with `set_alloc_logging` and
 `System_utils/system_utils.hpp` provides a simple assertion helper that logs failures using the
 global logger before terminating the process. The header also offers direct helpers to abort or
 raise common signals and wrappers around environment helpers. Each call locks a global mutex before
-touching the process environment. It also exposes portable helpers to query CPU count and total
-physical memory.
+touching the process environment. It exposes portable helpers to query CPU count and total physical
+memory and to retrieve the current user's home directory.
 
 ```
 void    su_abort(void);
@@ -505,6 +505,7 @@ void    su_assert(bool condition, const char *message);
 char    *su_getenv(const char *name);
 int     su_setenv(const char *name, const char *value, int overwrite);
 int     su_putenv(char *string);
+char    *su_get_home_directory(void);
 int     su_open(const char *path_name);
 int     su_open(const char *path_name, int flags);
 int     su_open(const char *path_name, int flags, mode_t mode);

--- a/System_utils/Makefile
+++ b/System_utils/Makefile
@@ -2,16 +2,17 @@ TARGET := System_utils.a
 DEBUG_TARGET := System_utils_debug.a
 
 SRCS := System_utils_assert.cpp \
-	System_utils_env.cpp \
-	System_utils_abort.cpp \
-	System_utils_sigabrt.cpp \
-	System_utils_sigfpe.cpp \
-	System_utils_sigill.cpp \
-	System_utils_sigint.cpp \
-	System_utils_sigsegv.cpp \
-	System_utils_sigterm.cpp \
-	System_utils_sysinfo.cpp \
-	System_utils_file.cpp
+        System_utils_env.cpp \
+        System_utils_abort.cpp \
+        System_utils_sigabrt.cpp \
+        System_utils_sigfpe.cpp \
+        System_utils_sigill.cpp \
+        System_utils_sigint.cpp \
+        System_utils_sigsegv.cpp \
+        System_utils_sigterm.cpp \
+        System_utils_sysinfo.cpp \
+        System_utils_file.cpp \
+        System_utils_home.cpp
 
 HEADERS := system_utils.hpp
 

--- a/System_utils/System_utils_home.cpp
+++ b/System_utils/System_utils_home.cpp
@@ -1,0 +1,24 @@
+#include "system_utils.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+char    *su_get_home_directory(void)
+{
+#if defined(_WIN32) || defined(_WIN64)
+    char    *home;
+    char    *home_drive;
+    char    *home_path;
+
+    home = ft_getenv("USERPROFILE");
+    if (home != ft_nullptr)
+        return (home);
+    home_drive = ft_getenv("HOMEDRIVE");
+    home_path = ft_getenv("HOMEPATH");
+    if (home_drive == ft_nullptr || home_path == ft_nullptr)
+        return (ft_nullptr);
+    return (ft_strjoin_multiple(2, home_drive, home_path));
+#else
+    return (ft_getenv("HOME"));
+#endif
+}
+

--- a/System_utils/system_utils.hpp
+++ b/System_utils/system_utils.hpp
@@ -6,6 +6,7 @@
 char    *su_getenv(const char *name);
 int     su_setenv(const char *name, const char *value, int overwrite);
 int     su_putenv(char *string);
+char    *su_get_home_directory(void);
 int     su_open(const char *path_name);
 int     su_open(const char *path_name, int flags);
 int     su_open(const char *path_name, int flags, mode_t mode);

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -126,6 +126,8 @@ int test_setenv_getenv_basic(void);
 int test_setenv_no_overwrite(void);
 int test_su_get_cpu_count(void);
 int test_su_get_total_memory(void);
+int test_su_get_home_directory_posix(void);
+int test_su_get_home_directory_windows(void);
 int test_time_monotonic_increases(void);
 int test_time_format_iso8601_epoch(void);
 int test_time_format_iso8601_20210101(void);
@@ -353,6 +355,8 @@ int main(int argc, char **argv)
         { test_setenv_no_overwrite, "setenv no overwrite" },
         { test_su_get_cpu_count, "su get cpu count" },
         { test_su_get_total_memory, "su get total memory" },
+        { test_su_get_home_directory_posix, "su get home directory posix" },
+        { test_su_get_home_directory_windows, "su get home directory windows" },
         { test_time_monotonic_increases, "time_monotonic increases" },
         { test_time_format_iso8601_epoch, "time_format_iso8601 epoch" },
         { test_time_format_iso8601_20210101, "time_format_iso8601 2021-01-01" },

--- a/Test/test_extra_libft.cpp
+++ b/Test/test_extra_libft.cpp
@@ -6,6 +6,7 @@
 #include "../Time/time.hpp"
 #include "../CPP_class/class_string_class.hpp"
 #include <cstring>
+#include <cstdlib>
 #include <string>
 
 int test_strlen_size_t_null(void)
@@ -363,6 +364,51 @@ int test_su_get_cpu_count(void)
 int test_su_get_total_memory(void)
 {
     return (su_get_total_memory() > 0);
+}
+
+int test_su_get_home_directory_posix(void)
+{
+#if defined(_WIN32) || defined(_WIN64)
+    return (1);
+#else
+    char    *expected;
+    char    *result;
+
+    expected = ft_getenv("HOME");
+    result = su_get_home_directory();
+    if (expected == ft_nullptr || result == ft_nullptr)
+        return (0);
+    return (std::strcmp(result, expected) == 0);
+#endif
+}
+
+int test_su_get_home_directory_windows(void)
+{
+#if defined(_WIN32) || defined(_WIN64)
+    char    *expected;
+    char    *result;
+    char    *home_drive;
+    char    *home_path;
+    char    *combined;
+    int     test_ok;
+
+    expected = ft_getenv("USERPROFILE");
+    result = su_get_home_directory();
+    if (expected != ft_nullptr)
+        return (result != ft_nullptr && std::strcmp(result, expected) == 0);
+    home_drive = ft_getenv("HOMEDRIVE");
+    home_path = ft_getenv("HOMEPATH");
+    if (home_drive == ft_nullptr || home_path == ft_nullptr)
+        return (result == ft_nullptr);
+    combined = ft_strjoin_multiple(2, home_drive, home_path);
+    if (combined == ft_nullptr)
+        return (0);
+    test_ok = (result != ft_nullptr && std::strcmp(result, combined) == 0);
+    std::free(combined);
+    return (test_ok);
+#else
+    return (1);
+#endif
 }
 
 int test_time_monotonic_increases(void)


### PR DESCRIPTION
## Summary
- add cross-platform su_get_home_directory using environment variables
- expose su_get_home_directory in system_utils.hpp and update docs
- test home directory retrieval on POSIX and Windows

## Testing
- `make -C System_utils`
- `make -C Test`
- interactive: `run` then `all`

------
https://chatgpt.com/codex/tasks/task_e_68c2dffb86588331aa7e1e4c29551a93