### PR TITLE
Add zlib-based compression utilities

### DIFF
--- a/Compression/Makefile
+++ b/Compression/Makefile
@@ -1,0 +1,70 @@
+TARGET := compression.a
+DEBUG_TARGET := compression_debug.a
+
+SRCS := compression_zlib.cpp
+
+HEADERS := compression.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
+clean:
+	-$(RM) $(CLEAN_FILES)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/Compression/README
+++ b/Compression/README
@@ -1,0 +1,3 @@
+# Compression
+
+Provides zlib-based compression helpers using the Custom Memory Allocator (CMA).

--- a/Compression/compression.hpp
+++ b/Compression/compression.hpp
@@ -1,0 +1,10 @@
+#ifndef COMPRESSION_HPP
+# define COMPRESSION_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+unsigned char    *compress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size);
+unsigned char    *decompress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size);
+
+#endif

--- a/Compression/compression_zlib.cpp
+++ b/Compression/compression_zlib.cpp
@@ -1,0 +1,60 @@
+#include <zlib.h>
+#include "../CMA/CMA.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "compression.hpp"
+
+unsigned char    *compress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size)
+{
+    uLongf          zlib_bound;
+    uLongf          actual_size;
+    unsigned char   *result_buffer;
+    unsigned char   *resized_buffer;
+    uint32_t        original_size;
+    int             zlib_status;
+
+    if (!input_buffer || !compressed_size)
+        return (ft_nullptr);
+    zlib_bound = compressBound(static_cast<uLong>(input_size));
+    result_buffer = static_cast<unsigned char *>(cma_malloc(zlib_bound + sizeof(uint32_t)));
+    if (!result_buffer)
+        return (ft_nullptr);
+    actual_size = zlib_bound;
+    zlib_status = compress2(result_buffer + sizeof(uint32_t), &actual_size, input_buffer, static_cast<uLong>(input_size), Z_BEST_COMPRESSION);
+    if (zlib_status != Z_OK)
+    {
+        cma_free(result_buffer);
+        return (ft_nullptr);
+    }
+    original_size = static_cast<uint32_t>(input_size);
+    ft_memcpy(result_buffer, &original_size, sizeof(uint32_t));
+    *compressed_size = actual_size + sizeof(uint32_t);
+    resized_buffer = static_cast<unsigned char *>(cma_realloc(result_buffer, *compressed_size));
+    if (resized_buffer)
+        result_buffer = resized_buffer;
+    return (result_buffer);
+}
+
+unsigned char    *decompress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size)
+{
+    uint32_t        expected_size;
+    uLongf          actual_size;
+    unsigned char   *result_buffer;
+    int             zlib_status;
+
+    if (!input_buffer || input_size < sizeof(uint32_t) || !decompressed_size)
+        return (ft_nullptr);
+    ft_memcpy(&expected_size, input_buffer, sizeof(uint32_t));
+    result_buffer = static_cast<unsigned char *>(cma_malloc(expected_size));
+    if (!result_buffer)
+        return (ft_nullptr);
+    actual_size = static_cast<uLongf>(expected_size);
+    zlib_status = uncompress(result_buffer, &actual_size, input_buffer + sizeof(uint32_t), static_cast<uLong>(input_size - sizeof(uint32_t)));
+    if (zlib_status != Z_OK || actual_size != expected_size)
+    {
+        cma_free(result_buffer);
+        return (ft_nullptr);
+    }
+    *decompressed_size = actual_size;
+    return (result_buffer);
+}

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -72,6 +72,7 @@
 #include "Template/future.hpp"
 #include "Template/promise.hpp"
 #include "System_utils/system_utils.hpp"
+#include "Compression/compression.hpp"
 #include "Encryption/basic_encryption.hpp"
 #include "File/open_dir.hpp"
 #include "Time/time.hpp"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ SUBDIRS :=  CMA \
             Networking \
             API \
             Compatebility \
-            Encryption RNG JSon File HTML Game Time
+            Compression Encryption RNG JSon File HTML Game Time
 
 LIB_BASES := \
   CMA/CustomMemoryAllocator \
@@ -66,6 +66,7 @@ LIB_BASES := \
   Networking/networking \
   API/API \
   Compatebility/Compatebility \
+  Compression/compression \
   Encryption/encryption \
   RNG/RNG \
   JSon/JSon \

--- a/README.md
+++ b/README.md
@@ -626,6 +626,16 @@ aes_encrypt(block, key);
 aes_decrypt(block, key);
 ```
 
+#### Compression
+`compression.hpp` offers zlib-based buffer compression:
+
+```
+unsigned char *compress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size);
+unsigned char *decompress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size);
+```
+
+The returned buffers are allocated with CMA and must be freed using `cma_free`.
+
 #### JSon
 Creation, reading and manipulation helpers in `JSon/json.hpp`:
 

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -2,33 +2,33 @@ TARGET := libft_tests
 DEBUG_TARGET := libft_tests_debug
 
 EFF_SRCS := efficiency/efficiency_strlen.cpp efficiency/efficiency_memcpy.cpp \
-        efficiency/efficiency_memmove.cpp efficiency/efficiency_memset.cpp \
-        efficiency/efficiency_strcmp.cpp efficiency/efficiency_isdigit.cpp \
-        efficiency/efficiency_bzero.cpp efficiency/efficiency_memcmp.cpp \
-        efficiency/efficiency_strchr.cpp efficiency/efficiency_strncmp.cpp \
-        efficiency/efficiency_isalpha.cpp efficiency/efficiency_isalnum.cpp \
-        efficiency/efficiency_memchr.cpp efficiency/efficiency_strrchr.cpp \
-        efficiency/efficiency_isspace.cpp efficiency/efficiency_abs.cpp \
-        efficiency/efficiency_cma_malloc.cpp efficiency/efficiency_cma_calloc.cpp \
-            efficiency/efficiency_cma_strdup.cpp efficiency/efficiency_cma_memdup.cpp \
-            efficiency/efficiency_cma_realloc.cpp efficiency/efficiency_vector.cpp \
-            efficiency/efficiency_map.cpp efficiency/efficiency_shared_ptr.cpp \
-            efficiency/efficiency_string.cpp efficiency/efficiency_unique_ptr.cpp \
-            efficiency/efficiency_stack.cpp efficiency/efficiency_queue.cpp \
-            efficiency/efficiency_unord_map.cpp efficiency/efficiency_pair.cpp \
-            efficiency/efficiency_promise.cpp efficiency/efficiency_pow.cpp \
-            efficiency/efficiency_sqrt.cpp efficiency/efficiency_exp.cpp \
-            efficiency/efficiency_clamp.cpp \
-            efficiency/efficiency_atoi.cpp efficiency/efficiency_atol.cpp \
-            efficiency/efficiency_pool.cpp efficiency/efficiency_swap.cpp \
-            efficiency/efficiency_mutex.cpp efficiency/efficiency_printf.cpp
+	efficiency/efficiency_memmove.cpp efficiency/efficiency_memset.cpp \
+	efficiency/efficiency_strcmp.cpp efficiency/efficiency_isdigit.cpp \
+	efficiency/efficiency_bzero.cpp efficiency/efficiency_memcmp.cpp \
+	efficiency/efficiency_strchr.cpp efficiency/efficiency_strncmp.cpp \
+	efficiency/efficiency_isalpha.cpp efficiency/efficiency_isalnum.cpp \
+	efficiency/efficiency_memchr.cpp efficiency/efficiency_strrchr.cpp \
+	efficiency/efficiency_isspace.cpp efficiency/efficiency_abs.cpp \
+	efficiency/efficiency_cma_malloc.cpp efficiency/efficiency_cma_calloc.cpp \
+	    efficiency/efficiency_cma_strdup.cpp efficiency/efficiency_cma_memdup.cpp \
+	    efficiency/efficiency_cma_realloc.cpp efficiency/efficiency_vector.cpp \
+	    efficiency/efficiency_map.cpp efficiency/efficiency_shared_ptr.cpp \
+	    efficiency/efficiency_string.cpp efficiency/efficiency_unique_ptr.cpp \
+	    efficiency/efficiency_stack.cpp efficiency/efficiency_queue.cpp \
+	    efficiency/efficiency_unord_map.cpp efficiency/efficiency_pair.cpp \
+	    efficiency/efficiency_promise.cpp efficiency/efficiency_pow.cpp \
+	    efficiency/efficiency_sqrt.cpp efficiency/efficiency_exp.cpp \
+	    efficiency/efficiency_clamp.cpp \
+	    efficiency/efficiency_atoi.cpp efficiency/efficiency_atol.cpp \
+	    efficiency/efficiency_pool.cpp efficiency/efficiency_swap.cpp \
+	    efficiency/efficiency_mutex.cpp efficiency/efficiency_printf.cpp
 
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp test_strlen.cpp \
        test_toupper.cpp test_html.cpp test_networking.cpp test_extra_libft.cpp \
        test_cpp_class.cpp test_template.cpp test_printf.cpp test_get_next_line.cpp \
        test_cma.cpp test_game.cpp test_queue.cpp test_queue_class.cpp \
        test_promise.cpp test_config.cpp test_pthread_rwlock.cpp test_math_eval.cpp test_encryption_key.cpp \
-       test_math_trig.cpp test_rng.cpp test_json_validate.cpp $(EFF_SRCS)
+       test_math_trig.cpp test_rng.cpp test_json_validate.cpp test_compression.cpp $(EFF_SRCS)
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir
@@ -63,6 +63,7 @@ CXX       := g++
 COMPILE_FLAGS ?= -Wall -Wextra -Werror -std=c++17
 COMPILE_FLAGS += $(OPT_FLAGS) -pthread
 CFLAGS := $(COMPILE_FLAGS)
+LDFLAGS := -lz
 export COMPILE_FLAGS
 
 OBJDIR       := objs
@@ -74,7 +75,7 @@ DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
 all: $(TARGET)
 
 $(TARGET): $(OBJS) ../Full_Libft.a
-	$(CXX) $(CFLAGS) -o $@ $^
+	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 $(OBJDIR)/%.o: %.cpp
 	$(MKDIR) $(dir $@)
@@ -84,7 +85,7 @@ debug: CXXFLAGS += -DDEBUG=1
 debug: $(DEBUG_TARGET)
 
 $(DEBUG_TARGET): $(DEBUG_OBJS) ../Full_Libft_debug.a
-	$(CXX) $(CFLAGS) -o $@ $^
+	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 $(DEBUG_OBJDIR)/%.o: %.cpp
 	$(MKDIR) $(dir $@)

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -208,6 +208,7 @@ int test_json_roundtrip_string(void);
 int test_json_roundtrip_file(void);
 int test_json_validate_success(void);
 int test_json_validate_missing_field(void);
+int test_compression_round_trip(void);
 
 int test_efficiency_strlen(void);
 int test_efficiency_memcpy(void);
@@ -455,7 +456,8 @@ int main(int argc, char **argv)
         { test_json_roundtrip_string, "json roundtrip string" },
         { test_json_roundtrip_file, "json roundtrip file" },
         { test_json_validate_success, "json validate success" },
-        { test_json_validate_missing_field, "json validate missing field" }
+        { test_json_validate_missing_field, "json validate missing field" },
+        { test_compression_round_trip, "compression round trip" }
     };
 
     const s_perf_test perf_tests[] = {

--- a/Test/test_compression.cpp
+++ b/Test/test_compression.cpp
@@ -1,0 +1,35 @@
+#include "../Compression/compression.hpp"
+#include "../CMA/CMA.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+int test_compression_round_trip(void)
+{
+    const char      *input_string;
+    unsigned char   *compressed_buffer;
+    unsigned char   *decompressed_buffer;
+    size_t          input_length;
+    size_t          compressed_length;
+    size_t          decompressed_length;
+    int             comparison_result;
+
+    input_string = "The quick brown fox jumps over the lazy dog";
+    input_length = ft_strlen(input_string);
+    compressed_length = 0;
+    compressed_buffer = compress_buffer(reinterpret_cast<const unsigned char *>(input_string), input_length, &compressed_length);
+    if (!compressed_buffer)
+        return (0);
+    decompressed_length = 0;
+    decompressed_buffer = decompress_buffer(compressed_buffer, compressed_length, &decompressed_length);
+    cma_free(compressed_buffer);
+    if (!decompressed_buffer)
+        return (0);
+    comparison_result = ft_memcmp(decompressed_buffer, input_string, decompressed_length);
+    if (comparison_result == 0 && decompressed_length == input_length)
+    {
+        cma_free(decompressed_buffer);
+        return (1);
+    }
+    cma_free(decompressed_buffer);
+    return (0);
+}


### PR DESCRIPTION
## Summary
- add Compression module with `compress_buffer` and `decompress_buffer` using zlib and CMA
- integrate module into build system and umbrella header
- document compression helpers and exercise them in tests

## Testing
- `make -C Compression`
- `make -C Test`
- `./Test/libft_tests --all`

------
https://chatgpt.com/codex/tasks/task_e_68c2e59d88d883318479aacac03180bd