### PR TITLE
Add basic XML parser and tests

### DIFF
--- a/Compression/README
+++ b/Compression/README
@@ -1,3 +1,0 @@
-# Compression
-
-Provides zlib-based compression helpers using the Custom Memory Allocator (CMA).

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -20,6 +20,7 @@
 #include "GetNextLine/get_next_line.hpp"
 #include "HTML/parser.hpp"
 #include "HTML/document.hpp"
+#include "XML/xml.hpp"
 #include "JSon/json.hpp"
 #include "JSon/document.hpp"
 #include "Libft/libft.hpp"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ SUBDIRS :=  CMA \
             Networking \
             API \
             Compatebility \
-            Compression Encryption RNG JSon File HTML Game Time
+            Compression Encryption RNG JSon File HTML Game Time XML
 
 LIB_BASES := \
   CMA/CustomMemoryAllocator \
@@ -73,7 +73,8 @@ LIB_BASES := \
   File/file \
   HTML/HTMLParser \
   Game/Game \
-  Time/time
+  Time/time \
+  XML/XMLParser
 
 LIBS       := $(addsuffix .a, $(LIB_BASES))
 DEBUG_LIBS := $(addsuffix _debug.a, $(LIB_BASES))

--- a/README.md
+++ b/README.md
@@ -627,7 +627,9 @@ aes_decrypt(block, key);
 ```
 
 #### Compression
-`compression.hpp` offers zlib-based buffer compression:
+Provides zlib-based compression helpers using the Custom Memory Allocator (CMA).
+
+`compression.hpp` offers buffer compression functions:
 
 ```
 unsigned char *compress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size);
@@ -949,6 +951,30 @@ html_node *highlight = html_query_selector(root, ".highlight");
 
 `html_query_selector` supports only tag names, `.class`, and `#id` selectors.
 Combinators like descendant or child selectors are not implemented.
+
+#### XML
+Basic XML parsing and writing utilities (`XML/xml.hpp`):
+
+```
+xml_document doc;
+doc.load_from_string("<root><child>value</child></root>");
+xml_node *root = doc.get_root();
+char *xml = doc.write_to_string();
+if (xml)
+    cma_free(xml);
+```
+
+`xml_document` exposes methods:
+
+```
+xml_document() noexcept;
+~xml_document() noexcept;
+int load_from_string(const char *xml) noexcept;
+int load_from_file(const char *file_path) noexcept;
+char *write_to_string() const noexcept;
+int write_to_file(const char *file_path) const noexcept;
+xml_node *get_root() const noexcept;
+```
 
 #### Game
 Basic game related classes include `ft_character`, `ft_item`, `ft_inventory`,

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -28,7 +28,7 @@ SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp 
        test_cpp_class.cpp test_template.cpp test_printf.cpp test_get_next_line.cpp \
        test_cma.cpp test_game.cpp test_queue.cpp test_queue_class.cpp \
        test_promise.cpp test_config.cpp test_pthread_rwlock.cpp test_math_eval.cpp test_encryption_key.cpp \
-       test_math_trig.cpp test_rng.cpp test_json_validate.cpp test_compression.cpp $(EFF_SRCS)
+       test_math_trig.cpp test_rng.cpp test_json_validate.cpp test_compression.cpp test_xml.cpp $(EFF_SRCS)
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -62,6 +62,7 @@ int test_html_write_to_string(void);
 int test_html_find_by_attr(void);
 int test_html_find_by_selector(void);
 int test_html_query_selector(void);
+int test_xml_parse_simple(void);
 int test_network_send_receive(void);
 int test_network_invalid_ip(void);
 int test_network_send_uninitialized(void);
@@ -311,6 +312,7 @@ int main(int argc, char **argv)
         { test_html_find_by_attr, "html find by attr" },
         { test_html_find_by_selector, "html find by selector" },
         { test_html_query_selector, "html query selector" },
+        { test_xml_parse_simple, "xml parse simple" },
         { test_network_send_receive, "network send/receive" },
         { test_network_invalid_ip, "network invalid ip" },
         { test_network_send_uninitialized, "network send uninitialized" },

--- a/Test/test_xml.cpp
+++ b/Test/test_xml.cpp
@@ -1,0 +1,26 @@
+#include "../XML/xml.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../CMA/CMA.hpp"
+#include <cstring>
+
+int test_xml_parse_simple(void)
+{
+    const char *xml = "<root><child>value</child></root>";
+    xml_document doc;
+    if (doc.load_from_string(xml) != ER_SUCCESS)
+        return (0);
+    xml_node *root = doc.get_root();
+    if (!root)
+        return (0);
+    if (root->children.size() != 1)
+        return (0);
+    xml_node *child = root->children[0];
+    int ok = child && child->text && std::strcmp(child->text, "value") == 0;
+    char *written = doc.write_to_string();
+    if (!written)
+        return (0);
+    int ok2 = std::strcmp(written, "<root><child>value</child></root>\n") == 0;
+    cma_free(written);
+    return (ok && ok2);
+}
+

--- a/XML/Makefile
+++ b/XML/Makefile
@@ -1,0 +1,70 @@
+TARGET         := XMLParser.a
+DEBUG_TARGET   := XMLParser_debug.a
+
+SRCS := xml_document.cpp
+
+HEADERS := xml.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
+clean:
+	-$(RM) $(CLEAN_FILES)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/XML/xml.hpp
+++ b/XML/xml.hpp
@@ -1,0 +1,51 @@
+#ifndef XML_HPP
+#define XML_HPP
+
+#include "../Template/vector.hpp"
+#include "../Template/unordened_map.hpp"
+#include "../Errno/errno.hpp"
+#include "../CMA/CMA.hpp"
+
+struct xml_node
+{
+    char *name;
+    char *text;
+    ft_vector<xml_node*> children;
+    ft_unord_map<char*, char*> attributes;
+
+    xml_node() noexcept;
+    ~xml_node() noexcept;
+};
+
+/*
+Example usage:
+xml_document doc;
+doc.load_from_string("<root><child>value</child></root>");
+xml_node *root = doc.get_root();
+char *output = doc.write_to_string();
+if (output)
+    cma_free(output);
+*/
+
+class xml_document
+{
+    private:
+        xml_node *_root;
+        mutable int _error_code;
+
+        void set_error(int error_code) const;
+
+    public:
+        xml_document() noexcept;
+        ~xml_document() noexcept;
+
+        int load_from_string(const char *xml) noexcept;
+        int load_from_file(const char *file_path) noexcept;
+        char *write_to_string() const noexcept;
+        int write_to_file(const char *file_path) const noexcept;
+        xml_node *get_root() const noexcept;
+        int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
+};
+
+#endif

--- a/XML/xml_document.cpp
+++ b/XML/xml_document.cpp
@@ -1,0 +1,321 @@
+#include "xml.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Libft/libft.hpp"
+#include <cstdio>
+
+static const char *skip_whitespace(const char *string)
+{
+    while (string && (*string == ' ' || *string == '\n' || *string == '\t' || *string == '\r'))
+        string++;
+    return (string);
+}
+
+static char *duplicate_range(const char *start, size_t length)
+{
+    char *copy = (char *)cma_malloc(length + 1);
+    if (!copy)
+        return (ft_nullptr);
+    size_t index = 0;
+    while (index < length)
+    {
+        copy[index] = start[index];
+        index++;
+    }
+    copy[length] = '\0';
+    return (copy);
+}
+
+xml_node::xml_node() noexcept
+    : name(ft_nullptr), text(ft_nullptr), children(), attributes()
+{
+    return ;
+}
+
+xml_node::~xml_node() noexcept
+{
+    size_t child_index = 0;
+    size_t child_size = this->children.size();
+    while (child_index < child_size)
+    {
+        xml_node *child = this->children[child_index];
+        if (child)
+            delete child;
+        child_index++;
+    }
+    ft_unord_map<char*, char*>::iterator it = this->attributes.begin();
+    ft_unord_map<char*, char*>::iterator end = this->attributes.end();
+    while (it != end)
+    {
+        if (it->first)
+            cma_free(it->first);
+        if (it->second)
+            cma_free(it->second);
+        ++it;
+    }
+    if (this->name)
+        cma_free(this->name);
+    if (this->text)
+        cma_free(this->text);
+    return ;
+}
+
+static const char *parse_node(const char *string, xml_node **out_node)
+{
+    string = skip_whitespace(string);
+    if (!string || *string != '<')
+        return (ft_nullptr);
+    string++;
+    const char *name_start = string;
+    while (*string && *string != '>' && *string != ' ' && *string != '/')
+        string++;
+    size_t name_length = (size_t)(string - name_start);
+    char *name = duplicate_range(name_start, name_length);
+    xml_node *node = new xml_node();
+    if (!node || !name)
+    {
+        if (node)
+            delete node;
+        if (name)
+            cma_free(name);
+        return (ft_nullptr);
+    }
+    node->name = name;
+    while (*string && *string != '>')
+        string++;
+    if (*string != '>')
+    {
+        delete node;
+        return (ft_nullptr);
+    }
+    string++;
+    const char *text_start = string;
+    if (*string == '<' && string[1] == '/');
+    else if (*string == '<')
+    {
+        while (1)
+        {
+            xml_node *child = ft_nullptr;
+            string = parse_node(string, &child);
+            if (!string)
+            {
+                delete node;
+                return (ft_nullptr);
+            }
+            node->children.push_back(child);
+            string = skip_whitespace(string);
+            if (*string == '<' && string[1] == '/')
+                break;
+        }
+    }
+    else
+    {
+        while (*string && !(*string == '<' && string[1] == '/'))
+            string++;
+        size_t text_length = (size_t)(string - text_start);
+        node->text = duplicate_range(text_start, text_length);
+    }
+    if (*string != '<' || string[1] != '/')
+    {
+        delete node;
+        return (ft_nullptr);
+    }
+    string += 2;
+    while (*string && *string != '>')
+        string++;
+    if (*string != '>')
+    {
+        delete node;
+        return (ft_nullptr);
+    }
+    string++;
+    *out_node = node;
+    return (string);
+}
+
+xml_document::xml_document() noexcept
+    : _root(ft_nullptr), _error_code(ER_SUCCESS)
+{
+    return ;
+}
+
+xml_document::~xml_document() noexcept
+{
+    if (this->_root)
+        delete this->_root;
+    return ;
+}
+
+void xml_document::set_error(int error_code) const
+{
+    this->_error_code = error_code;
+    ft_errno = error_code;
+    return ;
+}
+
+int xml_document::load_from_string(const char *xml) noexcept
+{
+    if (!xml)
+    {
+        this->set_error(FT_EINVAL);
+        return (FT_EINVAL);
+    }
+    if (this->_root)
+    {
+        delete this->_root;
+        this->_root = ft_nullptr;
+    }
+    xml_node *node = ft_nullptr;
+    const char *end = parse_node(xml, &node);
+    if (!end)
+    {
+        this->set_error(FT_EINVAL);
+        return (FT_EINVAL);
+    }
+    this->_root = node;
+    return (ER_SUCCESS);
+}
+
+static int read_file_content(const char *file_path, char **out_content)
+{
+    FILE *file = std::fopen(file_path, "rb");
+    if (!file)
+        return (FT_EINVAL);
+    if (std::fseek(file, 0, SEEK_END) != 0)
+    {
+        std::fclose(file);
+        return (FT_EINVAL);
+    }
+    long size = std::ftell(file);
+    if (size <= 0)
+    {
+        std::fclose(file);
+        return (FT_EINVAL);
+    }
+    if (std::fseek(file, 0, SEEK_SET) != 0)
+    {
+        std::fclose(file);
+        return (FT_EINVAL);
+    }
+    char *buffer = (char *)cma_malloc((size_t)size + 1);
+    if (!buffer)
+    {
+        std::fclose(file);
+        return (CMA_BAD_ALLOC);
+    }
+    size_t read_size = std::fread(buffer, 1, (size_t)size, file);
+    std::fclose(file);
+    if (read_size != (size_t)size)
+    {
+        cma_free(buffer);
+        return (FT_EINVAL);
+    }
+    buffer[size] = '\0';
+    *out_content = buffer;
+    return (ER_SUCCESS);
+}
+
+int xml_document::load_from_file(const char *file_path) noexcept
+{
+    char *content = ft_nullptr;
+    int result = read_file_content(file_path, &content);
+    if (result != ER_SUCCESS)
+    {
+        this->set_error(result);
+        return (result);
+    }
+    result = this->load_from_string(content);
+    cma_free(content);
+    return (result);
+}
+
+static void append_string(ft_vector<char> &buffer, const char *string)
+{
+    if (!string)
+        return ;
+    size_t index = 0;
+    size_t length = ft_strlen(string);
+    while (index < length)
+    {
+        buffer.push_back(string[index]);
+        index++;
+    }
+    return ;
+}
+
+static void write_node(const xml_node *node, ft_vector<char> &buffer)
+{
+    buffer.push_back('<');
+    append_string(buffer, node->name);
+    buffer.push_back('>');
+    if (node->text)
+        append_string(buffer, node->text);
+    size_t index = 0;
+    size_t size = node->children.size();
+    while (index < size)
+    {
+        write_node(node->children[index], buffer);
+        index++;
+    }
+    buffer.push_back('<');
+    buffer.push_back('/');
+    append_string(buffer, node->name);
+    buffer.push_back('>');
+    return ;
+}
+
+char *xml_document::write_to_string() const noexcept
+{
+    if (!this->_root)
+        return (ft_nullptr);
+    ft_vector<char> buffer;
+    write_node(this->_root, buffer);
+    buffer.push_back('\n');
+    buffer.push_back('\0');
+    size_t length = buffer.size();
+    char *result = (char *)cma_malloc(length);
+    if (!result)
+        return (ft_nullptr);
+    size_t index = 0;
+    while (index < length)
+    {
+        result[index] = buffer[index];
+        index++;
+    }
+    return (result);
+}
+
+int xml_document::write_to_file(const char *file_path) const noexcept
+{
+    char *content = this->write_to_string();
+    if (!content)
+        return (FT_EINVAL);
+    FILE *file = std::fopen(file_path, "wb");
+    if (!file)
+    {
+        cma_free(content);
+        return (FT_EINVAL);
+    }
+    size_t length = ft_strlen(content);
+    size_t written = std::fwrite(content, 1, length, file);
+    std::fclose(file);
+    cma_free(content);
+    if (written != length)
+        return (FT_EINVAL);
+    return (ER_SUCCESS);
+}
+
+xml_node *xml_document::get_root() const noexcept
+{
+    return (this->_root);
+}
+
+int xml_document::get_error() const noexcept
+{
+    return (this->_error_code);
+}
+
+const char *xml_document::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error_code));
+}
+


### PR DESCRIPTION
## Summary
- add lightweight XML DOM structures and parser
- expose xml_document API for reading/writing strings and files
- document XML module and add unit test
- remove outdated compression README

## Testing
- `make -C Test`
- `printf "run\nall\nexit\n" | ./Test/libft_tests` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e87b2e948331b857c62382a1afcd