### PR TITLE
Add Poisson random generator and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,14 @@ int   ft_dice_roll(int number, int faces);
 float ft_random_float(void);
 float ft_random_normal(void);
 float ft_random_exponential(float lambda_value);
+int   ft_random_poisson(double lambda_value);
 int   ft_random_seed(const char *seed_str = ft_nullptr);
+```
+
+Example:
+
+```
+int occurrences = ft_random_poisson(4.0);
 ```
 
 `RNG/deck.hpp` provides a simple deck container:

--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -2,7 +2,8 @@ TARGET := RNG.a
 DEBUG_TARGET := RNG_debug.a
 
 SRCS := rng_dice_roll.cpp rng_random_int.cpp rng_random_float.cpp \
-       rng_random_normal.cpp rng_random_exponential.cpp rng_random_seed.cpp
+       rng_random_normal.cpp rng_random_exponential.cpp rng_random_poisson.cpp \
+       rng_random_seed.cpp
 
 HEADERS := rng.hpp rng_internal.hpp deck.hpp loot_table.hpp
 

--- a/RNG/rng.hpp
+++ b/RNG/rng.hpp
@@ -14,6 +14,7 @@ int ft_dice_roll(int number, int faces);
 float ft_random_float(void);
 float ft_random_normal(void);
 float ft_random_exponential(float lambda_value);
+int ft_random_poisson(double lambda_value);
 int ft_random_seed(const char *seed_str = ft_nullptr);
 
 #endif

--- a/RNG/rng_random_poisson.cpp
+++ b/RNG/rng_random_poisson.cpp
@@ -1,0 +1,25 @@
+#include "rng.hpp"
+#include "rng_internal.hpp"
+#include "../Math/math.hpp"
+
+int ft_random_poisson(double lambda_value)
+{
+    double limit_value;
+    double product_value;
+    int count_value;
+    double random_value;
+
+    ft_init_srand();
+    if (lambda_value <= 0.0)
+        return (0);
+    limit_value = math_exp(-lambda_value);
+    product_value = 1.0;
+    count_value = 0;
+    while (product_value > limit_value)
+    {
+        random_value = static_cast<double>(ft_random_float());
+        product_value = product_value * random_value;
+        count_value = count_value + 1;
+    }
+    return (count_value - 1);
+}

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -205,6 +205,7 @@ int test_math_eval_dice_rejected(void);
 int test_encryption_key_random(void);
 int test_rng_random_normal(void);
 int test_rng_random_exponential(void);
+int test_rng_random_poisson(void);
 int test_json_roundtrip_string(void);
 int test_json_roundtrip_file(void);
 int test_json_validate_success(void);
@@ -455,6 +456,7 @@ int main(int argc, char **argv)
         { test_encryption_key_random, "encryption key random" },
         { test_rng_random_normal, "rng random normal" },
         { test_rng_random_exponential, "rng random exponential" },
+        { test_rng_random_poisson, "rng random poisson" },
         { test_json_roundtrip_string, "json roundtrip string" },
         { test_json_roundtrip_file, "json roundtrip file" },
         { test_json_validate_success, "json validate success" },

--- a/Test/test_rng.cpp
+++ b/Test/test_rng.cpp
@@ -41,3 +41,25 @@ int test_rng_random_exponential(void)
         return (0);
     return (1);
 }
+
+int test_rng_random_poisson(void)
+{
+    g_srand_init = true;
+    srand(123);
+    int sample_count = 10000;
+    int index = 0;
+    int sum_values = 0;
+    double lambda_value = 4.0;
+    while (index < sample_count)
+    {
+        sum_values += ft_random_poisson(lambda_value);
+        index++;
+    }
+    double mean_value = static_cast<double>(sum_values) /
+                         static_cast<double>(sample_count);
+    if (mean_value < lambda_value - 0.1)
+        return (0);
+    if (mean_value > lambda_value + 0.1)
+        return (0);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- implement Poisson random number generator via inverse transform sampling
- expose `ft_random_poisson` and update RNG build and docs
- add unit test verifying Poisson mean matches lambda

## Testing
- `g++ -std=c++17 poisson_test.cpp ../RNG/RNG.a ../Math/Math.a ../CPP_class/CPP_class.a -I.. -I../RNG -I../Math -I../CPP_class -o poisson_test`
- `./poisson_test`


------
https://chatgpt.com/codex/tasks/task_e_68c2f08885748331a9d3198bdf4d75f9