### PR TITLE
Add nonblocking socket polling utilities

### DIFF
--- a/Networking/Makefile
+++ b/Networking/Makefile
@@ -6,7 +6,8 @@ SRCS := networking_socket_class.cpp \
         networking_setup_server.cpp \
         networking_setup_client.cpp \
         networking_socket_wrapper_functions.cpp \
-        networking_ssl_wrapper.cpp
+        networking_ssl_wrapper.cpp \
+        networking_nonblocking.cpp
 
 HEADERS := socket_class.hpp \
            networking.hpp \

--- a/Networking/networking.hpp
+++ b/Networking/networking.hpp
@@ -16,6 +16,10 @@ int nw_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 int nw_listen(int sockfd, int backlog);
 int nw_socket(int domain, int type, int protocol);
 int nw_inet_pton(int family, const char *ip_address, void *destination);
+int nw_set_nonblocking(int socket_fd);
+int nw_poll(int *read_file_descriptors, int read_count,
+            int *write_file_descriptors, int write_count,
+            int timeout_milliseconds);
 
 enum class SocketType
 {

--- a/Networking/networking_nonblocking.cpp
+++ b/Networking/networking_nonblocking.cpp
@@ -1,0 +1,229 @@
+#include "networking.hpp"
+#ifdef _WIN32
+# include <winsock2.h>
+#else
+# include <fcntl.h>
+# include <unistd.h>
+# include <sys/select.h>
+# ifdef __linux__
+#  include <sys/epoll.h>
+#  include <stdlib.h>
+# endif
+#endif
+
+int nw_set_nonblocking(int socket_fd)
+{
+#ifdef _WIN32
+    u_long mode;
+    mode = 1;
+    if (ioctlsocket(static_cast<SOCKET>(socket_fd), FIONBIO, &mode) != 0)
+        return (-1);
+    return (0);
+#else
+    int flags;
+    flags = fcntl(socket_fd, F_GETFL, 0);
+    if (flags == -1)
+        return (-1);
+    if (fcntl(socket_fd, F_SETFL, flags | O_NONBLOCK) == -1)
+        return (-1);
+    return (0);
+#endif
+}
+
+int nw_poll(int *read_file_descriptors, int read_count,
+            int *write_file_descriptors, int write_count,
+            int timeout_milliseconds)
+{
+#ifdef _WIN32
+    fd_set read_set;
+    fd_set write_set;
+    int index;
+    int max_descriptor;
+    int ready_descriptors;
+    int total_ready;
+    timeval timeout;
+
+    FD_ZERO(&read_set);
+    FD_ZERO(&write_set);
+    index = 0;
+    max_descriptor = 0;
+    while (read_file_descriptors && index < read_count)
+    {
+        FD_SET(static_cast<SOCKET>(read_file_descriptors[index]), &read_set);
+        if (read_file_descriptors[index] > max_descriptor)
+            max_descriptor = read_file_descriptors[index];
+        index++;
+    }
+    index = 0;
+    while (write_file_descriptors && index < write_count)
+    {
+        FD_SET(static_cast<SOCKET>(write_file_descriptors[index]), &write_set);
+        if (write_file_descriptors[index] > max_descriptor)
+            max_descriptor = write_file_descriptors[index];
+        index++;
+    }
+    timeout.tv_sec = timeout_milliseconds / 1000;
+    timeout.tv_usec = (timeout_milliseconds % 1000) * 1000;
+    ready_descriptors = select(max_descriptor + 1, &read_set, &write_set, NULL, &timeout);
+    if (ready_descriptors <= 0)
+        return (ready_descriptors);
+    index = 0;
+    total_ready = 0;
+    while (read_file_descriptors && index < read_count)
+    {
+        if (!FD_ISSET(static_cast<SOCKET>(read_file_descriptors[index]), &read_set))
+            read_file_descriptors[index] = -1;
+        else
+            total_ready++;
+        index++;
+    }
+    index = 0;
+    while (write_file_descriptors && index < write_count)
+    {
+        if (!FD_ISSET(static_cast<SOCKET>(write_file_descriptors[index]), &write_set))
+            write_file_descriptors[index] = -1;
+        else
+            total_ready++;
+        index++;
+    }
+    return (total_ready);
+#elif defined(__linux__)
+    int epoll_descriptor;
+    epoll_event event;
+    epoll_event *events;
+    int index;
+    int maximum_events;
+    int ready_descriptors;
+    int ready_index;
+    int descriptor;
+    int search_index;
+
+    epoll_descriptor = epoll_create1(0);
+    if (epoll_descriptor == -1)
+        return (-1);
+    index = 0;
+    while (read_file_descriptors && index < read_count)
+    {
+        event.events = EPOLLIN;
+        event.data.fd = read_file_descriptors[index];
+        if (epoll_ctl(epoll_descriptor, EPOLL_CTL_ADD, read_file_descriptors[index], &event) == -1)
+        {
+            close(epoll_descriptor);
+            return (-1);
+        }
+        index++;
+    }
+    index = 0;
+    while (write_file_descriptors && index < write_count)
+    {
+        event.events = EPOLLOUT;
+        event.data.fd = write_file_descriptors[index];
+        if (epoll_ctl(epoll_descriptor, EPOLL_CTL_ADD, write_file_descriptors[index], &event) == -1)
+        {
+            close(epoll_descriptor);
+            return (-1);
+        }
+        index++;
+    }
+    maximum_events = read_count + write_count;
+    if (maximum_events == 0)
+    {
+        close(epoll_descriptor);
+        return (0);
+    }
+    events = static_cast<epoll_event *>(malloc(sizeof(epoll_event) * maximum_events));
+    if (!events)
+    {
+        close(epoll_descriptor);
+        return (-1);
+    }
+    ready_descriptors = epoll_wait(epoll_descriptor, events, maximum_events, timeout_milliseconds);
+    if (ready_descriptors <= 0)
+    {
+        free(events);
+        close(epoll_descriptor);
+        return (ready_descriptors);
+    }
+    ready_index = 0;
+    while (ready_index < ready_descriptors)
+    {
+        descriptor = events[ready_index].data.fd;
+        search_index = 0;
+        while (read_file_descriptors && search_index < read_count)
+        {
+            if (read_file_descriptors[search_index] == descriptor)
+                break;
+            search_index++;
+        }
+        if (read_file_descriptors && search_index < read_count)
+            read_file_descriptors[search_index] = descriptor;
+        search_index = 0;
+        while (write_file_descriptors && search_index < write_count)
+        {
+            if (write_file_descriptors[search_index] == descriptor)
+                break;
+            search_index++;
+        }
+        if (write_file_descriptors && search_index < write_count)
+            write_file_descriptors[search_index] = descriptor;
+        ready_index++;
+    }
+    free(events);
+    close(epoll_descriptor);
+    return (ready_descriptors);
+#else
+    fd_set read_set;
+    fd_set write_set;
+    int index;
+    int max_descriptor;
+    int ready_descriptors;
+    int total_ready;
+    timeval timeout;
+
+    FD_ZERO(&read_set);
+    FD_ZERO(&write_set);
+    index = 0;
+    max_descriptor = 0;
+    while (read_file_descriptors && index < read_count)
+    {
+        FD_SET(read_file_descriptors[index], &read_set);
+        if (read_file_descriptors[index] > max_descriptor)
+            max_descriptor = read_file_descriptors[index];
+        index++;
+    }
+    index = 0;
+    while (write_file_descriptors && index < write_count)
+    {
+        FD_SET(write_file_descriptors[index], &write_set);
+        if (write_file_descriptors[index] > max_descriptor)
+            max_descriptor = write_file_descriptors[index];
+        index++;
+    }
+    timeout.tv_sec = timeout_milliseconds / 1000;
+    timeout.tv_usec = (timeout_milliseconds % 1000) * 1000;
+    ready_descriptors = select(max_descriptor + 1, &read_set, &write_set, NULL, &timeout);
+    if (ready_descriptors <= 0)
+        return (ready_descriptors);
+    index = 0;
+    total_ready = 0;
+    while (read_file_descriptors && index < read_count)
+    {
+        if (!FD_ISSET(read_file_descriptors[index], &read_set))
+            read_file_descriptors[index] = -1;
+        else
+            total_ready++;
+        index++;
+    }
+    index = 0;
+    while (write_file_descriptors && index < write_count)
+    {
+        if (!FD_ISSET(write_file_descriptors[index], &write_set))
+            write_file_descriptors[index] = -1;
+        else
+            total_ready++;
+        index++;
+    }
+    return (total_ready);
+#endif
+}
+

--- a/README.md
+++ b/README.md
@@ -377,6 +377,10 @@ int nw_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 int nw_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 int nw_listen(int sockfd, int backlog);
 int nw_socket(int domain, int type, int protocol);
+int nw_set_nonblocking(int socket_fd);
+int nw_poll(int *read_file_descriptors, int read_count,
+            int *write_file_descriptors, int write_count,
+            int timeout_milliseconds);
 ```
 
 `wrapper.hpp` adds helpers for encrypted sockets:
@@ -384,6 +388,32 @@ int nw_socket(int domain, int type, int protocol);
 ```
 ssize_t nw_ssl_write(SSL *ssl, const void *buf, size_t len);
 ssize_t nw_ssl_read(SSL *ssl, void *buf, size_t len);
+```
+
+Simple event loop example:
+
+```
+#include "Networking/networking.hpp"
+
+int main()
+{
+    int server_socket;
+    int read_descriptors[1];
+    int result;
+
+    server_socket = nw_socket(AF_INET, SOCK_STREAM, 0);
+    nw_set_nonblocking(server_socket);
+    read_descriptors[0] = server_socket;
+    while (true)
+    {
+        result = nw_poll(read_descriptors, 1, NULL, 0, 1000);
+        if (result > 0 && read_descriptors[0] != -1)
+        {
+            /* handle events */
+        }
+    }
+    return (0);
+}
 ```
 
 #### `SocketConfig`


### PR DESCRIPTION
## Summary
- add cross-platform `nw_set_nonblocking` and `nw_poll` helpers
- expose new APIs in networking headers and build
- document simple event loop usage

## Testing
- `make -C Networking`


------
https://chatgpt.com/codex/tasks/task_e_68c2f56e8cac8331b5d6ea2da0a83292