### PR TITLE
Add basic RSA encryption

### DIFF
--- a/Encryption/Makefile
+++ b/Encryption/Makefile
@@ -3,10 +3,12 @@ DEBUG_TARGET := encryption_debug.a
 
 SRCS := encryption_basic_encryption.cpp \
         encryption_key.cpp \
-        encryption_aes.cpp
+        encryption_aes.cpp \
+        encryption_rsa.cpp
 
 HEADERS := basic_encryption.hpp \
-        aes.hpp
+        aes.hpp \
+        rsa.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Encryption/README
+++ b/Encryption/README
@@ -9,3 +9,25 @@ unavailable, it falls back to `ft_random_seed` to preserve variability.
 Mapping bytes to alphabetic characters maintains compatibility with the
 existing interface while ensuring keys differ across runs.
 
+## RSA
+
+Basic RSA helpers generate a key pair and perform modular exponentiation for
+encrypting and decrypting small integers.
+
+### Usage
+
+```
+uint64_t public_key;
+uint64_t private_key;
+uint64_t modulus;
+rsa_generate_key_pair(&public_key, &private_key, &modulus, 32);
+uint64_t encrypted = rsa_encrypt(42, public_key, modulus);
+uint64_t decrypted = rsa_decrypt(encrypted, private_key, modulus);
+```
+
+### Warning
+
+This implementation uses small primes for demonstration and relies on 64-bit
+arithmetic. Large key sizes drastically slow down operations and may exceed
+the limits of this module. For real-world security, use keys of at least 2048
+bits and a vetted cryptographic library.

--- a/Encryption/basic_encryption.hpp
+++ b/Encryption/basic_encryption.hpp
@@ -2,6 +2,7 @@
 #define BASIC_ENCRYPTION_HPP
 
 #include "aes.hpp"
+#include "rsa.hpp"
 
 int            be_saveGame(const char *filename, const char *data, const char *key);
 char        **be_DecryptData(char **data, const char *key);
@@ -13,6 +14,13 @@ Usage:
     unsigned char key[16] = {0};
     aes_encrypt(block, key);
     aes_decrypt(block, key);
+
+    uint64_t public_key;
+    uint64_t private_key;
+    uint64_t modulus;
+    rsa_generate_key_pair(&public_key, &private_key, &modulus, 32);
+    uint64_t encrypted = rsa_encrypt(42, public_key, modulus);
+    uint64_t decrypted = rsa_decrypt(encrypted, private_key, modulus);
 */
 
 #endif

--- a/Encryption/encryption_rsa.cpp
+++ b/Encryption/encryption_rsa.cpp
@@ -1,0 +1,114 @@
+#include <stdint.h>
+#include "../RNG/rng.hpp"
+#include "rsa.hpp"
+
+static uint64_t rsa_gcd(uint64_t first_value, uint64_t second_value)
+{
+    while (second_value != 0)
+    {
+        uint64_t temp_value = second_value;
+        second_value = first_value % second_value;
+        first_value = temp_value;
+    }
+    return (first_value);
+}
+
+static uint64_t rsa_mod_inverse(uint64_t value, uint64_t modulus)
+{
+    int64_t t_value = 0;
+    int64_t new_t_value = 1;
+    int64_t r_value = static_cast<int64_t>(modulus);
+    int64_t new_r_value = static_cast<int64_t>(value);
+    while (new_r_value != 0)
+    {
+        int64_t quotient_value = r_value / new_r_value;
+        int64_t temp_t_value = t_value - quotient_value * new_t_value;
+        t_value = new_t_value;
+        new_t_value = temp_t_value;
+        int64_t temp_r_value = r_value - quotient_value * new_r_value;
+        r_value = new_r_value;
+        new_r_value = temp_r_value;
+    }
+    if (r_value > 1)
+        return (0);
+    if (t_value < 0)
+        t_value += modulus;
+    return (static_cast<uint64_t>(t_value));
+}
+
+static bool rsa_is_prime(uint64_t value)
+{
+    if (value < 2)
+        return (false);
+    uint64_t divisor_value = 2;
+    while (divisor_value * divisor_value <= value)
+    {
+        if (value % divisor_value == 0)
+            return (false);
+        divisor_value = divisor_value + 1;
+    }
+    return (true);
+}
+
+static uint64_t rsa_generate_prime(uint64_t limit)
+{
+    uint64_t prime_candidate = 0;
+    while (prime_candidate < 2 || rsa_is_prime(prime_candidate) == false)
+    {
+        prime_candidate = static_cast<uint64_t>(ft_random_int()) % limit;
+        if ((prime_candidate & 1) == 0)
+            prime_candidate = prime_candidate + 1;
+    }
+    return (prime_candidate);
+}
+
+static uint64_t rsa_mod_pow(uint64_t base_value, uint64_t exponent_value, uint64_t modulus_value)
+{
+    uint64_t result_value = 1;
+    base_value = base_value % modulus_value;
+    while (exponent_value > 0)
+    {
+        if ((exponent_value & 1) == 1)
+            result_value = (result_value * base_value) % modulus_value;
+        exponent_value = exponent_value >> 1;
+        base_value = (base_value * base_value) % modulus_value;
+    }
+    return (result_value);
+}
+
+int rsa_generate_key_pair(uint64_t *public_key, uint64_t *private_key, uint64_t *modulus, int bit_size)
+{
+    if (!public_key || !private_key || !modulus)
+        return (1);
+    uint64_t limit_value = 1ULL << (bit_size / 2);
+    uint64_t prime_one = rsa_generate_prime(limit_value);
+    uint64_t prime_two = rsa_generate_prime(limit_value);
+    while (prime_two == prime_one)
+        prime_two = rsa_generate_prime(limit_value);
+    uint64_t phi_value = (prime_one - 1) * (prime_two - 1);
+    *modulus = prime_one * prime_two;
+    uint64_t public_exponent = 65537;
+    if (rsa_gcd(public_exponent, phi_value) != 1)
+    {
+        public_exponent = 3;
+        while (rsa_gcd(public_exponent, phi_value) != 1)
+            public_exponent = public_exponent + 2;
+    }
+    uint64_t private_exponent = rsa_mod_inverse(public_exponent, phi_value);
+    if (private_exponent == 0)
+        return (1);
+    *public_key = public_exponent;
+    *private_key = private_exponent;
+    return (0);
+}
+
+uint64_t rsa_encrypt(uint64_t message, uint64_t public_key, uint64_t modulus)
+{
+    return (rsa_mod_pow(message, public_key, modulus));
+}
+
+uint64_t rsa_decrypt(uint64_t cipher, uint64_t private_key, uint64_t modulus)
+{
+    return (rsa_mod_pow(cipher, private_key, modulus));
+}
+

--- a/Encryption/rsa.hpp
+++ b/Encryption/rsa.hpp
@@ -1,0 +1,20 @@
+#ifndef RSA_HPP
+#define RSA_HPP
+
+#include <stdint.h>
+
+int        rsa_generate_key_pair(uint64_t *public_key, uint64_t *private_key, uint64_t *modulus, int bit_size);
+uint64_t    rsa_encrypt(uint64_t message, uint64_t public_key, uint64_t modulus);
+uint64_t    rsa_decrypt(uint64_t cipher, uint64_t private_key, uint64_t modulus);
+
+/*
+Usage:
+    uint64_t public_key;
+    uint64_t private_key;
+    uint64_t modulus;
+    rsa_generate_key_pair(&public_key, &private_key, &modulus, 32);
+    uint64_t encrypted = rsa_encrypt(42, public_key, modulus);
+    uint64_t decrypted = rsa_decrypt(encrypted, private_key, modulus);
+*/
+
+#endif

--- a/README.md
+++ b/README.md
@@ -648,7 +648,12 @@ char      **be_DecryptData(char **data, const char *key);
 const char *be_getEncryptionKey();
 void        aes_encrypt(uint8_t *block, const uint8_t *key);
 void        aes_decrypt(uint8_t *block, const uint8_t *key);
+int         rsa_generate_key_pair(uint64_t *public_key, uint64_t *private_key, uint64_t *modulus, int bit_size);
+uint64_t    rsa_encrypt(uint64_t message, uint64_t public_key, uint64_t modulus);
+uint64_t    rsa_decrypt(uint64_t cipher, uint64_t private_key, uint64_t modulus);
 ```
+
+RSA helpers operate on 64-bit integers and are intended for small demonstrations. Key generation with large sizes significantly impacts performance.
 
 `be_getEncryptionKey` sources entropy from `/dev/urandom` on Unix or
 `CryptGenRandom` on Windows with a fallback to `ft_random_seed`, ensuring
@@ -661,6 +666,12 @@ unsigned char block[16] = {0};
 unsigned char key[16] = {0};
 aes_encrypt(block, key);
 aes_decrypt(block, key);
+uint64_t public_key;
+uint64_t private_key;
+uint64_t modulus;
+rsa_generate_key_pair(&public_key, &private_key, &modulus, 32);
+uint64_t encrypted = rsa_encrypt(42, public_key, modulus);
+uint64_t decrypted = rsa_decrypt(encrypted, private_key, modulus);
 ```
 
 #### Compression


### PR DESCRIPTION
## Summary
- implement RSA key generation and basic encrypt/decrypt helpers
- expose RSA helpers through basic_encryption.hpp
- document RSA usage with key size and performance warnings

## Testing
- `cd Encryption && make`


------
https://chatgpt.com/codex/tasks/task_e_68c319746c248331bbf3159eefffb337