### PR TITLE
Replace libc string search and snprintf calls with libft versions

### DIFF
--- a/API/api_request.cpp
+++ b/API/api_request.cpp
@@ -4,8 +4,7 @@
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
 #include "../Logger/logger.hpp"
-#include <cstring>
-#include <cstdio>
+#include "../Printf/printf.hpp"
 #include <string>
 #include <thread>
 #include <errno.h>
@@ -99,11 +98,11 @@ char *api_request_string(const char *ip, uint16_t port,
     if (status)
     {
         *status = -1;
-        const char *space = strchr(response.c_str(), ' ');
+        const char *space = ft_strchr(response.c_str(), ' ');
         if (space)
             *status = ft_atoi(space + 1);
     }
-    const char *body = strstr(response.c_str(), "\r\n\r\n");
+    const char *body = ft_strstr(response.c_str(), "\r\n\r\n");
     if (!body)
         return (ft_nullptr);
     body += 4;
@@ -159,7 +158,7 @@ char *api_request_string_host(const char *host, uint16_t port,
     ft_bzero(&hints, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_family = AF_UNSPEC;
-    std::snprintf(port_string, sizeof(port_string), "%u", port);
+    pf_snprintf(port_string, sizeof(port_string), "%u", port);
     if (getaddrinfo(host, port_string, &hints, &address_results) != 0)
         goto cleanup;
 
@@ -231,11 +230,11 @@ char *api_request_string_host(const char *host, uint16_t port,
     if (status)
     {
         *status = -1;
-        const char *space = strchr(response.c_str(), ' ');
+        const char *space = ft_strchr(response.c_str(), ' ');
         if (space)
             *status = ft_atoi(space + 1);
     }
-    body = strstr(response.c_str(), "\r\n\r\n");
+    body = ft_strstr(response.c_str(), "\r\n\r\n");
     if (!body)
         goto cleanup;
     body += 4;
@@ -396,13 +395,13 @@ static bool parse_url(const char *url, bool &tls, std::string &host,
 {
     if (!url)
         return (false);
-    const char *scheme_end = std::strstr(url, "://");
+    const char *scheme_end = ft_strstr(url, "://");
     if (!scheme_end)
         return (false);
     std::string scheme(url, scheme_end - url);
     tls = (scheme == "https");
     const char *host_start = scheme_end + 3;
-    const char *path_start = std::strchr(host_start, '/');
+    const char *path_start = ft_strchr(host_start, '/');
     if (path_start)
         path.assign(path_start);
     else
@@ -412,7 +411,7 @@ static bool parse_url(const char *url, bool &tls, std::string &host,
         hostport.assign(host_start, path_start - host_start);
     else
         hostport = host_start;
-    const char *colon = std::strchr(hostport.c_str(), ':');
+    const char *colon = ft_strchr(hostport.c_str(), ':');
     if (colon)
     {
         host.assign(hostport.c_str(), colon - hostport.c_str());
@@ -506,7 +505,7 @@ static void api_async_worker(api_async_request *data)
     ft_bzero(&hints, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_family = AF_UNSPEC;
-    std::snprintf(port_string, sizeof(port_string), "%u", data->port);
+    pf_snprintf(port_string, sizeof(port_string), "%u", data->port);
     if (getaddrinfo(data->ip, port_string, &hints, &address_results) != 0)
         goto cleanup;
     address_info = address_results;
@@ -620,10 +619,10 @@ static void api_async_worker(api_async_request *data)
 
     if (response.size() > 0)
     {
-        const char *space = strchr(response.c_str(), ' ');
+        const char *space = ft_strchr(response.c_str(), ' ');
         if (space)
             status = ft_atoi(space + 1);
-        const char *body = strstr(response.c_str(), "\r\n\r\n");
+        const char *body = ft_strstr(response.c_str(), "\r\n\r\n");
         if (body)
         {
             body += 4;

--- a/API/api_request_tls.cpp
+++ b/API/api_request_tls.cpp
@@ -5,8 +5,7 @@
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
 #include "../Logger/logger.hpp"
-#include <cstring>
-#include <cstdio>
+#include "../Printf/printf.hpp"
 #include <thread>
 #include <errno.h>
 #ifdef _WIN32
@@ -80,7 +79,7 @@ char *api_request_string_tls(const char *host, uint16_t port,
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_family = AF_UNSPEC;
     char port_string[6];
-    std::snprintf(port_string, sizeof(port_string), "%u", port);
+    pf_snprintf(port_string, sizeof(port_string), "%u", port);
     if (getaddrinfo(host, port_string, &hints, &address_results) != 0)
         goto cleanup;
 
@@ -161,11 +160,11 @@ char *api_request_string_tls(const char *host, uint16_t port,
     if (status)
     {
         *status = -1;
-        const char *space = strchr(response.c_str(), ' ');
+        const char *space = ft_strchr(response.c_str(), ' ');
         if (space)
             *status = ft_atoi(space + 1);
     }
-    body = strstr(response.c_str(), "\r\n\r\n");
+    body = ft_strstr(response.c_str(), "\r\n\r\n");
     if (!body)
         goto cleanup;
     body += 4;
@@ -309,7 +308,7 @@ static void api_tls_async_worker(api_tls_async_request *data)
     ft_bzero(&hints, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_family = AF_UNSPEC;
-    std::snprintf(port_string, sizeof(port_string), "%u", data->port);
+    pf_snprintf(port_string, sizeof(port_string), "%u", data->port);
     if (getaddrinfo(data->host, port_string, &hints, &address_results) != 0)
         goto cleanup;
     address_info = address_results;
@@ -469,10 +468,10 @@ static void api_tls_async_worker(api_tls_async_request *data)
 
     if (response.size() > 0)
     {
-        const char *space = strchr(response.c_str(), ' ');
+        const char *space = ft_strchr(response.c_str(), ' ');
         if (space)
             status = ft_atoi(space + 1);
-        const char *body = strstr(response.c_str(), "\r\n\r\n");
+        const char *body = ft_strstr(response.c_str(), "\r\n\r\n");
         if (body)
         {
             body += 4;

--- a/API/api_tls_client.cpp
+++ b/API/api_tls_client.cpp
@@ -1,7 +1,6 @@
 #include "tls_client.hpp"
-#include <cstring>
-#include <cstdio>
 #include <thread>
+#include "../Printf/printf.hpp"
 #include "../Networking/socket_class.hpp"
 #include "../Networking/ssl_wrapper.hpp"
 #include "../Libft/libft.hpp"
@@ -56,7 +55,7 @@ api_tls_client::api_tls_client(const char *host_c, uint16_t port, int timeout_ms
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_family = AF_UNSPEC;
     char port_string[6];
-    std::snprintf(port_string, sizeof(port_string), "%u", port);
+    pf_snprintf(port_string, sizeof(port_string), "%u", port);
     if (getaddrinfo(host_c, port_string, &hints, &address_results) != 0)
         return ;
 
@@ -180,23 +179,23 @@ char *api_tls_client::request(const char *method, const char *path, json_group *
             return (ft_nullptr);
         buffer[bytes_received] = '\0';
         response += buffer;
-        header_end_ptr = strstr(response.c_str(), "\r\n\r\n");
+        header_end_ptr = ft_strstr(response.c_str(), "\r\n\r\n");
     }
 
     if (status)
     {
         *status = -1;
-        const char *space = strchr(response.c_str(), ' ');
+        const char *space = ft_strchr(response.c_str(), ' ');
         if (space)
             *status = ft_atoi(space + 1);
     }
 
     size_t header_len = static_cast<size_t>(header_end_ptr - response.c_str()) + 4;
     size_t content_length = 0;
-    const char *content_length_ptr = strstr(response.c_str(), "Content-Length:");
+    const char *content_length_ptr = ft_strstr(response.c_str(), "Content-Length:");
     if (content_length_ptr)
     {
-        content_length_ptr += strlen("Content-Length:");
+        content_length_ptr += ft_strlen("Content-Length:");
         while (*content_length_ptr == ' ') content_length_ptr++;
         content_length = static_cast<size_t>(ft_atoi(content_length_ptr));
     }

--- a/Config/config_flag_parser.cpp
+++ b/Config/config_flag_parser.cpp
@@ -93,7 +93,7 @@ bool cnfg_flag_parser::has_short_flag(char flag)
 {
     if (!this->_short_flags)
         return (false);
-    if (std::strchr(this->_short_flags, flag))
+    if (ft_strchr(this->_short_flags, flag))
         return (true);
     return (false);
 }

--- a/Config/config_flags.cpp
+++ b/Config/config_flags.cpp
@@ -26,7 +26,7 @@ char *cnfg_parse_flags(int argument_count, char **argument_values)
             char current_flag = argument[char_index];
             if (std::isalpha(static_cast<unsigned char>(current_flag)))
             {
-                if (!flags || !std::strchr(flags, current_flag))
+                if (!flags || !ft_strchr(flags, current_flag))
                 {
                     char *new_flags = static_cast<char*>(cma_realloc(flags, length + 2));
                     if (!new_flags)

--- a/Config/config_parse.cpp
+++ b/Config/config_parse.cpp
@@ -60,7 +60,7 @@ cnfg_config *cnfg_parse(const char *filename)
             continue ;
         if (*line_string == '[')
         {
-            char *closing_bracket = std::strchr(line_string, ']');
+            char *closing_bracket = ft_strchr(line_string, ']');
             if (closing_bracket)
             {
                 *closing_bracket = '\0';
@@ -76,7 +76,7 @@ cnfg_config *cnfg_parse(const char *filename)
             }
             continue ;
         }
-        char *equals_sign = std::strchr(line_string, '=');
+        char *equals_sign = ft_strchr(line_string, '=');
         char *key = ft_nullptr;
         char *value = ft_nullptr;
         if (equals_sign)
@@ -316,7 +316,7 @@ cnfg_config *config_load_env()
         char *pair = environ[index];
         char *equals_sign = ft_nullptr;
         if (pair)
-            equals_sign = std::strchr(pair, '=');
+            equals_sign = ft_strchr(pair, '=');
         cnfg_entry *entry = &config->entries[index];
         if (equals_sign)
         {

--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -15,6 +15,7 @@ SRCS := libft_atoi.cpp \
     libft_strlen.cpp \
     libft_strncmp.cpp \
     libft_strnstr.cpp \
+    libft_strstr.cpp \
     libft_strrchr.cpp \
     libft_atol.cpp \
     libft_strtol.cpp \

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -28,6 +28,7 @@ size_t            ft_strlcat(char *destination, const char *source, size_t buffe
 size_t            ft_strlcpy(char *destination, const char *source, size_t bufferSize);
 char            *ft_strrchr(const char *string, int char_to_find);
 char            *ft_strnstr(const char *haystack, const char *needle, size_t length);
+char            *ft_strstr(const char *haystack, const char *needle);
 int                ft_strncmp(const char *string_1, const char *string_2, size_t max_len);
 int                ft_memcmp(const void *pointer1, const void *pointer2, size_t size);
 int                ft_isdigit(int character);

--- a/Libft/libft_strstr.cpp
+++ b/Libft/libft_strstr.cpp
@@ -1,0 +1,12 @@
+#include "libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+char    *ft_strstr(const char *haystack, const char *needle)
+{
+    size_t  haystack_length;
+
+    if (!haystack || !needle)
+        return (ft_nullptr);
+    haystack_length = ft_strlen(haystack);
+    return (ft_strnstr(haystack, needle, haystack_length));
+}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ size_t  ft_strlcat(char *dst, const char *src, size_t size);
 size_t  ft_strlcpy(char *dst, const char *src, size_t size);
 char   *ft_strrchr(const char *s, int c);
 char   *ft_strnstr(const char *haystack, const char *needle, size_t len);
+char   *ft_strstr(const char *haystack, const char *needle);
 int     ft_strncmp(const char *s1, const char *s2, size_t n);
 int     ft_memcmp(const void *s1, const void *s2, size_t n);
 int     ft_isdigit(int c);


### PR DESCRIPTION
## Summary
- add `ft_strstr` helper and expose it in libft headers
- switch config and API modules from `strchr`/`strstr` to `ft_strchr`/`ft_strstr`
- use `pf_snprintf` instead of `std::snprintf` in API code

## Testing
- `make` *(fails: zero as null pointer constant in Logger/logger_logger.cpp)*
- `make -C Test`


------
https://chatgpt.com/codex/tasks/task_e_68c3214207ec83319662eda11534a3db