### PR TITLE
Use libft string and printf utilities

### DIFF
--- a/Compression/compression_zlib.cpp
+++ b/Compression/compression_zlib.cpp
@@ -49,7 +49,7 @@ unsigned char    *decompress_buffer(const unsigned char *input_buffer, std::size
     if (!result_buffer)
         return (ft_nullptr);
     actual_size = static_cast<uLongf>(expected_size);
-    zlib_status = uncompress(result_buffer, &actual_size, input_buffer + sizeof(uint32_t), static_cast<uLong>(input_size - sizeof(uint32_t)));
+    zlib_status = uncompress(result_buffer, &actual_size, input_buffer + sizeof(uint32_t), input_size - sizeof(uint32_t));
     if (zlib_status != Z_OK || actual_size != expected_size)
     {
         cma_free(result_buffer);

--- a/Config/config_parse.cpp
+++ b/Config/config_parse.cpp
@@ -13,7 +13,7 @@ static char *trim_whitespace(char *string)
         return (string);
     while (*string && std::isspace(static_cast<unsigned char>(*string)))
         string++;
-    char *end_pointer = string + std::strlen(string);
+    char *end_pointer = string + ft_strlen(string);
     while (end_pointer > string && std::isspace(static_cast<unsigned char>(end_pointer[-1])))
         end_pointer--;
     *end_pointer = '\0';

--- a/File/file_opendir.cpp
+++ b/File/file_opendir.cpp
@@ -4,9 +4,8 @@
 #include "../CMA/CMA.hpp"
 #include "../System_utils/system_utils.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Printf/printf.hpp"
 #include "open_dir.hpp"
-#include <stdio.h>
-#include <string.h>
 #include <stdint.h>
 
 #ifndef _WIN32
@@ -18,7 +17,7 @@
 static inline file_dir* opendir_win(const char* directoryPath)
 {
     char searchPath[MAX_PATH];
-    snprintf(searchPath, sizeof(searchPath), "%s\\*", directoryPath);
+    pf_snprintf(searchPath, sizeof(searchPath), "%s\\*", directoryPath);
     file_dir* directoryStream = reinterpret_cast<file_dir*>(cma_malloc(sizeof(file_dir)));
     if (!directoryStream)
         return (ft_nullptr);

--- a/Game/game_load.cpp
+++ b/Game/game_load.cpp
@@ -8,6 +8,8 @@
 #include "../CPP_class/class_string_class.hpp"
 
 int deserialize_character(ft_character &character, json_group *group);
+int deserialize_world(ft_world &world, json_group *group);
+int deserialize_inventory(ft_inventory &inventory, json_group *group);
 
 static int parse_item_field(json_group *group, const ft_string &key, int &out_value)
 {

--- a/Game/game_save.cpp
+++ b/Game/game_save.cpp
@@ -8,6 +8,8 @@
 #include "../CPP_class/class_string_class.hpp"
 
 json_group *serialize_character(const ft_character &character);
+json_group *serialize_world(const ft_world &world);
+json_group *serialize_inventory(const ft_inventory &inventory);
 
 static int add_item_field(json_group *group, const ft_string &key, int value)
 {

--- a/Logger/logger_log_set_file.cpp
+++ b/Logger/logger_log_set_file.cpp
@@ -1,7 +1,7 @@
 #include "logger_internal.hpp"
 #include <fcntl.h>
 #include <unistd.h>
-#include <cstring>
+#include "../Libft/libft.hpp"
 
 void ft_file_sink(const char *message, void *user_data)
 {
@@ -12,7 +12,7 @@ void ft_file_sink(const char *message, void *user_data)
     sink = static_cast<s_file_sink *>(user_data);
     if (!sink)
         return ;
-    length = std::strlen(message);
+    length = ft_strlen(message);
     written = write(sink->fd, message, length);
     (void)written;
     return ;
@@ -21,26 +21,26 @@ void ft_file_sink(const char *message, void *user_data)
 int ft_log_set_file(const char *path, size_t max_size)
 {
     s_file_sink *sink;
-    int          fd;
+    int          file_descriptor;
 
     if (!path)
         return (-1);
-    fd = open(path, O_CREAT | O_WRONLY | O_APPEND, 0644);
-    if (fd == -1)
+    file_descriptor = open(path, O_CREAT | O_WRONLY | O_APPEND, 0644);
+    if (file_descriptor == -1)
         return (-1);
     sink = new s_file_sink;
     if (!sink)
     {
-        close(fd);
+        close(file_descriptor);
         return (-1);
     }
-    sink->fd = fd;
+    sink->fd = file_descriptor;
     sink->path = path;
     sink->max_size = max_size;
     if (sink->path.get_error() != ER_SUCCESS ||
         ft_log_add_sink(ft_file_sink, sink) != 0)
     {
-        close(fd);
+        close(file_descriptor);
         delete sink;
         return (-1);
     }

--- a/Logger/logger_logger.cpp
+++ b/Logger/logger_logger.cpp
@@ -10,8 +10,11 @@
 ft_logger *g_logger = ft_nullptr;
 bool g_async_running = false;
 static ft_queue<ft_string> g_log_queue;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static pthread_mutex_t g_condition_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t g_queue_condition = PTHREAD_COND_INITIALIZER;
+#pragma GCC diagnostic pop
 static pthread_t g_log_thread;
 
 static void ft_log_process_message(const ft_string &message)

--- a/Printf/printf_ft_fprintf.cpp
+++ b/Printf/printf_ft_fprintf.cpp
@@ -8,7 +8,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <string.h>
 #include <cfloat>
 
 typedef enum
@@ -32,7 +31,7 @@ static void ft_putstr_stream(const char *string, FILE *stream, size_t *count)
         *count += 6;
         return ;
     }
-    size_t length = strlen(string);
+    size_t length = ft_strlen(string);
     fwrite(string, 1, length, stream);
     *count += length;
 }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ It provides implementations of common libc functions, custom memory allocation h
 basic threading helpers, containers, string utilities, simple networking and more.
 The top level `Makefile` builds every submodule and links them into `Full_Libft.a`.
 The umbrella header `FullLibft.hpp` includes every component.
+Internal code uses custom replacements such as `ft_strlen`, `ft_strchr`, `ft_strstr`, and `pf_snprintf` instead of the standard library equivalents.
 Header files now use class names or concise module names instead of module prefixes, except internal headers which retain their module prefix.
 
 This document briefly lists the main headers and the interfaces they expose. The

--- a/Test/efficiency/efficiency_strchr.cpp
+++ b/Test/efficiency/efficiency_strchr.cpp
@@ -7,25 +7,25 @@
 int test_efficiency_strchr(void)
 {
     const size_t iterations = 100000;
-    std::string s(1000, 'a');
-    s[500] = 'b';
+    std::string string(1000, 'a');
+    string[500] = 'b';
     volatile const char *result = nullptr;
-    auto std_strchr = static_cast<const char *(*)(const char *, int)>(std::strchr);
+    auto standard_strchr = static_cast<const char *(*)(const char *, int)>(std::strchr);
 
     auto start_std = clock_type::now();
-    for (size_t i = 0; i < iterations; ++i)
+    for (size_t index = 0; index < iterations; ++index)
     {
-        prevent_optimization(const_cast<char*>(s.data()));
-        result = std_strchr(s.c_str(), 'b');
+        prevent_optimization(const_cast<char*>(string.data()));
+        result = standard_strchr(string.c_str(), 'b');
         prevent_optimization(const_cast<char*>(result));
     }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
-    for (size_t i = 0; i < iterations; ++i)
+    for (size_t index = 0; index < iterations; ++index)
     {
-        prevent_optimization(const_cast<char*>(s.data()));
-        result = ft_strchr(s.c_str(), 'b');
+        prevent_optimization(const_cast<char*>(string.data()));
+        result = ft_strchr(string.c_str(), 'b');
         prevent_optimization(const_cast<char*>(result));
     }
     auto end_ft = clock_type::now();

--- a/Test/efficiency/efficiency_strlen.cpp
+++ b/Test/efficiency/efficiency_strlen.cpp
@@ -7,24 +7,24 @@
 int test_efficiency_strlen(void)
 {
     const size_t iterations = 100000;
-    std::string s(1000, 'a');
+    std::string string(1000, 'a');
     volatile size_t sink = 0;
-    auto std_strlen = static_cast<size_t (*)(const char *)>(std::strlen);
+    auto standard_strlen = static_cast<size_t (*)(const char *)>(std::strlen);
 
     auto start_std = clock_type::now();
-    for (size_t i = 0; i < iterations; ++i)
+    for (size_t index = 0; index < iterations; ++index)
     {
-        prevent_optimization(s.data());
-        sink += std_strlen(s.c_str());
+        prevent_optimization(string.data());
+        sink += standard_strlen(string.c_str());
         prevent_optimization((void*)&sink);
     }
     auto end_std = clock_type::now();
 
     auto start_ft = clock_type::now();
-    for (size_t i = 0; i < iterations; ++i)
+    for (size_t index = 0; index < iterations; ++index)
     {
-        prevent_optimization(s.data());
-        sink += ft_strlen(s.c_str());
+        prevent_optimization(string.data());
+        sink += ft_strlen(string.c_str());
         prevent_optimization((void*)&sink);
     }
     auto end_ft = clock_type::now();


### PR DESCRIPTION
## Summary
- restore efficiency benchmarks to compare standard `strchr`/`strlen` against libft versions
- silence pthread initializer warning in logger and remove useless zlib cast
- declare serialization helpers to satisfy `-Wmissing-declarations`

## Testing
- `make` *(fails: old-style cast in XML module)*
- `make -C Test`

------
https://chatgpt.com/codex/tasks/task_e_68c325fa37ec8331884b72a9ee06ce3d