### PR TITLE
Replace std character checks with custom implementations

### DIFF
--- a/JSon/json_reader.cpp
+++ b/JSon/json_reader.cpp
@@ -1,4 +1,3 @@
-#include <cctype>
 #include "../Libft/libft.hpp"
 #include "json.hpp"
 #include "../GetNextLine/get_next_line.hpp"
@@ -8,7 +7,7 @@
 static void skip_whitespace(const char *json_string, size_t &index)
 {
     while (json_string[index]
-        && std::isspace(static_cast<unsigned char>(json_string[index])))
+        && ft_isspace(static_cast<unsigned char>(json_string[index])))
         index++;
     return ;
 }
@@ -38,7 +37,7 @@ static char *parse_number(const char *json_string, size_t &index)
         index++;
     bool has_digits = false;
     while (index < length
-        && std::isdigit(static_cast<unsigned char>(json_string[index])))
+        && ft_isdigit(static_cast<unsigned char>(json_string[index])))
     {
         index++;
         has_digits = true;
@@ -47,7 +46,7 @@ static char *parse_number(const char *json_string, size_t &index)
     {
         index++;
         while (index < length
-            && std::isdigit(static_cast<unsigned char>(json_string[index])))
+            && ft_isdigit(static_cast<unsigned char>(json_string[index])))
             index++;
     }
     if (index < length && (json_string[index] == 'e' || json_string[index] == 'E'))
@@ -56,7 +55,7 @@ static char *parse_number(const char *json_string, size_t &index)
         if (index < length && (json_string[index] == '-' || json_string[index] == '+'))
             index++;
         while (index < length
-            && std::isdigit(static_cast<unsigned char>(json_string[index])))
+            && ft_isdigit(static_cast<unsigned char>(json_string[index])))
             index++;
     }
     if (!has_digits)
@@ -83,7 +82,7 @@ static char *parse_value(const char *json_string, size_t &index)
         index += 5;
         return (cma_strdup("false"));
     }
-    if (std::isdigit(static_cast<unsigned char>(json_string[index]))
+    if (ft_isdigit(static_cast<unsigned char>(json_string[index]))
         || json_string[index] == '-' || json_string[index] == '+')
         return (parse_number(json_string, index));
     return (ft_nullptr);

--- a/Math/math_isnan.cpp
+++ b/Math/math_isnan.cpp
@@ -1,7 +1,20 @@
 #include "math.hpp"
-#include <cmath>
 
 int math_isnan(double number)
 {
-    return (std::isnan(number));
+    union
+    {
+        double double_value;
+        unsigned long long integer_value;
+    } converter;
+
+    unsigned long long exponent_bits;
+    unsigned long long mantissa_bits;
+
+    converter.double_value = number;
+    exponent_bits = converter.integer_value & 0x7ff0000000000000ULL;
+    mantissa_bits = converter.integer_value & 0x000fffffffffffffULL;
+    if (exponent_bits == 0x7ff0000000000000ULL && mantissa_bits != 0)
+        return (1);
+    return (0);
 }

--- a/README.md
+++ b/README.md
@@ -734,7 +734,6 @@ void         json_update_item(json_group *group, const char *key, const int valu
 void         json_update_item(json_group *group, const char *key, const bool value);
 bool         json_validate(json_group *group, const json_schema &schema);
 ```
-
 The `json_document` class wraps these helpers and manages a group list:
 
 ```

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -28,7 +28,7 @@ SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp 
        test_cpp_class.cpp test_template.cpp test_printf.cpp test_get_next_line.cpp \
        test_cma.cpp test_game.cpp test_queue.cpp test_queue_class.cpp \
        test_promise.cpp test_config.cpp test_pthread_rwlock.cpp test_math_eval.cpp test_encryption_key.cpp \
-       test_math_trig.cpp test_rng.cpp test_json_validate.cpp test_compression.cpp test_xml.cpp $(EFF_SRCS)
+       test_math_isnan.cpp test_math_trig.cpp test_rng.cpp test_json_validate.cpp test_compression.cpp test_xml.cpp $(EFF_SRCS)
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -115,6 +115,8 @@ int test_abs_int_min(void);
 int test_abs_llong_min(void);
 int test_fabs_negative_zero(void);
 int test_fabs_nan(void);
+int test_math_isnan_nan(void);
+int test_math_isnan_numbers(void);
 int test_ft_sin_zero(void);
 int test_ft_sin_ninety(void);
 int test_ft_tan_zero(void);
@@ -347,6 +349,8 @@ int main(int argc, char **argv)
         { test_abs_llong_min, "abs LLONG_MIN" },
         { test_fabs_negative_zero, "fabs negative zero" },
         { test_fabs_nan, "fabs NaN" },
+        { test_math_isnan_nan, "math_isnan NaN" },
+        { test_math_isnan_numbers, "math_isnan numbers" },
         { test_ft_sin_zero, "ft_sin zero" },
         { test_ft_sin_ninety, "ft_sin ninety" },
         { test_ft_tan_zero, "ft_tan zero" },

--- a/Test/test_math_isnan.cpp
+++ b/Test/test_math_isnan.cpp
@@ -1,0 +1,20 @@
+#include "../Math/math.hpp"
+
+int test_math_isnan_nan(void)
+{
+    double value;
+
+    value = math_nan();
+    if (!math_isnan(value))
+        return (0);
+    return (1);
+}
+
+int test_math_isnan_numbers(void)
+{
+    if (math_isnan(0.0))
+        return (0);
+    if (math_isnan(42.0))
+        return (0);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- use `ft_isspace` and `ft_isdigit` in JSON reader instead of `<cctype>`
- drop `<cmath>` and implement `math_isnan` with bitwise check
- add unit tests for `math_isnan` and remove redundant README notes

## Testing
- `make` *(fails: XML module old-style cast errors)*
- `make -C Test` *(fails: redefinition of std::move)*
- `make -C Math re`
- `make -C JSon re`


------
https://chatgpt.com/codex/tasks/task_e_68c3c2c2d9d08331927bf7b483248b9e