### PR TITLE
refactor: hide compatibility file ops

### DIFF
--- a/Compatebility/Compatebility_file.cpp
+++ b/Compatebility/Compatebility_file.cpp
@@ -1,4 +1,4 @@
-#include "file.hpp"
+#include "compatebility_file_internal.hpp"
 
 #if defined(_WIN32) || defined(_WIN64)
 # include "../CPP_class/class_nullptr.hpp"

--- a/Compatebility/Makefile
+++ b/Compatebility/Makefile
@@ -5,7 +5,7 @@ DEBUG_TARGET := Compatebility_debug.a
 
 SRCS := Compatebility_file.cpp
 
-HEADERS := file.hpp
+HEADERS := compatebility_file_internal.hpp
 
 ifeq ($(OS),Windows_NT)
 MKDIR   = mkdir

--- a/Compatebility/compatebility_file_internal.hpp
+++ b/Compatebility/compatebility_file_internal.hpp
@@ -1,5 +1,5 @@
-#ifndef COMPATEBILITY_FILE_HPP
-# define COMPATEBILITY_FILE_HPP
+#ifndef COMPATEBILITY_FILE_INTERNAL_HPP
+# define COMPATEBILITY_FILE_INTERNAL_HPP
 
 #if defined(_WIN32) || defined(_WIN64)
 # include <BaseTsd.h>

--- a/README.md
+++ b/README.md
@@ -569,6 +569,11 @@ unsigned int    su_get_cpu_count(void);
 unsigned long long su_get_total_memory(void);
 ```
 
+Internally these helpers rely on compatibility wrappers that are not part of the
+public API. The low level `ft_open`, `ft_read` and `ft_write` functions are now
+declared in `Compatebility/compatebility_file_internal.hpp` and are used only
+within the library.
+
 ### Template Utilities
 
 `Template/` contains a wide range of generic helpers and containers. Key

--- a/System_utils/System_utils_file.cpp
+++ b/System_utils/System_utils_file.cpp
@@ -1,4 +1,5 @@
 #include "system_utils.hpp"
+#include "../Compatebility/compatebility_file_internal.hpp"
 #if defined(__linux__) || defined(__APPLE__)
 # include <cerrno>
 # include <ctime>

--- a/System_utils/system_utils.hpp
+++ b/System_utils/system_utils.hpp
@@ -1,7 +1,16 @@
 #ifndef SYSTEM_UTILS_HPP
 # define SYSTEM_UTILS_HPP
 
-# include "../Compatebility/file.hpp"
+#if defined(_WIN32) || defined(_WIN64)
+# include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+# ifndef O_DIRECTORY
+#  define O_DIRECTORY 0
+# endif
+#else
+# include <fcntl.h>
+# include <unistd.h>
+#endif
 
 char    *su_getenv(const char *name);
 int     su_setenv(const char *name, const char *value, int overwrite);


### PR DESCRIPTION
## Summary
- move low level `ft_open`, `ft_read`, and `ft_write` into new `compatebility_file_internal.hpp`
- stop exposing compatibility internals via `system_utils.hpp`
- document that file operations are internal to the compatibility layer

## Testing
- `make -C Compatebility`
- `make -C System_utils`


------
https://chatgpt.com/codex/tasks/task_e_68c3c9ddac988331ba9905209c76b8f3