### PR TITLE
Add ft_strtok string tokenization function

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -17,6 +17,7 @@ SRCS := libft_atoi.cpp \
     libft_strnstr.cpp \
     libft_strstr.cpp \
     libft_strrchr.cpp \
+    libft_strtok.cpp \
     libft_atol.cpp \
     libft_strtol.cpp \
     libft_strtoul.cpp \

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -44,6 +44,7 @@ int                ft_strcmp(const char *string1, const char *string2);
 void            ft_to_lower(char *string);
 void            ft_to_upper(char *string);
 char             *ft_strncpy(char *destination, const char *source, size_t number_of_characters);
+char            *ft_strtok(char *string, const char *delimiters);
 void             *ft_memset(void *destination, int value, size_t number_of_bytes);
 int             ft_isspace(int character);
 char            *ft_strjoin_multiple(int count, ...);

--- a/Libft/libft_strtok.cpp
+++ b/Libft/libft_strtok.cpp
@@ -1,0 +1,68 @@
+#include "libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+char    *ft_strtok(char *string, const char *delimiters)
+{
+    static char *saved_string = ft_nullptr;
+    char    *token_start;
+    char    *current_pointer;
+    int     is_delimiter;
+    size_t  delimiter_index;
+
+    if (string != ft_nullptr)
+        saved_string = string;
+    if (saved_string == ft_nullptr || delimiters == ft_nullptr)
+        return (ft_nullptr);
+    current_pointer = saved_string;
+    while (*current_pointer != '\0')
+    {
+        is_delimiter = 0;
+        delimiter_index = 0;
+        while (delimiters[delimiter_index] != '\0')
+        {
+            if (*current_pointer == delimiters[delimiter_index])
+            {
+                is_delimiter = 1;
+                break;
+            }
+            delimiter_index++;
+        }
+        if (is_delimiter == 0)
+            break;
+        current_pointer++;
+    }
+    if (*current_pointer == '\0')
+    {
+        saved_string = ft_nullptr;
+        return (ft_nullptr);
+    }
+    token_start = current_pointer;
+    while (*current_pointer != '\0')
+    {
+        is_delimiter = 0;
+        delimiter_index = 0;
+        while (delimiters[delimiter_index] != '\0')
+        {
+            if (*current_pointer == delimiters[delimiter_index])
+            {
+                is_delimiter = 1;
+                break;
+            }
+            delimiter_index++;
+        }
+        if (is_delimiter)
+            break;
+        current_pointer++;
+    }
+    if (*current_pointer == '\0')
+    {
+        saved_string = ft_nullptr;
+    }
+    else
+    {
+        *current_pointer = '\0';
+        saved_string = current_pointer + 1;
+    }
+    return (token_start);
+}
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ int     ft_strcmp(const char *s1, const char *s2);
 void    ft_to_lower(char *string);
 void    ft_to_upper(char *string);
 char   *ft_strncpy(char *dst, const char *src, size_t n);
+char   *ft_strtok(char *string, const char *delimiters);
 void   *ft_memset(void *dst, int value, size_t n);
 int     ft_isspace(int c);
 char   *ft_fgets(char *string, int size, FILE *stream);


### PR DESCRIPTION
## Summary
- implement `ft_strtok` for tokenizing strings by delimiters
- expose the new function in `libft.hpp` and build system
- document `ft_strtok` in README

## Testing
- `make -C Libft`


------
https://chatgpt.com/codex/tasks/task_e_68c3e8dee1988331b704b9d6dd8ceb9c