### PR TITLE
Add basic linear algebra classes and integer validation

### DIFF
--- a/CMA/CMA.hpp
+++ b/CMA/CMA.hpp
@@ -17,6 +17,7 @@ void    *cma_aligned_alloc(std::size_t alignment, std::size_t size)
             __attribute__ ((warn_unused_result, hot));
 std::size_t    cma_alloc_size(const void* ptr)
             __attribute__ ((warn_unused_result, hot));
+int    *cma_atoi(const char *string) __attribute__ ((warn_unused_result));
 char    **cma_split(char const *string, char delimiter) __attribute__ ((warn_unused_result));
 char    *cma_itoa(int number) __attribute__ ((warn_unused_result));
 char    *cma_itoa_base(int number, int base) __attribute__ ((warn_unused_result));

--- a/CMA/Makefile
+++ b/CMA/Makefile
@@ -10,6 +10,7 @@ SRCS := cma_calloc.cpp \
         cma_realloc.cpp \
         cma_aligned_alloc.cpp \
         cma_alloc_size.cpp \
+        cma_atoi.cpp \
         cma_itoa.cpp \
         cma_itoa_base.cpp \
         cma_split.cpp \

--- a/CMA/cma_atoi.cpp
+++ b/CMA/cma_atoi.cpp
@@ -1,0 +1,15 @@
+#include "CMA.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+int *cma_atoi(const char *string)
+{
+    int *number;
+
+    if (ft_validate_int(string))
+        return (ft_nullptr);
+    number = static_cast<int *>(cma_malloc(sizeof(int)));
+    if (!number)
+        return (ft_nullptr);
+    *number = ft_atoi(string);
+    return (number);
+}

--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -46,7 +46,8 @@ SRCS := libft_atoi.cpp \
     libft_fwrite.cpp \
     libft_fseek.cpp \
     libft_ftell.cpp \
-    libft_time.cpp
+    libft_time.cpp \
+    libft_validate_int.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -18,6 +18,7 @@ size_t             ft_strlen_size_t(const char *string);
 int                ft_strlen(const char *string);
 char            *ft_strchr(const char *string, int char_to_find);
 int                ft_atoi(const char *string);
+int             ft_validate_int(const char *input);
 void            ft_bzero(void *string, size_t size);
 void            *ft_memchr(const void *pointer, int character, size_t size);
 void            *ft_memcpy(void* destination, const void* source, size_t num);

--- a/Libft/libft_validate_int.cpp
+++ b/Libft/libft_validate_int.cpp
@@ -1,0 +1,33 @@
+#include "limits.hpp"
+
+int ft_validate_int(const char *input)
+{
+    long number;
+    int index;
+    int sign;
+    long signed_number;
+
+    number = 0;
+    index = 0;
+    sign = 1;
+    if (input[index] == '+' || input[index] == '-')
+        index++;
+    if (!input[index])
+        return (1);
+    if (input[0] == '-')
+        sign = -1;
+    while (input[index])
+    {
+        if (input[index] >= '0' && input[index] <= '9')
+        {
+            number = (number * 10) + input[index] - '0';
+            signed_number = sign * number;
+            if (signed_number < FT_INT_MIN || signed_number > FT_INT_MAX)
+                return (2);
+            index++;
+        }
+        else
+            return (3);
+    }
+    return (0);
+}

--- a/Math/Makefile
+++ b/Math/Makefile
@@ -33,9 +33,11 @@ SRCS := math_abs.cpp \
         math_roll_parse_pm.cpp \
         math_roll_parse_utils.cpp \
         math_roll_validate_string.cpp \
-        math_roll_validate_utils.cpp
+        math_roll_validate_utils.cpp \
+        math_validate_int.cpp \
+        linear_algebra.cpp
 
-HEADERS := math.hpp roll.hpp math_internal.hpp
+HEADERS := math.hpp roll.hpp math_internal.hpp linear_algebra.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Math/linear_algebra.cpp
+++ b/Math/linear_algebra.cpp
@@ -1,0 +1,607 @@
+#include "linear_algebra.hpp"
+#include "math.hpp"
+#include "../Errno/errno.hpp"
+
+vector2::vector2()
+{
+    this->_x = 0.0;
+    this->_y = 0.0;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+vector2::vector2(double x, double y)
+{
+    this->_x = x;
+    this->_y = y;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+vector2::~vector2()
+{
+    return ;
+}
+
+double  vector2::get_x() const
+{
+    return (this->_x);
+}
+
+double  vector2::get_y() const
+{
+    return (this->_y);
+}
+
+double  vector2::dot(const vector2 &other) const
+{
+    this->set_error(ER_SUCCESS);
+    return (this->_x * other._x + this->_y * other._y);
+}
+
+double  vector2::length() const
+{
+    double result;
+
+    result = this->_x * this->_x + this->_y * this->_y;
+    this->set_error(ER_SUCCESS);
+    return (math_sqrt(result));
+}
+
+vector2 vector2::normalize() const
+{
+    double len;
+    vector2 result;
+
+    len = this->length();
+    if (len == 0.0)
+    {
+        result.set_error(FT_EINVAL);
+        return (result);
+    }
+    result._x = this->_x / len;
+    result._y = this->_y / len;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+void    vector2::set_error(int error_code) const
+{
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
+}
+
+int     vector2::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char  *vector2::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}
+
+vector3::vector3()
+{
+    this->_x = 0.0;
+    this->_y = 0.0;
+    this->_z = 0.0;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+vector3::vector3(double x, double y, double z)
+{
+    this->_x = x;
+    this->_y = y;
+    this->_z = z;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+vector3::~vector3()
+{
+    return ;
+}
+
+double  vector3::get_x() const
+{
+    return (this->_x);
+}
+
+double  vector3::get_y() const
+{
+    return (this->_y);
+}
+
+double  vector3::get_z() const
+{
+    return (this->_z);
+}
+
+double  vector3::dot(const vector3 &other) const
+{
+    this->set_error(ER_SUCCESS);
+    return (this->_x * other._x + this->_y * other._y + this->_z * other._z);
+}
+
+vector3 vector3::cross(const vector3 &other) const
+{
+    vector3 result;
+
+    result._x = this->_y * other._z - this->_z * other._y;
+    result._y = this->_z * other._x - this->_x * other._z;
+    result._z = this->_x * other._y - this->_y * other._x;
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
+double  vector3::length() const
+{
+    double result;
+
+    result = this->_x * this->_x + this->_y * this->_y + this->_z * this->_z;
+    this->set_error(ER_SUCCESS);
+    return (math_sqrt(result));
+}
+
+vector3 vector3::normalize() const
+{
+    double len;
+    vector3 result;
+
+    len = this->length();
+    if (len == 0.0)
+    {
+        result.set_error(FT_EINVAL);
+        return (result);
+    }
+    result._x = this->_x / len;
+    result._y = this->_y / len;
+    result._z = this->_z / len;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+void    vector3::set_error(int error_code) const
+{
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
+}
+
+int     vector3::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char  *vector3::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}
+
+vector4::vector4()
+{
+    this->_x = 0.0;
+    this->_y = 0.0;
+    this->_z = 0.0;
+    this->_w = 0.0;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+vector4::vector4(double x, double y, double z, double w)
+{
+    this->_x = x;
+    this->_y = y;
+    this->_z = z;
+    this->_w = w;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+vector4::~vector4()
+{
+    return ;
+}
+
+double  vector4::get_x() const
+{
+    return (this->_x);
+}
+
+double  vector4::get_y() const
+{
+    return (this->_y);
+}
+
+double  vector4::get_z() const
+{
+    return (this->_z);
+}
+
+double  vector4::get_w() const
+{
+    return (this->_w);
+}
+
+double  vector4::dot(const vector4 &other) const
+{
+    this->set_error(ER_SUCCESS);
+    return (this->_x * other._x + this->_y * other._y + this->_z * other._z + this->_w * other._w);
+}
+
+double  vector4::length() const
+{
+    double result;
+
+    result = this->_x * this->_x + this->_y * this->_y + this->_z * this->_z + this->_w * this->_w;
+    this->set_error(ER_SUCCESS);
+    return (math_sqrt(result));
+}
+
+vector4 vector4::normalize() const
+{
+    double len;
+    vector4 result;
+
+    len = this->length();
+    if (len == 0.0)
+    {
+        result.set_error(FT_EINVAL);
+        return (result);
+    }
+    result._x = this->_x / len;
+    result._y = this->_y / len;
+    result._z = this->_z / len;
+    result._w = this->_w / len;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+void    vector4::set_error(int error_code) const
+{
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
+}
+
+int     vector4::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char  *vector4::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}
+
+matrix4::matrix4()
+{
+    int row;
+    int column;
+
+    row = 0;
+    while (row < 4)
+    {
+        column = 0;
+        while (column < 4)
+        {
+            if (row == column)
+                this->_m[row][column] = 1.0;
+            else
+                this->_m[row][column] = 0.0;
+            column++;
+        }
+        row++;
+    }
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+matrix4::matrix4(double m00, double m01, double m02, double m03,
+        double m10, double m11, double m12, double m13,
+        double m20, double m21, double m22, double m23,
+        double m30, double m31, double m32, double m33)
+{
+    this->_m[0][0] = m00;
+    this->_m[0][1] = m01;
+    this->_m[0][2] = m02;
+    this->_m[0][3] = m03;
+    this->_m[1][0] = m10;
+    this->_m[1][1] = m11;
+    this->_m[1][2] = m12;
+    this->_m[1][3] = m13;
+    this->_m[2][0] = m20;
+    this->_m[2][1] = m21;
+    this->_m[2][2] = m22;
+    this->_m[2][3] = m23;
+    this->_m[3][0] = m30;
+    this->_m[3][1] = m31;
+    this->_m[3][2] = m32;
+    this->_m[3][3] = m33;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+matrix4::~matrix4()
+{
+    return ;
+}
+
+vector4 matrix4::transform(const vector4 &vector) const
+{
+    vector4 result(
+        this->_m[0][0] * vector.get_x() + this->_m[0][1] * vector.get_y() + this->_m[0][2] * vector.get_z() + this->_m[0][3] * vector.get_w(),
+        this->_m[1][0] * vector.get_x() + this->_m[1][1] * vector.get_y() + this->_m[1][2] * vector.get_z() + this->_m[1][3] * vector.get_w(),
+        this->_m[2][0] * vector.get_x() + this->_m[2][1] * vector.get_y() + this->_m[2][2] * vector.get_z() + this->_m[2][3] * vector.get_w(),
+        this->_m[3][0] * vector.get_x() + this->_m[3][1] * vector.get_y() + this->_m[3][2] * vector.get_z() + this->_m[3][3] * vector.get_w()
+    );
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
+
+matrix4 matrix4::multiply(const matrix4 &other) const
+{
+    matrix4 result;
+
+    result._m[0][0] = this->_m[0][0] * other._m[0][0] + this->_m[0][1] * other._m[1][0] + this->_m[0][2] * other._m[2][0] + this->_m[0][3] * other._m[3][0];
+    result._m[0][1] = this->_m[0][0] * other._m[0][1] + this->_m[0][1] * other._m[1][1] + this->_m[0][2] * other._m[2][1] + this->_m[0][3] * other._m[3][1];
+    result._m[0][2] = this->_m[0][0] * other._m[0][2] + this->_m[0][1] * other._m[1][2] + this->_m[0][2] * other._m[2][2] + this->_m[0][3] * other._m[3][2];
+    result._m[0][3] = this->_m[0][0] * other._m[0][3] + this->_m[0][1] * other._m[1][3] + this->_m[0][2] * other._m[2][3] + this->_m[0][3] * other._m[3][3];
+    result._m[1][0] = this->_m[1][0] * other._m[0][0] + this->_m[1][1] * other._m[1][0] + this->_m[1][2] * other._m[2][0] + this->_m[1][3] * other._m[3][0];
+    result._m[1][1] = this->_m[1][0] * other._m[0][1] + this->_m[1][1] * other._m[1][1] + this->_m[1][2] * other._m[2][1] + this->_m[1][3] * other._m[3][1];
+    result._m[1][2] = this->_m[1][0] * other._m[0][2] + this->_m[1][1] * other._m[1][2] + this->_m[1][2] * other._m[2][2] + this->_m[1][3] * other._m[3][2];
+    result._m[1][3] = this->_m[1][0] * other._m[0][3] + this->_m[1][1] * other._m[1][3] + this->_m[1][2] * other._m[2][3] + this->_m[1][3] * other._m[3][3];
+    result._m[2][0] = this->_m[2][0] * other._m[0][0] + this->_m[2][1] * other._m[1][0] + this->_m[2][2] * other._m[2][0] + this->_m[2][3] * other._m[3][0];
+    result._m[2][1] = this->_m[2][0] * other._m[0][1] + this->_m[2][1] * other._m[1][1] + this->_m[2][2] * other._m[2][1] + this->_m[2][3] * other._m[3][1];
+    result._m[2][2] = this->_m[2][0] * other._m[0][2] + this->_m[2][1] * other._m[1][2] + this->_m[2][2] * other._m[2][2] + this->_m[2][3] * other._m[3][2];
+    result._m[2][3] = this->_m[2][0] * other._m[0][3] + this->_m[2][1] * other._m[1][3] + this->_m[2][2] * other._m[2][3] + this->_m[2][3] * other._m[3][3];
+    result._m[3][0] = this->_m[3][0] * other._m[0][0] + this->_m[3][1] * other._m[1][0] + this->_m[3][2] * other._m[2][0] + this->_m[3][3] * other._m[3][0];
+    result._m[3][1] = this->_m[3][0] * other._m[0][1] + this->_m[3][1] * other._m[1][1] + this->_m[3][2] * other._m[2][1] + this->_m[3][3] * other._m[3][1];
+    result._m[3][2] = this->_m[3][0] * other._m[0][2] + this->_m[3][1] * other._m[1][2] + this->_m[3][2] * other._m[2][2] + this->_m[3][3] * other._m[3][2];
+    result._m[3][3] = this->_m[3][0] * other._m[0][3] + this->_m[3][1] * other._m[1][3] + this->_m[3][2] * other._m[2][3] + this->_m[3][3] * other._m[3][3];
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
+matrix4 matrix4::invert() const
+{
+    double temp[4][8];
+    matrix4 result;
+    int row;
+    int column;
+    int other;
+    double pivot;
+    double factor;
+
+    row = 0;
+    while (row < 4)
+    {
+        column = 0;
+        while (column < 4)
+        {
+            temp[row][column] = this->_m[row][column];
+            column++;
+        }
+        column = 0;
+        while (column < 4)
+        {
+            if (row == column)
+                temp[row][column + 4] = 1.0;
+            else
+                temp[row][column + 4] = 0.0;
+            column++;
+        }
+        row++;
+    }
+    row = 0;
+    while (row < 4)
+    {
+        pivot = temp[row][row];
+        if (math_fabs(pivot) < 0.000001)
+        {
+            result.set_error(FT_EINVAL);
+            return (result);
+        }
+        column = 0;
+        while (column < 8)
+        {
+            temp[row][column] = temp[row][column] / pivot;
+            column++;
+        }
+        other = 0;
+        while (other < 4)
+        {
+            if (other != row)
+            {
+                factor = temp[other][row];
+                column = 0;
+                while (column < 8)
+                {
+                    temp[other][column] = temp[other][column] - factor * temp[row][column];
+                    column++;
+                }
+            }
+            other++;
+        }
+        row++;
+    }
+    row = 0;
+    while (row < 4)
+    {
+        column = 0;
+        while (column < 4)
+        {
+            result._m[row][column] = temp[row][column + 4];
+            column++;
+        }
+        row++;
+    }
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
+void    matrix4::set_error(int error_code) const
+{
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
+}
+
+int     matrix4::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char  *matrix4::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}
+
+quaternion::quaternion()
+{
+    this->_w = 1.0;
+    this->_x = 0.0;
+    this->_y = 0.0;
+    this->_z = 0.0;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+quaternion::quaternion(double w, double x, double y, double z)
+{
+    this->_w = w;
+    this->_x = x;
+    this->_y = y;
+    this->_z = z;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+quaternion::~quaternion()
+{
+    return ;
+}
+
+double      quaternion::get_w() const
+{
+    return (this->_w);
+}
+
+double      quaternion::get_x() const
+{
+    return (this->_x);
+}
+
+double      quaternion::get_y() const
+{
+    return (this->_y);
+}
+
+double      quaternion::get_z() const
+{
+    return (this->_z);
+}
+
+quaternion  quaternion::multiply(const quaternion &other) const
+{
+    quaternion result;
+
+    result._w = this->_w * other._w - this->_x * other._x - this->_y * other._y - this->_z * other._z;
+    result._x = this->_w * other._x + this->_x * other._w + this->_y * other._z - this->_z * other._y;
+    result._y = this->_w * other._y - this->_x * other._z + this->_y * other._w + this->_z * other._x;
+    result._z = this->_w * other._z + this->_x * other._y - this->_y * other._x + this->_z * other._w;
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
+double      quaternion::length() const
+{
+    double result;
+
+    result = this->_w * this->_w + this->_x * this->_x + this->_y * this->_y + this->_z * this->_z;
+    this->set_error(ER_SUCCESS);
+    return (math_sqrt(result));
+}
+
+quaternion  quaternion::normalize() const
+{
+    double len;
+    quaternion result;
+
+    len = this->length();
+    if (len == 0.0)
+    {
+        result.set_error(FT_EINVAL);
+        return (result);
+    }
+    result._w = this->_w / len;
+    result._x = this->_x / len;
+    result._y = this->_y / len;
+    result._z = this->_z / len;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+quaternion  quaternion::invert() const
+{
+    double len_sq;
+    quaternion result;
+
+    len_sq = this->_w * this->_w + this->_x * this->_x + this->_y * this->_y + this->_z * this->_z;
+    if (len_sq == 0.0)
+    {
+        result.set_error(FT_EINVAL);
+        return (result);
+    }
+    result._w = this->_w / len_sq;
+    result._x = -this->_x / len_sq;
+    result._y = -this->_y / len_sq;
+    result._z = -this->_z / len_sq;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+vector3     quaternion::transform(const vector3 &vector) const
+{
+    quaternion vec_q;
+    quaternion inv;
+    quaternion res;
+
+    vec_q._w = 0.0;
+    vec_q._x = vector.get_x();
+    vec_q._y = vector.get_y();
+    vec_q._z = vector.get_z();
+    inv = this->invert();
+    if (inv.get_error() != ER_SUCCESS)
+    {
+        this->set_error(inv.get_error());
+        return (vector3());
+    }
+    res = this->multiply(vec_q).multiply(inv);
+    this->set_error(ER_SUCCESS);
+    return (vector3(res._x, res._y, res._z));
+}
+void    quaternion::set_error(int error_code) const
+{
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
+}
+
+int     quaternion::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char  *quaternion::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}

--- a/Math/linear_algebra.hpp
+++ b/Math/linear_algebra.hpp
@@ -1,0 +1,127 @@
+#ifndef LINEAR_ALGEBRA_HPP
+# define LINEAR_ALGEBRA_HPP
+
+class vector2
+{
+    private:
+        double _x;
+        double _y;
+        mutable int _error_code;
+
+        void    set_error(int error_code) const;
+
+    public:
+        vector2();
+        vector2(double x, double y);
+        ~vector2();
+        double  get_x() const;
+        double  get_y() const;
+        double  dot(const vector2 &other) const;
+        double  length() const;
+        vector2 normalize() const;
+        int     get_error() const;
+        const char  *get_error_str() const;
+};
+
+class vector3
+{
+    private:
+        double _x;
+        double _y;
+        double _z;
+        mutable int _error_code;
+
+        void    set_error(int error_code) const;
+
+    public:
+        vector3();
+        vector3(double x, double y, double z);
+        ~vector3();
+        double  get_x() const;
+        double  get_y() const;
+        double  get_z() const;
+        double  dot(const vector3 &other) const;
+        vector3 cross(const vector3 &other) const;
+        double  length() const;
+        vector3 normalize() const;
+        int     get_error() const;
+        const char  *get_error_str() const;
+};
+
+class vector4
+{
+    private:
+        double _x;
+        double _y;
+        double _z;
+        double _w;
+        mutable int _error_code;
+
+        void    set_error(int error_code) const;
+
+    public:
+        vector4();
+        vector4(double x, double y, double z, double w);
+        ~vector4();
+        double  get_x() const;
+        double  get_y() const;
+        double  get_z() const;
+        double  get_w() const;
+        double  dot(const vector4 &other) const;
+        double  length() const;
+        vector4 normalize() const;
+        int     get_error() const;
+        const char  *get_error_str() const;
+};
+
+class matrix4
+{
+    private:
+        double _m[4][4];
+        mutable int _error_code;
+
+        void    set_error(int error_code) const;
+
+    public:
+        matrix4();
+        matrix4(double m00, double m01, double m02, double m03,
+                double m10, double m11, double m12, double m13,
+                double m20, double m21, double m22, double m23,
+                double m30, double m31, double m32, double m33);
+        ~matrix4();
+        vector4 transform(const vector4 &vector) const;
+        matrix4 multiply(const matrix4 &other) const;
+        matrix4 invert() const;
+        int     get_error() const;
+        const char  *get_error_str() const;
+};
+
+class quaternion
+{
+    private:
+        double _w;
+        double _x;
+        double _y;
+        double _z;
+        mutable int _error_code;
+
+        void    set_error(int error_code) const;
+
+    public:
+        quaternion();
+        quaternion(double w, double x, double y, double z);
+        ~quaternion();
+        double      get_w() const;
+        double      get_x() const;
+        double      get_y() const;
+        double      get_z() const;
+        quaternion  multiply(const quaternion &other) const;
+        double      length() const;
+        quaternion  normalize() const;
+        quaternion  invert() const;
+        vector3     transform(const vector3 &vector) const;
+        int         get_error() const;
+        const char  *get_error_str() const;
+};
+
+#endif

--- a/Math/math.hpp
+++ b/Math/math.hpp
@@ -43,6 +43,9 @@ double      math_cos(double value);
 double      ft_sin(double value);
 double      ft_tan(double value);
 double      math_deg2rad(double degrees);
+int         math_validate_int(const char *input);
 double      math_rad2deg(double radians);
+
+# include "linear_algebra.hpp"
 
 #endif

--- a/Math/math_validate_int.cpp
+++ b/Math/math_validate_int.cpp
@@ -1,0 +1,7 @@
+#include "math.hpp"
+#include "../Libft/libft.hpp"
+
+int math_validate_int(const char *input)
+{
+    return (ft_validate_int(input));
+}

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ size_t  ft_strlen_size_t(const char *string);
 int     ft_strlen(const char *string);
 char   *ft_strchr(const char *string, int char_to_find);
 int     ft_atoi(const char *string);
+int     ft_validate_int(const char *input);
 void    ft_bzero(void *string, size_t size);
 void   *ft_memchr(const void *ptr, int c, size_t size);
 void   *ft_memcpy(void *dst, const void *src, size_t n);
@@ -136,6 +137,7 @@ double      math_cos(double value);
 double      ft_sin(double value);
 double      ft_tan(double value);
 double      math_deg2rad(double degrees);
+int         math_validate_int(const char *input);
 double      math_rad2deg(double radians);
 ```
 
@@ -144,6 +146,42 @@ Example usage:
 ```
 double sine = ft_sin(math_deg2rad(90.0));
 double tangent = ft_tan(math_deg2rad(45.0));
+```
+
+Basic linear algebra types are provided in `linear_algebra.hpp`:
+
+```
+vector2(double x, double y);
+double dot(const vector2 &other) const;
+double length() const;
+vector2 normalize() const;
+
+vector3(double x, double y, double z);
+vector3 cross(const vector3 &other) const;
+double dot(const vector3 &other) const;
+double length() const;
+vector3 normalize() const;
+
+vector4(double x, double y, double z, double w);
+double dot(const vector4 &other) const;
+double length() const;
+vector4 normalize() const;
+
+matrix4();
+matrix4(double m00, double m01, double m02, double m03,
+        double m10, double m11, double m12, double m13,
+        double m20, double m21, double m22, double m23,
+        double m30, double m31, double m32, double m33);
+matrix4 multiply(const matrix4 &other) const;
+matrix4 invert() const;
+vector4 transform(const vector4 &vector) const;
+
+quaternion(double w, double x, double y, double z);
+quaternion multiply(const quaternion &other) const;
+double length() const;
+quaternion normalize() const;
+quaternion invert() const;
+vector3 transform(const vector3 &vector) const;
 ```
 
 Additional helpers for parsing expressions are available. They allocate a
@@ -163,7 +201,9 @@ Located in `CMA/`. Header: `CMA.hpp`. Provides memory helpers such as
 `cma_malloc`, `cma_free`, aligned allocations, allocation-size queries,
 and string helpers. Aligned allocations round the block size up to the
 specified power-of-two (e.g., requesting 100 bytes with alignment 32
-returns a 128-byte block) and are released with `cma_free`.
+returns a 128-byte block) and are released with `cma_free`. A safe
+`atoi` helper first validates the input and returns an allocated integer
+or `ft_nullptr` on failure.
 When allocation logging is enabled via the logger, the allocator emits debug messages for each `cma_malloc` and `cma_free`.
 The allocator enforces an optional global allocation limit that can be
 changed at runtime with `cma_set_alloc_limit`. A limit of `0` disables the
@@ -182,6 +222,7 @@ void   *cma_calloc(std::size_t nmemb, std::size_t size);
 void   *cma_realloc(void *ptr, std::size_t new_size);
 void   *cma_aligned_alloc(std::size_t alignment, std::size_t size);
 std::size_t cma_alloc_size(const void *ptr);
+int   *cma_atoi(const char *string);
 char  **cma_split(const char *s, char c);
 char   *cma_itoa(int n);
 char   *cma_itoa_base(int n, int base);

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -4,7 +4,7 @@ DEBUG_TARGET := libft_tests_debug
 EFF_SRCS :=
 
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp \
-       test_strlen.cpp test_promise.cpp test_networking.cpp
+       test_strlen.cpp test_promise.cpp test_networking.cpp test_linear_algebra.cpp test_validate_int.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/test_linear_algebra.cpp
+++ b/Test/test_linear_algebra.cpp
@@ -1,0 +1,56 @@
+#include "../Math/math.hpp"
+#include "../System_utils/test_runner.hpp"
+
+FT_TEST(test_vector3_dot, "vector3 dot product")
+{
+    vector3 a(1.0, 0.0, 0.0);
+    vector3 b(0.0, 1.0, 0.0);
+
+    FT_ASSERT(math_fabs(a.dot(b)) < 0.000001);
+    return (1);
+}
+
+FT_TEST(test_vector3_cross, "vector3 cross product")
+{
+    vector3 a(1.0, 0.0, 0.0);
+    vector3 b(0.0, 1.0, 0.0);
+    vector3 c;
+
+    c = a.cross(b);
+    FT_ASSERT(math_fabs(c.get_x()) < 0.000001);
+    FT_ASSERT(math_fabs(c.get_y()) < 0.000001);
+    FT_ASSERT(math_fabs(c.get_z() - 1.0) < 0.000001);
+    return (1);
+}
+
+FT_TEST(test_matrix4_identity_transform, "matrix4 identity transform")
+{
+    matrix4 identity;
+    vector4 v(1.0, 2.0, 3.0, 1.0);
+    vector4 r;
+
+    r = identity.transform(v);
+    FT_ASSERT(math_fabs(r.get_x() - 1.0) < 0.000001);
+    FT_ASSERT(math_fabs(r.get_y() - 2.0) < 0.000001);
+    FT_ASSERT(math_fabs(r.get_z() - 3.0) < 0.000001);
+    FT_ASSERT(math_fabs(r.get_w() - 1.0) < 0.000001);
+    return (1);
+}
+
+FT_TEST(test_quaternion_rotate_z, "quaternion rotate around z")
+{
+    double angle;
+    double half;
+    quaternion q;
+    vector3 v(1.0, 0.0, 0.0);
+    vector3 r;
+
+    angle = math_deg2rad(90.0);
+    half = angle / 2.0;
+    q = quaternion(math_cos(half), 0.0, 0.0, ft_sin(half));
+    r = q.transform(v);
+    FT_ASSERT(math_fabs(r.get_x()) < 0.000001);
+    FT_ASSERT(math_fabs(r.get_y() - 1.0) < 0.000001);
+    FT_ASSERT(math_fabs(r.get_z()) < 0.000001);
+    return (1);
+}

--- a/Test/test_validate_int.cpp
+++ b/Test/test_validate_int.cpp
@@ -1,0 +1,51 @@
+#include "../Libft/libft.hpp"
+#include "../Math/math.hpp"
+#include "../CMA/CMA.hpp"
+#include "../System_utils/test_runner.hpp"
+
+FT_TEST(test_validate_int_ok, "validate int ok")
+{
+    FT_ASSERT_EQ(0, ft_validate_int("123"));
+    FT_ASSERT_EQ(0, math_validate_int("456"));
+    return (1);
+}
+
+FT_TEST(test_validate_int_empty, "validate int empty")
+{
+    FT_ASSERT_EQ(1, ft_validate_int("+"));
+    FT_ASSERT_EQ(1, math_validate_int("-"));
+    return (1);
+}
+
+FT_TEST(test_validate_int_range, "validate int range")
+{
+    FT_ASSERT_EQ(2, ft_validate_int("2147483648"));
+    FT_ASSERT_EQ(2, math_validate_int("-2147483649"));
+    return (1);
+}
+
+FT_TEST(test_validate_int_invalid, "validate int invalid")
+{
+    FT_ASSERT_EQ(3, ft_validate_int("12a3"));
+    FT_ASSERT_EQ(3, math_validate_int("123b"));
+    return (1);
+}
+
+FT_TEST(test_cma_atoi_ok, "cma atoi ok")
+{
+    int *number;
+    int test_ok;
+
+    number = cma_atoi("789");
+    if (number == ft_nullptr)
+        return (0);
+    test_ok = (*number == 789);
+    cma_free(number);
+    return (test_ok);
+}
+
+FT_TEST(test_cma_atoi_invalid, "cma atoi invalid")
+{
+    FT_ASSERT_EQ(ft_nullptr, cma_atoi("99x"));
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add vector, matrix, and quaternion types with core math operations
- wire linear algebra into math module build and headers
- implement integer validation helpers in libft and math
- introduce `cma_atoi` for validated, allocation-backed conversion
- test vector, matrix, quaternion, integer validation, and safe atoi

## Testing
- `make -C Libft`
- `make -C CMA`
- `make -C Math`
- `make -C Test`
- `./Test/libft_tests`


------
https://chatgpt.com/codex/tasks/task_e_68c3f6b1b13483318187c4f06cb1e72a