### PR TITLE
Add streaming and base64 compression utilities

### DIFF
--- a/Compression/Makefile
+++ b/Compression/Makefile
@@ -1,7 +1,9 @@
 TARGET := compression.a
 DEBUG_TARGET := compression_debug.a
 
-SRCS := compression_zlib.cpp
+SRCS := compression_zlib.cpp \
+        compression_stream.cpp \
+        compression_base64.cpp
 
 HEADERS := compression.hpp
 

--- a/Compression/compression.hpp
+++ b/Compression/compression.hpp
@@ -3,8 +3,16 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 
 unsigned char    *compress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size);
 unsigned char    *decompress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size);
+
+unsigned char    *ft_compress(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size);
+unsigned char    *ft_decompress(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size);
+int              ft_compress_stream(FILE *input_stream, FILE *output_stream);
+int              ft_decompress_stream(FILE *input_stream, FILE *output_stream);
+unsigned char    *ft_base64_encode(const unsigned char *input_buffer, std::size_t input_size, std::size_t *encoded_size);
+unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decoded_size);
 
 #endif

--- a/Compression/compression_base64.cpp
+++ b/Compression/compression_base64.cpp
@@ -1,0 +1,152 @@
+#include "../CMA/CMA.hpp"
+#include "../Libft/libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "compression.hpp"
+
+static int base64_char_value(unsigned char character)
+{
+    if (character >= 'A' && character <= 'Z')
+        return (character - 'A');
+    if (character >= 'a' && character <= 'z')
+        return (character - 'a' + 26);
+    if (character >= '0' && character <= '9')
+        return (character - '0' + 52);
+    if (character == '+')
+        return (62);
+    if (character == '/')
+        return (63);
+    return (-1);
+}
+
+unsigned char    *ft_base64_encode(const unsigned char *input_buffer, std::size_t input_size, std::size_t *encoded_size)
+{
+    const char      *base64_table;
+    unsigned char   *output_buffer;
+    std::size_t     output_length;
+    std::size_t     input_index;
+    std::size_t     output_index;
+    unsigned char   byte_one;
+    unsigned char   byte_two;
+    unsigned char   byte_three;
+    int             has_byte_two;
+    int             has_byte_three;
+
+    if (!input_buffer || !encoded_size)
+        return (ft_nullptr);
+    base64_table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    output_length = ((input_size + 2) / 3) * 4;
+    output_buffer = static_cast<unsigned char *>(cma_malloc(output_length));
+    if (!output_buffer)
+        return (ft_nullptr);
+    input_index = 0;
+    output_index = 0;
+    while (input_index < input_size)
+    {
+        byte_one = input_buffer[input_index];
+        input_index++;
+        has_byte_two = 0;
+        has_byte_three = 0;
+        if (input_index < input_size)
+        {
+            byte_two = input_buffer[input_index];
+            input_index++;
+            has_byte_two = 1;
+        }
+        if (input_index < input_size)
+        {
+            byte_three = input_buffer[input_index];
+            input_index++;
+            has_byte_three = 1;
+        }
+        output_buffer[output_index] = static_cast<unsigned char>(base64_table[byte_one >> 2]);
+        output_index++;
+        output_buffer[output_index] = static_cast<unsigned char>(base64_table[((byte_one & 0x03) << 4) | (byte_two >> 4)]);
+        output_index++;
+        if (has_byte_two)
+        {
+            output_buffer[output_index] = static_cast<unsigned char>(base64_table[((byte_two & 0x0F) << 2) | (byte_three >> 6)]);
+            output_index++;
+        }
+        else
+        {
+            output_buffer[output_index] = '=';
+            output_index++;
+        }
+        if (has_byte_three)
+        {
+            output_buffer[output_index] = static_cast<unsigned char>(base64_table[byte_three & 0x3F]);
+            output_index++;
+        }
+        else
+        {
+            output_buffer[output_index] = '=';
+            output_index++;
+        }
+    }
+    *encoded_size = output_index;
+    return (output_buffer);
+}
+
+unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decoded_size)
+{
+    unsigned char   *output_buffer;
+    std::size_t     output_length;
+    std::size_t     input_index;
+    std::size_t     output_index;
+    int             value_one;
+    int             value_two;
+    int             value_three;
+    int             value_four;
+    unsigned char   char_three;
+    unsigned char   char_four;
+
+    if (!input_buffer || !decoded_size)
+        return (ft_nullptr);
+    if (input_size % 4 != 0)
+        return (ft_nullptr);
+    output_length = (input_size / 4) * 3;
+    if (input_buffer[input_size - 1] == '=')
+    {
+        output_length--;
+        if (input_buffer[input_size - 2] == '=')
+            output_length--;
+    }
+    output_buffer = static_cast<unsigned char *>(cma_malloc(output_length));
+    if (!output_buffer)
+        return (ft_nullptr);
+    input_index = 0;
+    output_index = 0;
+    while (input_index < input_size)
+    {
+        value_one = base64_char_value(input_buffer[input_index]);
+        input_index++;
+        value_two = base64_char_value(input_buffer[input_index]);
+        input_index++;
+        char_three = input_buffer[input_index];
+        if (char_three != '=')
+            value_three = base64_char_value(char_three);
+        else
+            value_three = 0;
+        input_index++;
+        char_four = input_buffer[input_index];
+        if (char_four != '=')
+            value_four = base64_char_value(char_four);
+        else
+            value_four = 0;
+        input_index++;
+        output_buffer[output_index] = static_cast<unsigned char>((value_one << 2) | (value_two >> 4));
+        output_index++;
+        if (char_three != '=')
+        {
+            output_buffer[output_index] = static_cast<unsigned char>(((value_two & 0x0F) << 4) | (value_three >> 2));
+            output_index++;
+        }
+        if (char_four != '=')
+        {
+            output_buffer[output_index] = static_cast<unsigned char>(((value_three & 0x03) << 6) | value_four);
+            output_index++;
+        }
+    }
+    *decoded_size = output_index;
+    return (output_buffer);
+}

--- a/Compression/compression_stream.cpp
+++ b/Compression/compression_stream.cpp
@@ -1,0 +1,99 @@
+#include <zlib.h>
+#include "../Libft/libft.hpp"
+#include "../CMA/CMA.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "compression.hpp"
+
+int ft_compress_stream(FILE *input_stream, FILE *output_stream)
+{
+    z_stream        stream;
+    unsigned char   input_buffer[4096];
+    unsigned char   output_buffer[4096];
+    int             flush_mode;
+    int             deflate_status;
+    std::size_t     read_bytes;
+
+    if (!input_stream || !output_stream)
+        return (1);
+    ft_bzero(&stream, sizeof(stream));
+    if (deflateInit(&stream, Z_BEST_COMPRESSION) != Z_OK)
+        return (1);
+    flush_mode = Z_NO_FLUSH;
+    while (flush_mode != Z_FINISH)
+    {
+        read_bytes = ft_fread(input_buffer, 1, sizeof(input_buffer), input_stream);
+        stream.next_in = input_buffer;
+        stream.avail_in = static_cast<unsigned int>(read_bytes);
+        if (read_bytes < sizeof(input_buffer))
+            flush_mode = Z_FINISH;
+        else
+            flush_mode = Z_NO_FLUSH;
+        do
+        {
+            stream.next_out = output_buffer;
+            stream.avail_out = sizeof(output_buffer);
+            deflate_status = deflate(&stream, flush_mode);
+            if (deflate_status == Z_STREAM_ERROR)
+            {
+                deflateEnd(&stream);
+                return (1);
+            }
+            std::size_t produced_bytes = sizeof(output_buffer) - stream.avail_out;
+            if (ft_fwrite(output_buffer, 1, produced_bytes, output_stream) != produced_bytes)
+            {
+                deflateEnd(&stream);
+                return (1);
+            }
+        }
+        while (stream.avail_out == 0);
+    }
+    deflateEnd(&stream);
+    return (0);
+}
+
+int ft_decompress_stream(FILE *input_stream, FILE *output_stream)
+{
+    z_stream        stream;
+    unsigned char   input_buffer[4096];
+    unsigned char   output_buffer[4096];
+    int             inflate_status;
+    std::size_t     read_bytes;
+    int             flush_mode;
+
+    if (!input_stream || !output_stream)
+        return (1);
+    ft_bzero(&stream, sizeof(stream));
+    if (inflateInit(&stream) != Z_OK)
+        return (1);
+    flush_mode = Z_NO_FLUSH;
+    while (flush_mode != Z_FINISH)
+    {
+        read_bytes = ft_fread(input_buffer, 1, sizeof(input_buffer), input_stream);
+        stream.next_in = input_buffer;
+        stream.avail_in = static_cast<unsigned int>(read_bytes);
+        if (read_bytes == 0)
+            flush_mode = Z_FINISH;
+        else
+            flush_mode = Z_NO_FLUSH;
+        do
+        {
+            stream.next_out = output_buffer;
+            stream.avail_out = sizeof(output_buffer);
+            inflate_status = inflate(&stream, flush_mode);
+            if (inflate_status == Z_NEED_DICT || inflate_status == Z_DATA_ERROR || inflate_status == Z_MEM_ERROR)
+            {
+                inflateEnd(&stream);
+                return (1);
+            }
+            std::size_t produced_bytes = sizeof(output_buffer) - stream.avail_out;
+            if (ft_fwrite(output_buffer, 1, produced_bytes, output_stream) != produced_bytes)
+            {
+                inflateEnd(&stream);
+                return (1);
+            }
+        }
+        while (stream.avail_out == 0);
+    }
+    inflateEnd(&stream);
+    return (0);
+}

--- a/Compression/compression_zlib.cpp
+++ b/Compression/compression_zlib.cpp
@@ -58,3 +58,13 @@ unsigned char    *decompress_buffer(const unsigned char *input_buffer, std::size
     *decompressed_size = actual_size;
     return (result_buffer);
 }
+
+unsigned char    *ft_compress(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size)
+{
+    return (compress_buffer(input_buffer, input_size, compressed_size));
+}
+
+unsigned char    *ft_decompress(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size)
+{
+    return (decompress_buffer(input_buffer, input_size, decompressed_size));
+}

--- a/README.md
+++ b/README.md
@@ -781,6 +781,19 @@ unsigned char *decompress_buffer(const unsigned char *input_buffer, std::size_t 
 
 The returned buffers are allocated with CMA and must be freed using `cma_free`.
 
+High level helpers are also available:
+
+```
+unsigned char *ft_compress(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size);
+unsigned char *ft_decompress(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size);
+int ft_compress_stream(FILE *input_stream, FILE *output_stream);
+int ft_decompress_stream(FILE *input_stream, FILE *output_stream);
+unsigned char *ft_base64_encode(const unsigned char *input_buffer, std::size_t input_size, std::size_t *encoded_size);
+unsigned char *ft_base64_decode(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decoded_size);
+```
+
+The streaming functions operate on `FILE*` streams, and the Base64 helpers encode or decode buffers.
+
 #### JSon
 Creation, reading and manipulation helpers in `JSon/json.hpp`:
 

--- a/Test/test_compression.cpp
+++ b/Test/test_compression.cpp
@@ -2,25 +2,27 @@
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../System_utils/test_runner.hpp"
+#include <cstdio>
 
-int test_compression_round_trip(void)
+FT_TEST(test_ft_compress_round_trip, "ft_compress round trip")
 {
     const char      *input_string;
     unsigned char   *compressed_buffer;
     unsigned char   *decompressed_buffer;
-    size_t          input_length;
-    size_t          compressed_length;
-    size_t          decompressed_length;
+    std::size_t     input_length;
+    std::size_t     compressed_length;
+    std::size_t     decompressed_length;
     int             comparison_result;
 
     input_string = "The quick brown fox jumps over the lazy dog";
-    input_length = ft_strlen(input_string);
+    input_length = ft_strlen_size_t(input_string);
     compressed_length = 0;
-    compressed_buffer = compress_buffer(reinterpret_cast<const unsigned char *>(input_string), input_length, &compressed_length);
+    compressed_buffer = ft_compress(reinterpret_cast<const unsigned char *>(input_string), input_length, &compressed_length);
     if (!compressed_buffer)
         return (0);
     decompressed_length = 0;
-    decompressed_buffer = decompress_buffer(compressed_buffer, compressed_length, &decompressed_length);
+    decompressed_buffer = ft_decompress(compressed_buffer, compressed_length, &decompressed_length);
     cma_free(compressed_buffer);
     if (!decompressed_buffer)
         return (0);
@@ -31,5 +33,117 @@ int test_compression_round_trip(void)
         return (1);
     }
     cma_free(decompressed_buffer);
+    return (0);
+}
+
+FT_TEST(test_compression_stream_round_trip, "stream compression round trip")
+{
+    const char      *input_string;
+    char            *input_copy;
+    FILE            *input_stream;
+    char            *compressed_data;
+    std::size_t     compressed_size;
+    FILE            *compressed_stream;
+    char            *decompressed_data;
+    std::size_t     decompressed_size;
+    FILE            *decompressed_stream;
+    int             comparison_result;
+
+    input_string = "Streaming API example";
+    input_copy = cma_strdup(input_string);
+    if (!input_copy)
+        return (0);
+    input_stream = fmemopen(input_copy, ft_strlen_size_t(input_copy), "r");
+    if (!input_stream)
+    {
+        cma_free(input_copy);
+        return (0);
+    }
+    compressed_data = ft_nullptr;
+    compressed_size = 0;
+    compressed_stream = open_memstream(&compressed_data, &compressed_size);
+    if (!compressed_stream)
+    {
+        fclose(input_stream);
+        cma_free(input_copy);
+        return (0);
+    }
+    if (ft_compress_stream(input_stream, compressed_stream) != 0)
+    {
+        fclose(input_stream);
+        fclose(compressed_stream);
+        cma_free(input_copy);
+        if (compressed_data)
+            cma_free(compressed_data);
+        return (0);
+    }
+    fclose(input_stream);
+    fclose(compressed_stream);
+    cma_free(input_copy);
+    decompressed_data = ft_nullptr;
+    decompressed_size = 0;
+    compressed_stream = fmemopen(compressed_data, compressed_size, "r");
+    if (!compressed_stream)
+    {
+        cma_free(compressed_data);
+        return (0);
+    }
+    decompressed_stream = open_memstream(&decompressed_data, &decompressed_size);
+    if (!decompressed_stream)
+    {
+        fclose(compressed_stream);
+        cma_free(compressed_data);
+        return (0);
+    }
+    if (ft_decompress_stream(compressed_stream, decompressed_stream) != 0)
+    {
+        fclose(compressed_stream);
+        fclose(decompressed_stream);
+        cma_free(compressed_data);
+        if (decompressed_data)
+            cma_free(decompressed_data);
+        return (0);
+    }
+    fclose(compressed_stream);
+    fclose(decompressed_stream);
+    cma_free(compressed_data);
+    comparison_result = ft_memcmp(decompressed_data, input_string, decompressed_size);
+    if (comparison_result == 0 && decompressed_size == ft_strlen_size_t(input_string))
+    {
+        cma_free(decompressed_data);
+        return (1);
+    }
+    cma_free(decompressed_data);
+    return (0);
+}
+
+FT_TEST(test_base64_round_trip, "base64 round trip")
+{
+    const char      *input_string;
+    unsigned char   *encoded_buffer;
+    unsigned char   *decoded_buffer;
+    std::size_t     input_length;
+    std::size_t     encoded_length;
+    std::size_t     decoded_length;
+    int             comparison_result;
+
+    input_string = "Base64 encoding";
+    input_length = ft_strlen_size_t(input_string);
+    encoded_length = 0;
+    encoded_buffer = ft_base64_encode(reinterpret_cast<const unsigned char *>(input_string), input_length, &encoded_length);
+    if (!encoded_buffer)
+        return (0);
+    decoded_length = 0;
+    decoded_buffer = ft_base64_decode(encoded_buffer, encoded_length, &decoded_length);
+    cma_free(encoded_buffer);
+    if (!decoded_buffer)
+        return (0);
+    comparison_result = ft_memcmp(decoded_buffer, input_string, decoded_length);
+    if (comparison_result == 0 && decoded_length == input_length)
+    {
+        cma_free(decoded_buffer);
+        return (1);
+    }
+    cma_free(decoded_buffer);
     return (0);
 }


### PR DESCRIPTION
## Summary
- extend compression API with ft_compress/ft_decompress
- add stream compression and Base64 encode/decode helpers
- document compression and base64 usage and add tests

## Testing
- `make -C Compression`
- `make` *(fails: no previous declaration for `ft_validate_int`)*
- `g++ -Wall -Wextra -Werror -std=c++17 Test/main.cpp Test/test_compression.cpp Compression/objs/compression_zlib.o Compression/objs/compression_stream.o Compression/objs/compression_base64.o Libft/objs/libft_strlen.o Libft/objs/libft_memcpy.o Libft/objs/libft_memcmp.o Libft/objs/libft_bzero.o Libft/objs/libft_fread.o Libft/objs/libft_fwrite.o CPP_class/cpp_class_nullptr.cpp CMA/CustomMemoryAllocator.a -I. -o compression_test -lz` *(fails: undefined reference to `ft_run_registered_tests` et al.)*


------
https://chatgpt.com/codex/tasks/task_e_68c404e5c4a88331b0b88d54011dfa5d