### PR TITLE
Add secure RNG helpers and documentation

### DIFF
--- a/Concurrency/Concurrency_task_scheduler.cpp
+++ b/Concurrency/Concurrency_task_scheduler.cpp
@@ -69,7 +69,12 @@ void ft_task_scheduler::timer_loop()
         {
             if (now >= this->_scheduled[index]._time)
             {
-                this->_queue.push(ft_move(this->_scheduled[index]._function));
+                if (this->_scheduled[index]._function)
+                {
+                    std::function<void()> function_copy;
+                    function_copy = this->_scheduled[index]._function;
+                    this->_queue.push(ft_move(function_copy));
+                }
                 if (this->_scheduled[index]._interval.count() > 0)
                 {
                     this->_scheduled[index]._time = now + this->_scheduled[index]._interval;

--- a/README.md
+++ b/README.md
@@ -712,6 +712,9 @@ void schedule_every(std::chrono::duration<Rep, Period> interval,
                     FunctionType function, Args... args);
 ```
 
+Recurring tasks preserve their callbacks across intervals, preventing
+empty function executions when rescheduled.
+
 Worker threads fetch jobs from a lock-free queue so producers and consumers do
 not block each other. The scheduler thread manages delayed and recurring jobs.
 
@@ -725,7 +728,9 @@ void        ft_exit(const char *msg, int code);
 ```
 
 #### RNG
-Random helpers and containers in `RNG/`.
+Random helpers and containers in `RNG/`. `rng_secure_bytes` obtains
+cryptographically secure random data from the operating system, and
+`ft_random_uint32` wraps it to produce a single 32-bit value.
 
 ```
 int   ft_random_int(void);
@@ -735,13 +740,26 @@ float ft_random_normal(void);
 float ft_random_exponential(float lambda_value);
 int   ft_random_poisson(double lambda_value);
 int   ft_random_seed(const char *seed_str = ft_nullptr);
+int   rng_secure_bytes(unsigned char *buffer, size_t length);
+uint32_t ft_random_uint32(void);
 ```
 
 Example:
 
 ```
+unsigned char buffer[16];
+if (rng_secure_bytes(buffer, 16) == 0)
+{
+    /* use buffer */
+}
+uint32_t secure_value = ft_random_uint32();
 int occurrences = ft_random_poisson(4.0);
 ```
+
+Secure randomness is required for secrets such as tokens, keys, and
+identifiers that must not be predictable. For simulations or gameplay
+where predictability is less critical, functions like `ft_random_int`
+or `ft_random_float` are sufficient.
 
 `RNG/deck.hpp` provides a simple deck container:
 

--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -3,7 +3,7 @@ DEBUG_TARGET := RNG_debug.a
 
 SRCS := rng_dice_roll.cpp rng_random_int.cpp rng_random_float.cpp \
        rng_random_normal.cpp rng_random_exponential.cpp rng_random_poisson.cpp \
-       rng_random_seed.cpp
+       rng_random_seed.cpp rng_secure_bytes.cpp
 
 HEADERS := rng.hpp rng_internal.hpp deck.hpp loot_table.hpp
 

--- a/RNG/rng.hpp
+++ b/RNG/rng.hpp
@@ -7,6 +7,8 @@
 
 #include <ctime>
 #include <cstdlib>
+#include <cstddef>
+#include <cstdint>
 #include "../CPP_class/class_nullptr.hpp"
 
 int ft_random_int(void);
@@ -16,5 +18,7 @@ float ft_random_normal(void);
 float ft_random_exponential(float lambda_value);
 int ft_random_poisson(double lambda_value);
 int ft_random_seed(const char *seed_str = ft_nullptr);
+int rng_secure_bytes(unsigned char *buffer, size_t length);
+uint32_t ft_random_uint32(void);
 
 #endif

--- a/RNG/rng_secure_bytes.cpp
+++ b/RNG/rng_secure_bytes.cpp
@@ -1,0 +1,60 @@
+#include "rng.hpp"
+
+#ifdef _WIN32
+# include <windows.h>
+# include <wincrypt.h>
+#else
+# include <unistd.h>
+# include <fcntl.h>
+#endif
+
+int rng_secure_bytes(unsigned char *buffer, size_t length)
+{
+    if (buffer == ft_nullptr)
+        return (-1);
+#ifdef _WIN32
+    HCRYPTPROV crypt_provider = 0;
+    if (CryptAcquireContext(&crypt_provider, ft_nullptr, ft_nullptr, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT) == 0)
+        return (-1);
+    if (CryptGenRandom(crypt_provider, static_cast<DWORD>(length), buffer) == 0)
+    {
+        CryptReleaseContext(crypt_provider, 0);
+        return (-1);
+    }
+    CryptReleaseContext(crypt_provider, 0);
+    return (0);
+#else
+    int file_descriptor = open("/dev/urandom", O_RDONLY);
+    if (file_descriptor < 0)
+        return (-1);
+    size_t offset = 0;
+    while (offset < length)
+    {
+        ssize_t bytes_read = read(file_descriptor, buffer + offset, length - offset);
+        if (bytes_read < 0)
+        {
+            close(file_descriptor);
+            return (-1);
+        }
+        offset += static_cast<size_t>(bytes_read);
+    }
+    close(file_descriptor);
+    return (0);
+#endif
+}
+
+uint32_t ft_random_uint32(void)
+{
+    unsigned char byte_buffer[4];
+    if (rng_secure_bytes(byte_buffer, 4) != 0)
+        return (0);
+    uint32_t random_value = 0;
+    size_t index = 0;
+    while (index < 4)
+    {
+        random_value |= static_cast<uint32_t>(byte_buffer[index]) << (index * 8);
+        index++;
+    }
+    return (random_value);
+}
+


### PR DESCRIPTION
## Summary
- add `rng_secure_bytes` for OS-backed randomness and `ft_random_uint32` wrapper
- document secure RNG usage in main README
- preserve scheduled callbacks in the task scheduler to avoid empty function calls

## Testing
- `make -C RNG`
- `make tests`
- `./Test/libft_tests`


------
https://chatgpt.com/codex/tasks/task_e_68c41780782c8331b996961813b84fac