### PR TITLE
Add portable file copy and move helpers

### DIFF
--- a/File/Makefile
+++ b/File/Makefile
@@ -3,9 +3,12 @@ DEBUG_TARGET   := file_debug.a
 
 SRCS := file_opendir.cpp \
         file_check_directory.cpp \
-        file_mkdir.cpp
+        file_mkdir.cpp \
+        file_copy.cpp \
+        file_move.cpp
 
-HEADERS := open_dir.hpp
+HEADERS := open_dir.hpp \
+           file_utils.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/File/file_copy.cpp
+++ b/File/file_copy.cpp
@@ -1,0 +1,24 @@
+#include "file_utils.hpp"
+
+#ifdef _WIN32
+# include <windows.h>
+
+int file_copy(const char *source_path, const char *destination_path)
+{
+    if (CopyFileA(source_path, destination_path, 0))
+        return (0);
+    return (-1);
+}
+
+#else
+# include <filesystem>
+
+int file_copy(const char *source_path, const char *destination_path)
+{
+    std::error_code copy_error_code;
+    std::filesystem::copy_file(source_path, destination_path, std::filesystem::copy_options::overwrite_existing, copy_error_code);
+    if (copy_error_code.value() == 0)
+        return (0);
+    return (-1);
+}
+#endif

--- a/File/file_move.cpp
+++ b/File/file_move.cpp
@@ -1,0 +1,22 @@
+#include "file_utils.hpp"
+
+#ifdef _WIN32
+# include <windows.h>
+
+int file_move(const char *source_path, const char *destination_path)
+{
+    if (MoveFileA(source_path, destination_path))
+        return (0);
+    return (-1);
+}
+
+#else
+# include <stdio.h>
+
+int file_move(const char *source_path, const char *destination_path)
+{
+    if (rename(source_path, destination_path) == 0)
+        return (0);
+    return (-1);
+}
+#endif

--- a/File/file_utils.hpp
+++ b/File/file_utils.hpp
@@ -1,0 +1,7 @@
+#ifndef FILE_FILE_UTILS_HPP
+# define FILE_FILE_UTILS_HPP
+
+int file_copy(const char *source_path, const char *destination_path);
+int file_move(const char *source_path, const char *destination_path);
+
+#endif

--- a/README.md
+++ b/README.md
@@ -921,7 +921,7 @@ bool valid = json_validate(group, schema);
 ```
 
 #### File
-Cross-platform file and directory utilities (`File/open_dir.hpp`):
+Cross-platform file and directory utilities (`File/open_dir.hpp` and `File/file_utils.hpp`):
 
 ```
 file_dir   *file_opendir(const char *directory_path);
@@ -929,7 +929,11 @@ int         file_closedir(file_dir *directory_stream);
 file_dirent *file_readdir(file_dir *directory_stream);
 int         file_dir_exists(const char *rel_path);
 int         file_create_directory(const char *path, mode_t mode);
+int         file_copy(const char *source_path, const char *destination_path);
+int         file_move(const char *source_path, const char *destination_path);
 ```
+
+The `file_copy` and `file_move` helpers return (-1) on failure to allow error handling. `file_copy` uses `CopyFile` on Windows and `std::filesystem::copy_file` on POSIX systems. `file_move` wraps `MoveFile` or `rename` to provide portable file operations.
 
 `System_utils/system_utils.hpp` provides cross-platform file descriptor utilities:
 


### PR DESCRIPTION
## Summary
- add file_copy and file_move implementations with Windows and POSIX support
- expose new helpers via file_utils.hpp and integrate them into File build system
- document file_copy and file_move usage and error behavior in README

## Testing
- `cd File && make`


------
https://chatgpt.com/codex/tasks/task_e_68c4339217e083319b0b627363f380d8