### PR TITLE
Add binomial and geometric RNG functions with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,8 @@ float ft_random_float(void);
 float ft_random_normal(void);
 float ft_random_exponential(float lambda_value);
 int   ft_random_poisson(double lambda_value);
+int   ft_random_binomial(int trial_count, double success_probability);
+int   ft_random_geometric(double success_probability);
 int   ft_random_seed(const char *seed_str = ft_nullptr);
 int   rng_secure_bytes(unsigned char *buffer, size_t length);
 uint32_t ft_random_uint32(void);
@@ -771,6 +773,8 @@ if (rng_secure_bytes(buffer, 16) == 0)
 }
 uint32_t secure_value = ft_random_uint32();
 int occurrences = ft_random_poisson(4.0);
+int successes = ft_random_binomial(10, 0.5);
+int attempts = ft_random_geometric(0.25);
 ```
 
 Secure randomness is required for secrets such as tokens, keys, and

--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -3,6 +3,7 @@ DEBUG_TARGET := RNG_debug.a
 
 SRCS := rng_dice_roll.cpp rng_random_int.cpp rng_random_float.cpp \
        rng_random_normal.cpp rng_random_exponential.cpp rng_random_poisson.cpp \
+       rng_random_binomial.cpp rng_random_geometric.cpp \
        rng_random_seed.cpp rng_secure_bytes.cpp
 
 HEADERS := rng.hpp rng_internal.hpp deck.hpp loot_table.hpp

--- a/RNG/rng.hpp
+++ b/RNG/rng.hpp
@@ -17,6 +17,8 @@ float ft_random_float(void);
 float ft_random_normal(void);
 float ft_random_exponential(float lambda_value);
 int ft_random_poisson(double lambda_value);
+int ft_random_binomial(int trial_count, double success_probability);
+int ft_random_geometric(double success_probability);
 int ft_random_seed(const char *seed_str = ft_nullptr);
 int rng_secure_bytes(unsigned char *buffer, size_t length);
 uint32_t ft_random_uint32(void);

--- a/RNG/rng_random_binomial.cpp
+++ b/RNG/rng_random_binomial.cpp
@@ -1,0 +1,31 @@
+#include "rng.hpp"
+#include "rng_internal.hpp"
+
+int ft_random_binomial(int trial_count, double success_probability)
+{
+    int trial_index;
+    int success_count;
+    double random_value;
+
+    ft_init_srand();
+    if (trial_count <= 0)
+        return (0);
+    if (success_probability <= 0.0)
+        return (0);
+    if (success_probability >= 1.0)
+    {
+        if (success_probability > 1.0)
+            return (0);
+        return (trial_count);
+    }
+    trial_index = 0;
+    success_count = 0;
+    while (trial_index < trial_count)
+    {
+        random_value = static_cast<double>(ft_random_float());
+        if (random_value < success_probability)
+            success_count = success_count + 1;
+        trial_index = trial_index + 1;
+    }
+    return (success_count);
+}

--- a/RNG/rng_random_geometric.cpp
+++ b/RNG/rng_random_geometric.cpp
@@ -1,0 +1,27 @@
+#include "rng.hpp"
+#include "rng_internal.hpp"
+
+int ft_random_geometric(double success_probability)
+{
+    int trial_count;
+    double random_value;
+
+    ft_init_srand();
+    if (success_probability <= 0.0)
+        return (0);
+    if (success_probability >= 1.0)
+    {
+        if (success_probability > 1.0)
+            return (0);
+        return (1);
+    }
+    trial_count = 1;
+    while (1)
+    {
+        random_value = static_cast<double>(ft_random_float());
+        if (random_value < success_probability)
+            return (trial_count);
+        trial_count = trial_count + 1;
+    }
+    return (0);
+}

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -5,7 +5,7 @@ EFF_SRCS :=
 
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp \
        test_strlen.cpp test_promise.cpp test_networking.cpp test_linear_algebra.cpp test_validate_int.cpp \
-       test_task_scheduler.cpp test_json_validate.cpp
+       test_task_scheduler.cpp test_json_validate.cpp test_rng.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/test_rng.cpp
+++ b/Test/test_rng.cpp
@@ -1,48 +1,49 @@
 #include "../RNG/rng.hpp"
 #include "../RNG/rng_internal.hpp"
+#include "../System_utils/test_runner.hpp"
 #include <cstdlib>
 
-int test_rng_random_normal(void)
+FT_TEST(test_rng_random_normal, "ft_random_normal mean")
 {
     g_srand_init = true;
     srand(123);
     int sample_count = 10000;
     int index = 0;
-    float sum = 0.0f;
+    float sum_values = 0.0f;
     while (index < sample_count)
     {
-        sum += ft_random_normal();
-        index++;
+        sum_values = sum_values + ft_random_normal();
+        index = index + 1;
     }
-    float mean = sum / static_cast<float>(sample_count);
-    if (mean < -0.1f)
+    float mean_value = sum_values / static_cast<float>(sample_count);
+    if (mean_value < -0.1f)
         return (0);
-    if (mean > 0.1f)
+    if (mean_value > 0.1f)
         return (0);
     return (1);
 }
 
-int test_rng_random_exponential(void)
+FT_TEST(test_rng_random_exponential, "ft_random_exponential mean")
 {
     g_srand_init = true;
     srand(123);
     int sample_count = 10000;
     int index = 0;
-    float sum = 0.0f;
+    float sum_values = 0.0f;
     while (index < sample_count)
     {
-        sum += ft_random_exponential(2.0f);
-        index++;
+        sum_values = sum_values + ft_random_exponential(2.0f);
+        index = index + 1;
     }
-    float mean = sum / static_cast<float>(sample_count);
-    if (mean < 0.4f)
+    float mean_value = sum_values / static_cast<float>(sample_count);
+    if (mean_value < 0.4f)
         return (0);
-    if (mean > 0.6f)
+    if (mean_value > 0.6f)
         return (0);
     return (1);
 }
 
-int test_rng_random_poisson(void)
+FT_TEST(test_rng_random_poisson, "ft_random_poisson mean")
 {
     g_srand_init = true;
     srand(123);
@@ -52,8 +53,8 @@ int test_rng_random_poisson(void)
     double lambda_value = 4.0;
     while (index < sample_count)
     {
-        sum_values += ft_random_poisson(lambda_value);
-        index++;
+        sum_values = sum_values + ft_random_poisson(lambda_value);
+        index = index + 1;
     }
     double mean_value = static_cast<double>(sum_values) /
                          static_cast<double>(sample_count);
@@ -61,5 +62,61 @@ int test_rng_random_poisson(void)
         return (0);
     if (mean_value > lambda_value + 0.1)
         return (0);
+    return (1);
+}
+
+FT_TEST(test_rng_random_binomial, "ft_random_binomial typical and edge cases")
+{
+    g_srand_init = true;
+    srand(123);
+    int sample_count = 10000;
+    int index = 0;
+    int sum_values = 0;
+    int trial_count = 10;
+    double success_probability = 0.5;
+    while (index < sample_count)
+    {
+        sum_values = sum_values +
+            ft_random_binomial(trial_count, success_probability);
+        index = index + 1;
+    }
+    double mean_value = static_cast<double>(sum_values) /
+                         static_cast<double>(sample_count);
+    if (mean_value < 4.9)
+        return (0);
+    if (mean_value > 5.1)
+        return (0);
+    FT_ASSERT_EQ(0, ft_random_binomial(0, success_probability));
+    FT_ASSERT_EQ(0, ft_random_binomial(trial_count, 0.0));
+    FT_ASSERT_EQ(trial_count, ft_random_binomial(trial_count, 1.0));
+    FT_ASSERT_EQ(0, ft_random_binomial(-3, success_probability));
+    FT_ASSERT_EQ(0, ft_random_binomial(trial_count, -0.1));
+    FT_ASSERT_EQ(0, ft_random_binomial(trial_count, 1.5));
+    return (1);
+}
+
+FT_TEST(test_rng_random_geometric, "ft_random_geometric typical and edge cases")
+{
+    g_srand_init = true;
+    srand(123);
+    int sample_count = 10000;
+    int index = 0;
+    int sum_values = 0;
+    double success_probability = 0.25;
+    while (index < sample_count)
+    {
+        sum_values = sum_values + ft_random_geometric(success_probability);
+        index = index + 1;
+    }
+    double mean_value = static_cast<double>(sum_values) /
+                         static_cast<double>(sample_count);
+    if (mean_value < 3.9)
+        return (0);
+    if (mean_value > 4.1)
+        return (0);
+    FT_ASSERT_EQ(0, ft_random_geometric(0.0));
+    FT_ASSERT_EQ(1, ft_random_geometric(1.0));
+    FT_ASSERT_EQ(0, ft_random_geometric(-0.1));
+    FT_ASSERT_EQ(0, ft_random_geometric(1.5));
     return (1);
 }


### PR DESCRIPTION
## Summary
- implement `ft_random_binomial` and `ft_random_geometric` for binomial and geometric distributions
- document new RNG helpers and wire sources into build system
- expand RNG tests to exercise distributions and edge cases

## Testing
- `make tests`
- `./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c44312d124833181673d2749844e0d