### PR TITLE
Add UUID generator using secure random bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,8 +746,9 @@ void        ft_exit(const char *msg, int code);
 
 #### RNG
 Random helpers and containers in `RNG/`. `rng_secure_bytes` obtains
-cryptographically secure random data from the operating system, and
-`ft_random_uint32` wraps it to produce a single 32-bit value.
+cryptographically secure random data from the operating system,
+`ft_random_uint32` wraps it to produce a single 32-bit value,
+and `ft_generate_uuid` formats secure bytes as a version 4 UUID string.
 
 ```
 int   ft_random_int(void);
@@ -761,6 +762,7 @@ int   ft_random_geometric(double success_probability);
 int   ft_random_seed(const char *seed_str = ft_nullptr);
 int   rng_secure_bytes(unsigned char *buffer, size_t length);
 uint32_t ft_random_uint32(void);
+void   ft_generate_uuid(char out[37]);
 ```
 
 Example:
@@ -772,6 +774,8 @@ if (rng_secure_bytes(buffer, 16) == 0)
     /* use buffer */
 }
 uint32_t secure_value = ft_random_uint32();
+char uuid[37];
+ft_generate_uuid(uuid);
 int occurrences = ft_random_poisson(4.0);
 int successes = ft_random_binomial(10, 0.5);
 int attempts = ft_random_geometric(0.25);

--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -4,7 +4,7 @@ DEBUG_TARGET := RNG_debug.a
 SRCS := rng_dice_roll.cpp rng_random_int.cpp rng_random_float.cpp \
        rng_random_normal.cpp rng_random_exponential.cpp rng_random_poisson.cpp \
        rng_random_binomial.cpp rng_random_geometric.cpp \
-       rng_random_seed.cpp rng_secure_bytes.cpp
+       rng_random_seed.cpp rng_secure_bytes.cpp rng_uuid.cpp
 
 HEADERS := rng.hpp rng_internal.hpp deck.hpp loot_table.hpp
 

--- a/RNG/rng.hpp
+++ b/RNG/rng.hpp
@@ -22,5 +22,6 @@ int ft_random_geometric(double success_probability);
 int ft_random_seed(const char *seed_str = ft_nullptr);
 int rng_secure_bytes(unsigned char *buffer, size_t length);
 uint32_t ft_random_uint32(void);
+void ft_generate_uuid(char out[37]);
 
 #endif

--- a/RNG/rng_uuid.cpp
+++ b/RNG/rng_uuid.cpp
@@ -1,0 +1,34 @@
+#include "rng.hpp"
+
+void ft_generate_uuid(char out[37])
+{
+    if (out == ft_nullptr)
+        return ;
+    unsigned char uuid_bytes[16];
+    if (rng_secure_bytes(uuid_bytes, 16) != 0)
+    {
+        out[0] = '\0';
+        return ;
+    }
+    uuid_bytes[6] = static_cast<unsigned char>((uuid_bytes[6] & 0x0F) | 0x40);
+    uuid_bytes[8] = static_cast<unsigned char>((uuid_bytes[8] & 0x3F) | 0x80);
+    const char hex_characters[] = "0123456789abcdef";
+    size_t byte_index = 0;
+    size_t output_index = 0;
+    while (byte_index < 16)
+    {
+        out[output_index] = hex_characters[(uuid_bytes[byte_index] >> 4) & 0x0F];
+        output_index++;
+        out[output_index] = hex_characters[uuid_bytes[byte_index] & 0x0F];
+        output_index++;
+        if (byte_index == 3 || byte_index == 5 || byte_index == 7 || byte_index == 9)
+        {
+            out[output_index] = '-';
+            output_index++;
+        }
+        byte_index++;
+    }
+    out[output_index] = '\0';
+    return ;
+}
+


### PR DESCRIPTION
## Summary
- add `ft_generate_uuid` to format secure random bytes as RFC 4122 UUIDs
- expose UUID helper in public RNG header and build system
- document UUID generation usage in README

## Testing
- `make -C RNG`


------
https://chatgpt.com/codex/tasks/task_e_68c448dce8d88331b6d5715e80d5dbe2