### PR TITLE
Add HMAC-SHA256 helper

### DIFF
--- a/Encryption/Makefile
+++ b/Encryption/Makefile
@@ -5,12 +5,14 @@ SRCS := encryption_basic_encryption.cpp \
         encryption_key.cpp \
         encryption_aes.cpp \
         encryption_rsa.cpp \
-        encryption_sha256.cpp
+        encryption_sha256.cpp \
+        encryption_hmac_sha256.cpp
 
 HEADERS := basic_encryption.hpp \
         aes.hpp \
         rsa.hpp \
-        encryption_sha256.hpp
+        encryption_sha256.hpp \
+        encryption_hmac_sha256.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Encryption/README
+++ b/Encryption/README
@@ -28,6 +28,20 @@ SHA-256 provides collision resistance for modern systems, but hashing alone
 does not secure passwords or sensitive data. Apply a keyed construction such as
 HMAC or use dedicated password hashing algorithms for authentication.
 
+## HMAC-SHA-256
+
+`hmac_sha256` computes a keyed hash using SHA-256. The function accepts a key,
+its length, a pointer to the data, the data length and a 32 byte output buffer.
+
+### Usage
+
+```
+const char *message = "hello";
+const unsigned char key[] = "secret";
+unsigned char digest[32];
+hmac_sha256(key, 6, message, 5, digest);
+```
+
 ## RSA
 
 Basic RSA helpers generate a key pair and perform modular exponentiation for

--- a/Encryption/basic_encryption.hpp
+++ b/Encryption/basic_encryption.hpp
@@ -3,6 +3,8 @@
 
 #include "aes.hpp"
 #include "rsa.hpp"
+#include "encryption_sha256.hpp"
+#include "encryption_hmac_sha256.hpp"
 
 int            be_saveGame(const char *filename, const char *data, const char *key);
 char        **be_DecryptData(char **data, const char *key);

--- a/Encryption/encryption_hmac_sha256.cpp
+++ b/Encryption/encryption_hmac_sha256.cpp
@@ -1,0 +1,68 @@
+#include <stddef.h>
+#include "../CMA/CMA.hpp"
+#include "encryption_hmac_sha256.hpp"
+#include "encryption_sha256.hpp"
+
+void hmac_sha256(const unsigned char *key, size_t key_len, const void *data, size_t len, unsigned char *digest)
+{
+    unsigned char key_block[64];
+    unsigned char inner_pad[64];
+    unsigned char outer_pad[64];
+    unsigned char hashed_key[32];
+    size_t current_index;
+
+    if (key_len > 64)
+    {
+        sha256_hash(key, key_len, hashed_key);
+        key = hashed_key;
+        key_len = 32;
+    }
+    current_index = 0;
+    while (current_index < 64)
+    {
+        unsigned char key_byte = 0;
+        if (current_index < key_len)
+            key_byte = key[current_index];
+        key_block[current_index] = key_byte;
+        inner_pad[current_index] = key_block[current_index] ^ 0x36;
+        outer_pad[current_index] = key_block[current_index] ^ 0x5c;
+        ++current_index;
+    }
+    unsigned char *inner_data = static_cast<unsigned char *>(cma_malloc(64 + len));
+    if (!inner_data)
+        return ;
+    current_index = 0;
+    while (current_index < 64)
+    {
+        inner_data[current_index] = inner_pad[current_index];
+        ++current_index;
+    }
+    size_t data_index = 0;
+    const unsigned char *byte_data = static_cast<const unsigned char *>(data);
+    while (data_index < len)
+    {
+        inner_data[64 + data_index] = byte_data[data_index];
+        ++data_index;
+    }
+    unsigned char inner_digest[32];
+    sha256_hash(inner_data, 64 + len, inner_digest);
+    cma_free(inner_data);
+    unsigned char *outer_data = static_cast<unsigned char *>(cma_malloc(64 + 32));
+    if (!outer_data)
+        return ;
+    current_index = 0;
+    while (current_index < 64)
+    {
+        outer_data[current_index] = outer_pad[current_index];
+        ++current_index;
+    }
+    current_index = 0;
+    while (current_index < 32)
+    {
+        outer_data[64 + current_index] = inner_digest[current_index];
+        ++current_index;
+    }
+    sha256_hash(outer_data, 96, digest);
+    cma_free(outer_data);
+    return ;
+}

--- a/Encryption/encryption_hmac_sha256.hpp
+++ b/Encryption/encryption_hmac_sha256.hpp
@@ -1,0 +1,8 @@
+#ifndef ENCRYPTION_HMAC_SHA256_HPP
+#define ENCRYPTION_HMAC_SHA256_HPP
+
+#include <stddef.h>
+
+void hmac_sha256(const unsigned char *key, size_t key_len, const void *data, size_t len, unsigned char *digest);
+
+#endif

--- a/README.md
+++ b/README.md
@@ -816,6 +816,7 @@ int         rsa_generate_key_pair(uint64_t *public_key, uint64_t *private_key, u
 uint64_t    rsa_encrypt(uint64_t message, uint64_t public_key, uint64_t modulus);
 uint64_t    rsa_decrypt(uint64_t cipher, uint64_t private_key, uint64_t modulus);
 void        sha256_hash(const void *data, size_t length, unsigned char *digest);
+void        hmac_sha256(const unsigned char *key, size_t key_len, const void *data, size_t len, unsigned char *digest);
 ```
 
 RSA helpers operate on 64-bit integers and are intended for small demonstrations. Key generation with large sizes significantly impacts performance.
@@ -840,6 +841,8 @@ uint64_t decrypted = rsa_decrypt(encrypted, private_key, modulus);
 unsigned char digest[32];
 const char *message = "hello";
 sha256_hash(message, 5, digest);
+const unsigned char key[] = "secret";
+hmac_sha256(key, 6, message, 5, digest);
 ```
 
 #### Compression


### PR DESCRIPTION
## Summary
- implement `hmac_sha256` using existing SHA-256 routine
- expose HMAC API via public headers and build system
- document HMAC usage in README files

## Testing
- `make -C Encryption`


------
https://chatgpt.com/codex/tasks/task_e_68c44f84b9ac833192e34cf50c06a4eb