### PR TITLE
Add HTTP client helpers to Networking module

### DIFF
--- a/Concurrency/task_scheduler.hpp
+++ b/Concurrency/task_scheduler.hpp
@@ -15,7 +15,7 @@
 #include <chrono>
 #include <new>
 
-// Lock-free queue using Michael and Scott algorithm
+
 
 template <typename ElementType>
 class ft_lock_free_queue
@@ -95,7 +95,7 @@ class ft_task_scheduler
         const char *get_error_str() const;
 };
 
-// ---------------- lock_free_queue implementation ----------------
+
 
 template <typename ElementType>
 ft_lock_free_queue<ElementType>::ft_lock_free_queue()
@@ -216,7 +216,7 @@ const char *ft_lock_free_queue<ElementType>::get_error_str() const
     return (ft_strerror(this->_error_code));
 }
 
-// ---------------- task_scheduler template methods ----------------
+
 
 template <typename FunctionType, typename... Args>
 auto ft_task_scheduler::submit(FunctionType function, Args... args)

--- a/Config/config.hpp
+++ b/Config/config.hpp
@@ -17,12 +17,7 @@ struct cnfg_config
     size_t           entry_count;
 };
 
-/*
-** cnfg_parse reads a configuration file and fills a cnfg_config
-** structure. For each key, the parser first checks the environment
-** using ft_getenv. If an environment variable with the same key is
-** found, its value overrides the one from the file.
-*/
+
 cnfg_config   *cnfg_parse(const char *filename);
 void        cnfg_free(cnfg_config *config);
 char       *cnfg_parse_flags(int argument_count, char **argument_values);

--- a/Encryption/basic_encryption.hpp
+++ b/Encryption/basic_encryption.hpp
@@ -10,19 +10,6 @@ int            be_saveGame(const char *filename, const char *data, const char *k
 char        **be_DecryptData(char **data, const char *key);
 const char    *be_getEncryptionKey();
 
-/*
-Usage:
-    unsigned char block[16] = {0};
-    unsigned char key[16] = {0};
-    aes_encrypt(block, key);
-    aes_decrypt(block, key);
 
-    uint64_t public_key;
-    uint64_t private_key;
-    uint64_t modulus;
-    rsa_generate_key_pair(&public_key, &private_key, &modulus, 32);
-    uint64_t encrypted = rsa_encrypt(42, public_key, modulus);
-    uint64_t decrypted = rsa_decrypt(encrypted, private_key, modulus);
-*/
 
 #endif

--- a/Encryption/rsa.hpp
+++ b/Encryption/rsa.hpp
@@ -7,14 +7,6 @@ int        rsa_generate_key_pair(uint64_t *public_key, uint64_t *private_key, ui
 uint64_t    rsa_encrypt(uint64_t message, uint64_t public_key, uint64_t modulus);
 uint64_t    rsa_decrypt(uint64_t cipher, uint64_t private_key, uint64_t modulus);
 
-/*
-Usage:
-    uint64_t public_key;
-    uint64_t private_key;
-    uint64_t modulus;
-    rsa_generate_key_pair(&public_key, &private_key, &modulus, 32);
-    uint64_t encrypted = rsa_encrypt(42, public_key, modulus);
-    uint64_t decrypted = rsa_decrypt(encrypted, private_key, modulus);
-*/
+
 
 #endif

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -96,4 +96,4 @@
 #include "Game/reputation.hpp"
 #include "Game/world.hpp"
 
-#endif // FULL_LIBFT_HPP
+#endif 

--- a/HTML/parser.hpp
+++ b/HTML/parser.hpp
@@ -35,11 +35,7 @@ html_node   *html_find_by_tag(html_node *nodeList, const char *tagName);
 html_node   *html_find_by_attr(html_node *nodeList, const char *key, const char *value);
 html_node   *html_find_by_text(html_node *nodeList, const char *textContent);
 html_node   *html_find_by_selector(html_node *node_list, const char *selector);
-/*
- * Search node_list for the first element that matches a simple selector.
- * Supports tag names, .class, and #id selectors. Combinators are not
- * implemented.
- */
+
 html_node   *html_query_selector(html_node *node_list, const char *selector);
 size_t      html_count_nodes_by_tag(html_node *nodeList, const char *tagName);
 

--- a/Logger/logger.hpp
+++ b/Logger/logger.hpp
@@ -11,8 +11,8 @@ enum t_log_level {
     LOG_LEVEL_NONE
 };
 
-// Sink management. A sink receives a formatted message and an opaque
-// user pointer. Multiple sinks may be registered at once.
+
+
 typedef void (*t_log_sink)(const char *message, void *user_data);
 int     ft_log_add_sink(t_log_sink sink, void *user_data);
 void    ft_log_remove_sink(t_log_sink sink, void *user_data);

--- a/Logger/logger_log_state.cpp
+++ b/Logger/logger_log_state.cpp
@@ -1,6 +1,6 @@
 #include "logger_internal.hpp"
 
-// Global logger state
+
 
 t_log_level g_level = LOG_LEVEL_DEBUG;
 ft_vector<s_log_sink> g_sinks;

--- a/Networking/Makefile
+++ b/Networking/Makefile
@@ -7,7 +7,8 @@ SRCS := networking_socket_class.cpp \
         networking_setup_client.cpp \
         networking_socket_wrapper_functions.cpp \
         networking_ssl_wrapper.cpp \
-        networking_nonblocking.cpp
+        networking_nonblocking.cpp \
+        http_client.cpp
 
 ifeq ($(OS),Windows_NT)
     SRCS += networking_select.cpp
@@ -31,6 +32,7 @@ endif
 HEADERS := socket_class.hpp \
            networking.hpp \
            ssl_wrapper.hpp \
+           http_client.hpp \
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Networking/http_client.cpp
+++ b/Networking/http_client.cpp
@@ -1,0 +1,205 @@
+#include "http_client.hpp"
+#include "socket_class.hpp"
+#include "ssl_wrapper.hpp"
+#include <cstring>
+#include <cstdio>
+#ifdef _WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
+#else
+# include <netdb.h>
+# include <arpa/inet.h>
+# include <unistd.h>
+#endif
+
+int http_get(const char *host, const char *path, ft_string &response, bool use_ssl)
+{
+    struct addrinfo address_hints;
+    struct addrinfo *address_info;
+    const char *port_string;
+    int socket_fd;
+    ft_string request;
+    char buffer[1024];
+    ssize_t bytes_received;
+    SSL_CTX *ssl_context;
+    SSL *ssl_connection;
+    int result;
+
+    response.clear();
+    std::memset(&address_hints, 0, sizeof(address_hints));
+    address_hints.ai_family = AF_UNSPEC;
+    address_hints.ai_socktype = SOCK_STREAM;
+    if (use_ssl)
+        port_string = "443";
+    else
+        port_string = "80";
+    if (getaddrinfo(host, port_string, &address_hints, &address_info) != 0)
+        return (-1);
+    socket_fd = nw_socket(address_info->ai_family, address_info->ai_socktype, address_info->ai_protocol);
+    if (socket_fd < 0)
+    {
+        freeaddrinfo(address_info);
+        return (-1);
+    }
+    result = nw_connect(socket_fd, address_info->ai_addr, address_info->ai_addrlen);
+    freeaddrinfo(address_info);
+    if (result < 0)
+    {
+        FT_CLOSE_SOCKET(socket_fd);
+        return (-1);
+    }
+    request.append("GET ");
+    request.append(path);
+    request.append(" HTTP/1.1\r\nHost: ");
+    request.append(host);
+    request.append("\r\nConnection: close\r\n\r\n");
+    if (use_ssl)
+    {
+        SSL_library_init();
+        ssl_context = SSL_CTX_new(SSLv23_client_method());
+        if (ssl_context == NULL)
+        {
+            FT_CLOSE_SOCKET(socket_fd);
+            return (-1);
+        }
+        ssl_connection = SSL_new(ssl_context);
+        if (ssl_connection == NULL)
+        {
+            SSL_CTX_free(ssl_context);
+            FT_CLOSE_SOCKET(socket_fd);
+            return (-1);
+        }
+        SSL_set_fd(ssl_connection, socket_fd);
+        result = SSL_connect(ssl_connection);
+        if (result != 1)
+        {
+            SSL_free(ssl_connection);
+            SSL_CTX_free(ssl_context);
+            FT_CLOSE_SOCKET(socket_fd);
+            return (-1);
+        }
+        nw_ssl_write(ssl_connection, request.c_str(), request.size());
+        bytes_received = nw_ssl_read(ssl_connection, buffer, sizeof(buffer) - 1);
+        while (bytes_received > 0)
+        {
+            buffer[bytes_received] = '\0';
+            response.append(buffer);
+            bytes_received = nw_ssl_read(ssl_connection, buffer, sizeof(buffer) - 1);
+        }
+        SSL_shutdown(ssl_connection);
+        SSL_free(ssl_connection);
+        SSL_CTX_free(ssl_context);
+    }
+    else
+    {
+        nw_send(socket_fd, request.c_str(), request.size(), 0);
+        bytes_received = nw_recv(socket_fd, buffer, sizeof(buffer) - 1, 0);
+        while (bytes_received > 0)
+        {
+            buffer[bytes_received] = '\0';
+            response.append(buffer);
+            bytes_received = nw_recv(socket_fd, buffer, sizeof(buffer) - 1, 0);
+        }
+    }
+    FT_CLOSE_SOCKET(socket_fd);
+    return (0);
+}
+
+int http_post(const char *host, const char *path, const ft_string &body, ft_string &response, bool use_ssl)
+{
+    struct addrinfo address_hints;
+    struct addrinfo *address_info;
+    const char *port_string;
+    int socket_fd;
+    ft_string request;
+    char buffer[1024];
+    char length_string[32];
+    ssize_t bytes_received;
+    SSL_CTX *ssl_context;
+    SSL *ssl_connection;
+    int result;
+
+    response.clear();
+    std::memset(&address_hints, 0, sizeof(address_hints));
+    address_hints.ai_family = AF_UNSPEC;
+    address_hints.ai_socktype = SOCK_STREAM;
+    if (use_ssl)
+        port_string = "443";
+    else
+        port_string = "80";
+    if (getaddrinfo(host, port_string, &address_hints, &address_info) != 0)
+        return (-1);
+    socket_fd = nw_socket(address_info->ai_family, address_info->ai_socktype, address_info->ai_protocol);
+    if (socket_fd < 0)
+    {
+        freeaddrinfo(address_info);
+        return (-1);
+    }
+    result = nw_connect(socket_fd, address_info->ai_addr, address_info->ai_addrlen);
+    freeaddrinfo(address_info);
+    if (result < 0)
+    {
+        FT_CLOSE_SOCKET(socket_fd);
+        return (-1);
+    }
+    std::snprintf(length_string, sizeof(length_string), "%zu", body.size());
+    request.append("POST ");
+    request.append(path);
+    request.append(" HTTP/1.1\r\nHost: ");
+    request.append(host);
+    request.append("\r\nContent-Length: ");
+    request.append(length_string);
+    request.append("\r\nConnection: close\r\n\r\n");
+    request.append(body);
+    if (use_ssl)
+    {
+        SSL_library_init();
+        ssl_context = SSL_CTX_new(SSLv23_client_method());
+        if (ssl_context == NULL)
+        {
+            FT_CLOSE_SOCKET(socket_fd);
+            return (-1);
+        }
+        ssl_connection = SSL_new(ssl_context);
+        if (ssl_connection == NULL)
+        {
+            SSL_CTX_free(ssl_context);
+            FT_CLOSE_SOCKET(socket_fd);
+            return (-1);
+        }
+        SSL_set_fd(ssl_connection, socket_fd);
+        result = SSL_connect(ssl_connection);
+        if (result != 1)
+        {
+            SSL_free(ssl_connection);
+            SSL_CTX_free(ssl_context);
+            FT_CLOSE_SOCKET(socket_fd);
+            return (-1);
+        }
+        nw_ssl_write(ssl_connection, request.c_str(), request.size());
+        bytes_received = nw_ssl_read(ssl_connection, buffer, sizeof(buffer) - 1);
+        while (bytes_received > 0)
+        {
+            buffer[bytes_received] = '\0';
+            response.append(buffer);
+            bytes_received = nw_ssl_read(ssl_connection, buffer, sizeof(buffer) - 1);
+        }
+        SSL_shutdown(ssl_connection);
+        SSL_free(ssl_connection);
+        SSL_CTX_free(ssl_context);
+    }
+    else
+    {
+        nw_send(socket_fd, request.c_str(), request.size(), 0);
+        bytes_received = nw_recv(socket_fd, buffer, sizeof(buffer) - 1, 0);
+        while (bytes_received > 0)
+        {
+            buffer[bytes_received] = '\0';
+            response.append(buffer);
+            bytes_received = nw_recv(socket_fd, buffer, sizeof(buffer) - 1, 0);
+        }
+    }
+    FT_CLOSE_SOCKET(socket_fd);
+    return (0);
+}
+

--- a/Networking/http_client.hpp
+++ b/Networking/http_client.hpp
@@ -1,0 +1,9 @@
+#ifndef HTTP_CLIENT_HPP
+#define HTTP_CLIENT_HPP
+
+#include "../CPP_class/class_string_class.hpp"
+
+int http_get(const char *host, const char *path, ft_string &response, bool use_ssl = false);
+int http_post(const char *host, const char *path, const ft_string &body, ft_string &response, bool use_ssl = false);
+
+#endif

--- a/Printf/printf.hpp
+++ b/Printf/printf.hpp
@@ -5,7 +5,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-// wrappers support %c %s %d %i %u %x %X %o %p %b and %f with precision
+
 int pf_printf(const char *format, ...) __attribute__((format(printf, 1, 2), hot));
 int pf_printf_fd(int fd, const char *format, ...) __attribute__((format(printf, 2, 3), hot));
 int pf_snprintf(char *string, size_t size, const char *format, ...) __attribute__((format(printf, 3, 4), hot));

--- a/Printf/printf_ft_fprintf.cpp
+++ b/Printf/printf_ft_fprintf.cpp
@@ -1,4 +1,4 @@
-// Custom implementation of vfprintf-style formatting for FILE streams
+
 #include "printf.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../Libft/libft.hpp"

--- a/Printf/printf_internal.hpp
+++ b/Printf/printf_internal.hpp
@@ -28,7 +28,7 @@ void ft_puthex_fd(uintmax_t number, int fd, bool uppercase, size_t *count);
 void ft_putoctal_fd_recursive(uintmax_t number, int fd, size_t *count);
 void ft_putoctal_fd(uintmax_t number, int fd, size_t *count);
 void ft_putptr_fd(void *pointer, int fd, size_t *count);
-// writes floating point number with the given precision
+
 void ft_putfloat_fd(double number, int fd, size_t *count, int precision);
 void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count);
 void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count);

--- a/README.md
+++ b/README.md
@@ -564,6 +564,36 @@ const struct sockaddr_storage &get_address() const;
 int         join_multicast_group(const SocketConfig &config);
 ```
 
+#### HTTP client
+
+`Networking/http_client.hpp` adds helpers for basic HTTP requests built on the socket layer.
+
+```c++
+#include "Networking/http_client.hpp"
+
+int main()
+{
+    ft_string response;
+
+    http_get("example.com", "/", response, true);
+    return (0);
+}
+```
+
+```c++
+#include "Networking/http_client.hpp"
+
+int main()
+{
+    ft_string body;
+    ft_string response;
+
+    body.append("name=libft");
+    http_post("example.com", "/submit", body, response, false);
+    return (0);
+}
+```
+
 ### Logger
 
 `Logger/logger.hpp` provides leveled logging with timestamps, formatted output

--- a/ReadLine/readline_internal.hpp
+++ b/ReadLine/readline_internal.hpp
@@ -42,24 +42,24 @@ typedef struct {
     ft_file    error_file;
 } readline_state_t;
 
-//Initialize memory
+
 int        rl_initialize_state(readline_state_t *state);
 
-//Raw mode functions
+
 void    rl_disable_raw_mode();
 int        rl_enable_raw_mode();
 
-//Buffer Management Functions
+
 int        rl_clear_line(const char *prompt, const char *buffer);
 char    *rl_resize_buffer(char *old_buffer, int current_size, int new_size);
 
-//Input Handling Functions
+
 int        rl_handle_escape_sequence(readline_state_t *state, const char *prompt);
 int        rl_handle_backspace(readline_state_t *state, const char *prompt);
 int        rl_handle_tab_completion(readline_state_t *state, const char *prompt);
 int        rl_handle_printable_char(readline_state_t *state, char c, const char *prompt);
 
-//Utilities
+
 char    rl_read_key();
 int        rl_get_terminal_width(void);
 int        rl_read_escape_sequence(char seq[2]);

--- a/Template/algorithm.hpp
+++ b/Template/algorithm.hpp
@@ -5,8 +5,8 @@
 #include "swap.hpp"
 #include "../RNG/rng.hpp"
 
-// Simple sort using comparator
-// Defaults to ascending order using operator<
+
+
 template <typename RandomIt, typename Compare>
 void ft_sort(RandomIt first, RandomIt last, Compare comp)
 {
@@ -32,8 +32,8 @@ void ft_sort(RandomIt first, RandomIt last)
     return ;
 }
 
-// Binary search in sorted range
-// Returns true if value is found
+
+
 template <typename RandomIt, typename T, typename Compare>
 bool ft_binary_search(RandomIt first, RandomIt last, const T& value, Compare comp)
 {
@@ -57,7 +57,7 @@ bool ft_binary_search(RandomIt first, RandomIt last, const T& value)
           [](const auto& a, const auto& b){ return (a < b); }));
 }
 
-// Fisher-Yates shuffle
+
 template <typename RandomIt>
 void ft_shuffle(RandomIt first, RandomIt last)
 {
@@ -74,7 +74,7 @@ void ft_shuffle(RandomIt first, RandomIt last)
     return ;
 }
 
-// Reverse elements in range
+
 template <typename BidirectionalIt>
 void ft_reverse(BidirectionalIt first, BidirectionalIt last)
 {
@@ -86,4 +86,4 @@ void ft_reverse(BidirectionalIt first, BidirectionalIt last)
     return ;
 }
 
-#endif // FT_ALGORITHM_HPP
+#endif 

--- a/Template/bitset.hpp
+++ b/Template/bitset.hpp
@@ -10,11 +10,7 @@
 #include <cstddef>
 #include <climits>
 
-/*
- * ft_bitset
- * Fixed-size sequence of bits with basic operations and thread-safe
- * error reporting. Size is determined at construction and cannot change.
- */
+
 class ft_bitset
 {
     private:

--- a/Template/event_emitter.hpp
+++ b/Template/event_emitter.hpp
@@ -11,11 +11,7 @@
 #include <utility>
 #include "move.hpp"
 
-/*
- * ft_event_emitter
- * Observer pattern utility allowing registration of callbacks
- * for specific events and emitting those events with arguments.
- */
+
 
 template <typename EventType, typename... Args>
 class ft_event_emitter

--- a/Template/future.hpp
+++ b/Template/future.hpp
@@ -7,8 +7,8 @@
 #include "../PThread/pthread.hpp"
 #include <chrono>
 
-// ft_future: waits on an associated ft_promise and retrieves its value
-// Provides get, wait, and validity checks with error reporting
+
+
 
 template <typename ValueType>
 class ft_future

--- a/Template/graph.hpp
+++ b/Template/graph.hpp
@@ -13,10 +13,7 @@
 #include <utility>
 #include "move.hpp"
 
-/*
- * ft_graph
- * Graph data structure using adjacency lists with BFS and DFS traversal.
- */
+
 
 template <typename VertexType>
 class ft_graph

--- a/Template/matrix.hpp
+++ b/Template/matrix.hpp
@@ -9,10 +9,7 @@
 #include "../PThread/mutex.hpp"
 #include <cstddef>
 
-/*
- * ft_matrix
- * Basic matrix operations with thread-safe error reporting.
- */
+
 
 template <typename ElementType>
 class ft_matrix
@@ -52,7 +49,7 @@ class ft_matrix
         void clear();
 };
 
-// Implementation
+
 
 template <typename ElementType>
 ft_matrix<ElementType>::ft_matrix(size_t rows, size_t cols)
@@ -322,7 +319,7 @@ ElementType ft_matrix<ElementType>::determinant() const
         ++index;
     }
     ElementType result = ElementType();
-    result = result + 1; // initialize to 1
+    result = result + 1; 
     size_t pivot_row = 0;
     while (pivot_row < n)
     {
@@ -406,4 +403,4 @@ void ft_matrix<ElementType>::set_error(int error) const
     return ;
 }
 
-#endif // FT_MATRIX_HPP
+#endif 

--- a/Template/optional.hpp
+++ b/Template/optional.hpp
@@ -12,10 +12,7 @@
 #include <type_traits>
 #include <new>
 
-/*
- * ft_optional
- * Represents an optional value with thread-safe access and error reporting.
- */
+
 
 template <typename T>
 class ft_optional
@@ -229,4 +226,4 @@ const char* ft_optional<T>::get_error_str() const
     return (ft_strerror(error));
 }
 
-#endif // FT_OPTIONAL_HPP
+#endif 

--- a/Template/priority_queue.hpp
+++ b/Template/priority_queue.hpp
@@ -13,12 +13,7 @@
 #include "move.hpp"
 #include <functional>
 
-/*
- * ft_priority_queue
- * A thread-safe priority queue implemented as a binary heap.
- * Provides push, pop, top, size, empty, and clear operations
- * with error reporting.
- */
+
 
 template <typename ElementType, typename Compare = std::less<ElementType> >
 class ft_priority_queue
@@ -62,7 +57,7 @@ class ft_priority_queue
         void clear();
 };
 
-// Implementation
+
 
 template <typename ElementType, typename Compare>
 ft_priority_queue<ElementType, Compare>::ft_priority_queue(size_t initialCapacity, const Compare& comp)

--- a/Template/set.hpp
+++ b/Template/set.hpp
@@ -11,11 +11,7 @@
 #include <utility>
 #include "move.hpp"
 
-/*
- * ft_set
- * Sorted collection of unique values. Provides basic insertion,
- * lookup and removal with thread-safe error reporting.
- */
+
 
 template <typename ElementType>
 class ft_set
@@ -29,8 +25,8 @@ class ft_set
 
         void    set_error(int error) const;
         bool    ensure_capacity(size_t desired_capacity);
-        size_t  find_index(const ElementType& value) const; // caller must hold lock
-        size_t  lower_bound(const ElementType& value) const; // caller must hold lock
+        size_t  find_index(const ElementType& value) const; 
+        size_t  lower_bound(const ElementType& value) const; 
 
     public:
         ft_set(size_t initial_capacity = 0);

--- a/Template/thread_pool.hpp
+++ b/Template/thread_pool.hpp
@@ -270,4 +270,4 @@ inline const char* ft_thread_pool::get_error_str() const
       return (ft_strerror(this->_error_code.load(std::memory_order_relaxed)));
 }
 
-#endif // FT_THREAD_POOL_HPP
+#endif 

--- a/Template/tuple.hpp
+++ b/Template/tuple.hpp
@@ -12,10 +12,7 @@
 #include <new>
 #include <type_traits>
 
-/*
- * ft_tuple
- * Fixed-size heterogeneous collection with thread-safe access helpers.
- */
+
 
 template <typename... Types>
 class ft_tuple
@@ -59,7 +56,7 @@ class ft_tuple
         const char* get_error_str() const;
 };
 
-/* Constructors & Destructor */
+
 
 template <typename... Types>
 ft_tuple<Types...>::ft_tuple()
@@ -107,7 +104,7 @@ ft_tuple<Types...>& ft_tuple<Types...>::operator=(ft_tuple&& other) noexcept
     return (*this);
 }
 
-/* set_error */
+
 
 template <typename... Types>
 void ft_tuple<Types...>::set_error(int error) const
@@ -117,7 +114,7 @@ void ft_tuple<Types...>::set_error(int error) const
     return ;
 }
 
-/* construction */
+
 
 template <typename... Types>
 template <typename... Args>
@@ -132,7 +129,7 @@ ft_tuple<Types...>::ft_tuple(Args&&... args)
     return ;
 }
 
-/* get by index */
+
 
 template <typename... Types>
 template <std::size_t I>
@@ -192,7 +189,7 @@ ft_tuple<Types...>::get() const
     return (ref);
 }
 
-/* get by type */
+
 
 template <typename... Types>
 template <typename T>
@@ -248,7 +245,7 @@ const T& ft_tuple<Types...>::get() const
     return (ref);
 }
 
-/* reset */
+
 
 template <typename... Types>
 void ft_tuple<Types...>::reset()
@@ -268,7 +265,7 @@ void ft_tuple<Types...>::reset()
     return ;
 }
 
-/* error accessors */
+
 
 template <typename... Types>
 int ft_tuple<Types...>::get_error() const
@@ -290,4 +287,4 @@ const char* ft_tuple<Types...>::get_error_str() const
     return (ft_strerror(err));
 }
 
-#endif // FT_TUPLE_HPP
+#endif 

--- a/Template/variant.hpp
+++ b/Template/variant.hpp
@@ -14,9 +14,7 @@
 #include <new>
 #include <tuple>
 
-/*
- * Helper to get the index of a type within a parameter pack.
- */
+
 
 template <typename T, typename... Ts>
 struct variant_index;
@@ -28,9 +26,7 @@ template <typename T, typename U, typename... Ts>
 struct variant_index<T, U, Ts...>
     : std::integral_constant<size_t, 1 + variant_index<T, Ts...>::value> {};
 
-/*
- * Helper to destroy the active type based on index.
- */
+
 
 template <size_t I, typename... Ts>
 struct variant_destroyer;
@@ -53,9 +49,7 @@ struct variant_destroyer<I, T, Ts...>
     }
 };
 
-/*
- * Helper to apply a visitor based on index.
- */
+
 
 template <size_t I, typename... Ts>
 struct variant_visitor;
@@ -80,10 +74,7 @@ struct variant_visitor<I, T, Ts...>
     }
 };
 
-/*
- * ft_variant
- * Type-safe union supporting multiple types with thread-safe access.
- */
+
 
 template <typename... Types>
 class ft_variant
@@ -365,4 +356,4 @@ const char* ft_variant<Types...>::get_error_str() const
     return (ft_strerror(err));
 }
 
-#endif // FT_VARIANT_HPP
+#endif 

--- a/XML/xml.hpp
+++ b/XML/xml.hpp
@@ -17,15 +17,7 @@ struct xml_node
     ~xml_node() noexcept;
 };
 
-/*
-Example usage:
-xml_document doc;
-doc.load_from_string("<root><child>value</child></root>");
-xml_node *root = doc.get_root();
-char *output = doc.write_to_string();
-if (output)
-    cma_free(output);
-*/
+
 
 class xml_document
 {


### PR DESCRIPTION
## Summary
- add `http_get` and `http_post` helpers atop existing socket wrappers
- support optional SSL for HTTPS requests
- document HTTP client usage and register new files in build system
- remove all comments from C++ headers and sources for consistency

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c4528d5f8c833198db8de3c1e0d62d