### PR TITLE
Add path join and normalize helpers

### DIFF
--- a/File/Makefile
+++ b/File/Makefile
@@ -7,7 +7,9 @@ SRCS := file_opendir.cpp \
         file_copy.cpp \
         file_move.cpp \
         file_exists.cpp \
-        file_delete.cpp
+        file_delete.cpp \
+        file_path_join.cpp \
+        file_path_normalize.cpp
 
 HEADERS := open_dir.hpp \
            file_utils.hpp

--- a/File/file_path_join.cpp
+++ b/File/file_path_join.cpp
@@ -1,0 +1,41 @@
+#include "../CPP_class/class_string_class.hpp"
+#include "file_utils.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+# define PATH_SEP '\\'
+#else
+# define PATH_SEP '/'
+#endif
+
+ft_string file_path_join(const char *path_left, const char *path_right)
+{
+    ft_string left = file_path_normalize(path_left);
+    if (left.get_error())
+        return (left);
+    ft_string right = file_path_normalize(path_right);
+    if (right.get_error())
+        return (right);
+    ft_string result(left);
+    if (result.get_error())
+        return (result);
+    if (result.size() != 0)
+    {
+        const char *data = result.c_str();
+        if (data[result.size() - 1] != PATH_SEP)
+            result.append(PATH_SEP);
+    }
+    const char *right_data = right.c_str();
+    size_t index = 0;
+    while (right_data[index] == PATH_SEP)
+    {
+        ++index;
+    }
+    while (right_data[index] != '\0')
+    {
+        result.append(right_data[index]);
+        ++index;
+    }
+    if (result.get_error())
+        return (result);
+    return (result);
+}

--- a/File/file_path_normalize.cpp
+++ b/File/file_path_normalize.cpp
@@ -1,0 +1,51 @@
+#include "../CPP_class/class_string_class.hpp"
+#include "file_utils.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+# define PATH_SEP '\\'
+#else
+# define PATH_SEP '/'
+#endif
+
+ft_string file_path_normalize(const char *path)
+{
+    ft_string original(path);
+    if (original.get_error())
+        return (original);
+    char *data = original.print();
+    size_t index = 0;
+    while (data[index] != '\0')
+    {
+#if defined(_WIN32) || defined(_WIN64)
+        if (data[index] == '/')
+            data[index] = '\\';
+#else
+        if (data[index] == '\\')
+            data[index] = '/';
+#endif
+        ++index;
+    }
+    ft_string result;
+    if (result.get_error())
+        return (result);
+    index = 0;
+    while (data[index] != '\0')
+    {
+        if (data[index] == PATH_SEP)
+        {
+            result.append(PATH_SEP);
+            while (data[index] == PATH_SEP)
+            {
+                ++index;
+            }
+        }
+        else
+        {
+            result.append(data[index]);
+            ++index;
+        }
+    }
+    if (result.get_error())
+        return (result);
+    return (result);
+}

--- a/File/file_utils.hpp
+++ b/File/file_utils.hpp
@@ -1,9 +1,13 @@
 #ifndef FILE_FILE_UTILS_HPP
 # define FILE_FILE_UTILS_HPP
 
-int file_copy(const char *source_path, const char *destination_path);
-int file_move(const char *source_path, const char *destination_path);
-int file_exists(const char *path);
-int file_delete(const char *path);
+#include "../CPP_class/class_string_class.hpp"
+
+int       file_copy(const char *source_path, const char *destination_path);
+int       file_move(const char *source_path, const char *destination_path);
+int       file_exists(const char *path);
+int       file_delete(const char *path);
+ft_string file_path_join(const char *path_left, const char *path_right);
+ft_string file_path_normalize(const char *path);
 
 #endif

--- a/README.md
+++ b/README.md
@@ -1016,9 +1016,20 @@ int         file_copy(const char *source_path, const char *destination_path);
 int         file_move(const char *source_path, const char *destination_path);
 int         file_exists(const char *path);
 int         file_delete(const char *path);
+ft_string   file_path_join(const char *path_left, const char *path_right);
+ft_string   file_path_normalize(const char *path);
 ```
 
 The `file_copy` and `file_move` helpers return (-1) on failure to allow error handling. `file_copy` uses `CopyFile` on Windows and `std::filesystem::copy_file` on POSIX systems. `file_move` wraps `MoveFile` or `rename` to provide portable file operations. `file_exists` returns (1) if the file exists and (0) otherwise. `file_delete` wraps `remove` or `unlink` to delete a file and returns (-1) on failure.
+
+`file_path_join` combines two path fragments using the platform's separator, removing redundant separators. `file_path_normalize` converts mixed separators to the current platform and collapses duplicates:
+
+```
+ft_string joined = file_path_join("dir", "file.txt");
+ft_string normalized = file_path_normalize("dir//sub\\file.txt");
+```
+
+On POSIX systems these evaluate to `dir/file.txt` and `dir/sub/file.txt` respectively.
 
 `System_utils/system_utils.hpp` provides cross-platform file descriptor utilities:
 


### PR DESCRIPTION
## Summary
- add file_path_join and file_path_normalize utilities for portable path handling
- compile helpers by updating File module Makefile
- document path helpers in README with examples

## Testing
- `make -C File`


------
https://chatgpt.com/codex/tasks/task_e_68c47d8f64e083319916dd21469faa24