### PR TITLE
Add templated string_view utility and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ components include:
   `ft_priority_queue`, `ft_set`, `ft_map`, `ft_unordened_map`,
   `ft_trie`, `ft_circular_buffer`, `ft_graph` and `ft_matrix`.
  - Utility types: `ft_pair`, `ft_tuple`, `ft_optional`, `ft_variant`,
-   `ft_bitset` and `ft_function`.
+   `ft_bitset`, `ft_function` and `ft_string_view`.
 - Smart pointers: `ft_shared_ptr` and `ft_unique_ptr`.
 - Concurrency helpers: `ft_thread_pool`, `ft_future`, `ft_event_emitter` and
   `ft_promise`.

--- a/Template/Makefile
+++ b/Template/Makefile
@@ -1,0 +1,6 @@
+HEADERS := algorithm.hpp bitset.hpp circular_buffer.hpp constructor.hpp deque.hpp event_emitter.hpp function.hpp future.hpp graph.hpp iterator.hpp map.hpp math.hpp matrix.hpp move.hpp optional.hpp pair.hpp pool.hpp priority_queue.hpp promise.hpp queue.hpp set.hpp shared_ptr.hpp stack.hpp static_cast.hpp string_view.hpp swap.hpp thread_pool.hpp trie.hpp tuple.hpp unique_ptr.hpp unordened_map.hpp variant.hpp vector.hpp
+
+all:
+	@echo "Template headers"
+
+.PHONY: all

--- a/Template/string_view.hpp
+++ b/Template/string_view.hpp
@@ -1,0 +1,184 @@
+#ifndef FT_STRING_VIEW_HPP
+#define FT_STRING_VIEW_HPP
+
+#include <cstddef>
+#include "../Errno/errno.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+
+template <typename CharType>
+class ft_string_view
+{
+    private:
+        const CharType* _data;
+        size_t          _size;
+        mutable int     _error_code;
+
+        void set_error(int error) const;
+
+    public:
+        static const size_t npos;
+
+        ft_string_view();
+        ft_string_view(const CharType* string);
+        ft_string_view(const CharType* string, size_t size);
+        ft_string_view(const ft_string_view& other);
+        ft_string_view& operator=(const ft_string_view& other);
+        ~ft_string_view();
+
+        const CharType* data() const;
+        size_t size() const;
+        bool empty() const;
+        CharType operator[](size_t index) const;
+
+        int compare(const ft_string_view& other) const;
+        ft_string_view substr(size_t position, size_t count = npos) const;
+
+        int get_error() const;
+        const char* get_error_str() const;
+};
+
+template <typename CharType>
+const size_t ft_string_view<CharType>::npos = static_cast<size_t>(-1);
+
+template <typename CharType>
+ft_string_view<CharType>::ft_string_view()
+    : _data(ft_nullptr), _size(0), _error_code(ER_SUCCESS)
+{
+    return ;
+}
+
+template <typename CharType>
+ft_string_view<CharType>::ft_string_view(const CharType* string)
+    : _data(string), _size(0), _error_code(ER_SUCCESS)
+{
+    if (string == ft_nullptr)
+        return ;
+    size_t index;
+    index = 0;
+    while (string[index] != CharType())
+    {
+        index++;
+    }
+    _size = index;
+    return ;
+}
+
+template <typename CharType>
+ft_string_view<CharType>::ft_string_view(const CharType* string, size_t size)
+    : _data(string), _size(size), _error_code(ER_SUCCESS)
+{
+    return ;
+}
+
+template <typename CharType>
+ft_string_view<CharType>::ft_string_view(const ft_string_view& other)
+    : _data(other._data), _size(other._size), _error_code(other._error_code)
+{
+    return ;
+}
+
+template <typename CharType>
+ft_string_view<CharType>& ft_string_view<CharType>::operator=(const ft_string_view& other)
+{
+    if (this != &other)
+    {
+        this->_data = other._data;
+        this->_size = other._size;
+        this->_error_code = other._error_code;
+    }
+    return (*this);
+}
+
+template <typename CharType>
+ft_string_view<CharType>::~ft_string_view()
+{
+    return ;
+}
+
+template <typename CharType>
+const CharType* ft_string_view<CharType>::data() const
+{
+    return (this->_data);
+}
+
+template <typename CharType>
+size_t ft_string_view<CharType>::size() const
+{
+    return (this->_size);
+}
+
+template <typename CharType>
+bool ft_string_view<CharType>::empty() const
+{
+    return (this->_size == 0);
+}
+
+template <typename CharType>
+CharType ft_string_view<CharType>::operator[](size_t index) const
+{
+    if (index >= this->_size)
+        return (CharType());
+    return (this->_data[index]);
+}
+
+template <typename CharType>
+int ft_string_view<CharType>::compare(const ft_string_view& other) const
+{
+    size_t index;
+    index = 0;
+    while (index < this->_size && index < other._size)
+    {
+        if (this->_data[index] != other._data[index])
+        {
+            if (this->_data[index] < other._data[index])
+                return (-1);
+            return (1);
+        }
+        index++;
+    }
+    if (this->_size == other._size)
+        return (0);
+    if (this->_size < other._size)
+        return (-1);
+    return (1);
+}
+
+template <typename CharType>
+ft_string_view<CharType> ft_string_view<CharType>::substr(size_t position, size_t count) const
+{
+    if (position > this->_size)
+    {
+        ft_string_view<CharType> result;
+        const_cast<ft_string_view<CharType>*>(this)->set_error(FT_EINVAL);
+        result.set_error(FT_EINVAL);
+        return (result);
+    }
+    size_t available;
+    available = this->_size - position;
+    if (count == npos || count > available)
+        count = available;
+    return (ft_string_view<CharType>(this->_data + position, count));
+}
+
+template <typename CharType>
+void ft_string_view<CharType>::set_error(int error) const
+{
+    this->_error_code = error;
+    ft_errno = error;
+    return ;
+}
+
+template <typename CharType>
+int ft_string_view<CharType>::get_error() const
+{
+    return (this->_error_code);
+}
+
+template <typename CharType>
+const char* ft_string_view<CharType>::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}
+
+#endif

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -6,7 +6,7 @@ EFF_SRCS :=
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp \
        test_strlen.cpp test_promise.cpp test_networking.cpp test_linear_algebra.cpp test_validate_int.cpp \
        test_task_scheduler.cpp test_json_validate.cpp test_rng.cpp test_http_server.cpp test_logger.cpp test_yaml.cpp \
-       test_quaternion.cpp
+       test_quaternion.cpp test_string_view.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir

--- a/Test/test_string_view.cpp
+++ b/Test/test_string_view.cpp
@@ -1,0 +1,32 @@
+#include "../Template/string_view.hpp"
+#include "../Errno/errno.hpp"
+#include "../System_utils/test_runner.hpp"
+
+FT_TEST(test_string_view_basic, "ft_string_view basic")
+{
+    ft_string_view<char> view("hello");
+    FT_ASSERT_EQ(5u, view.size());
+    FT_ASSERT_EQ('h', view.data()[0]);
+    return (1);
+}
+
+FT_TEST(test_string_view_compare_substr, "ft_string_view compare and substr")
+{
+    ft_string_view<char> view("hello");
+    ft_string_view<char> other_view("hello");
+    FT_ASSERT_EQ(0, view.compare(other_view));
+    ft_string_view<char> substring = view.substr(1, 3);
+    ft_string_view<char> expected_view("ell");
+    FT_ASSERT_EQ(0, substring.compare(expected_view));
+    return (1);
+}
+
+FT_TEST(test_string_view_substr_oob, "ft_string_view substr out of bounds")
+{
+    ft_string_view<char> view("world");
+    ft_string_view<char> substring = view.substr(10, 2);
+    FT_ASSERT_EQ(FT_EINVAL, view.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, substring.get_error());
+    FT_ASSERT_EQ(0u, substring.size());
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add header-only `ft_string_view` with basic accessors, compare, substr, and error tracking
- document string view in Template README and include in Template makefile
- cover string view with new unit tests

## Testing
- `make -C Template`
- `make -C Test OPT_LEVEL=0`
- `./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c48af687788331bc755f203c589667