### PR TITLE
Add minimal WebSocket client and server

### DIFF
--- a/Networking/Makefile
+++ b/Networking/Makefile
@@ -9,7 +9,9 @@ SRCS := networking_socket_class.cpp \
         networking_ssl_wrapper.cpp \
         networking_nonblocking.cpp \
         http_client.cpp \
-        http_server.cpp
+        http_server.cpp \
+        websocket_client.cpp \
+        websocket_server.cpp
 
 ifeq ($(OS),Windows_NT)
     SRCS += networking_select.cpp
@@ -35,6 +37,8 @@ HEADERS := socket_class.hpp \
            ssl_wrapper.hpp \
            http_client.hpp \
            http_server.hpp \
+           websocket_client.hpp \
+           websocket_server.hpp \
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Networking/networking.hpp
+++ b/Networking/networking.hpp
@@ -67,4 +67,7 @@ class SocketConfig
         const char *get_error_str();
 };
 
+#include "websocket_client.hpp"
+#include "websocket_server.hpp"
+
 #endif

--- a/Networking/websocket_client.cpp
+++ b/Networking/websocket_client.cpp
@@ -1,0 +1,447 @@
+#include "websocket_client.hpp"
+#include "networking.hpp"
+#include "socket_class.hpp"
+#include "../Compression/compression.hpp"
+#include "../CMA/CMA.hpp"
+#include "../RNG/rng.hpp"
+#include "../Encryption/encryption_sha256.hpp"
+#include "../Libft/libft.hpp"
+#include "../Errno/errno.hpp"
+#include <cstring>
+#include <cstdio>
+#include <cerrno>
+#ifdef _WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
+#else
+# include <netdb.h>
+# include <unistd.h>
+#endif
+
+static void compute_accept_key(const ft_string &key, ft_string &accept)
+{
+    unsigned char digest[32];
+    unsigned char *encoded;
+    std::size_t encoded_size;
+    ft_string magic;
+
+    magic = key;
+    magic.append("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    sha256_hash(magic.c_str(), magic.size(), digest);
+    accept.clear();
+    encoded = ft_base64_encode(digest, 32, &encoded_size);
+    if (encoded)
+    {
+        std::size_t index_value = 0;
+        while (index_value < encoded_size)
+        {
+            accept.append(reinterpret_cast<char *>(encoded)[index_value]);
+            index_value++;
+        }
+        cma_free(encoded);
+    }
+    return ;
+}
+
+ft_websocket_client::ft_websocket_client() : _socket_fd(-1), _error_code(ER_SUCCESS)
+{
+    return ;
+}
+
+ft_websocket_client::~ft_websocket_client()
+{
+    this->close();
+    return ;
+}
+
+void ft_websocket_client::set_error(int error_code) const
+{
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
+}
+
+void ft_websocket_client::close()
+{
+    if (this->_socket_fd >= 0)
+    {
+        #ifdef _WIN32
+        closesocket(this->_socket_fd);
+        #else
+        ::close(this->_socket_fd);
+        #endif
+        this->_socket_fd = -1;
+    }
+    this->_error_code = ER_SUCCESS;
+    return ;
+}
+
+int ft_websocket_client::perform_handshake(const char *host, const char *path)
+{
+    unsigned char random_key[16];
+    std::size_t byte_index;
+    std::size_t shift_index;
+    std::size_t encoded_size;
+    unsigned char *encoded_key;
+    ft_string key_string;
+    ft_string request;
+    char buffer[1024];
+    ssize_t bytes_received;
+    ft_string response;
+    const char *accept_line;
+    const char *line_end;
+    ft_string accept_key;
+    ft_string expected;
+
+    byte_index = 0;
+    while (byte_index < 16)
+    {
+        uint32_t random_value = ft_random_uint32();
+        shift_index = 0;
+        while (shift_index < 4 && byte_index < 16)
+        {
+            random_key[byte_index] = static_cast<unsigned char>(random_value >> (shift_index * 8));
+            byte_index++;
+            shift_index++;
+        }
+    }
+    encoded_key = ft_base64_encode(random_key, 16, &encoded_size);
+    if (!encoded_key)
+    {
+        this->set_error(FT_EINVAL);
+        return (1);
+    }
+    key_string.clear();
+    byte_index = 0;
+    while (byte_index < encoded_size)
+    {
+        key_string.append(reinterpret_cast<char *>(encoded_key)[byte_index]);
+        byte_index++;
+    }
+    cma_free(encoded_key);
+    request.append("GET ");
+    request.append(path);
+    request.append(" HTTP/1.1\r\nHost: ");
+    request.append(host);
+    request.append("\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: ");
+    request.append(key_string);
+    request.append("\r\n\r\n");
+    nw_send(this->_socket_fd, request.c_str(), request.size(), 0);
+    bytes_received = nw_recv(this->_socket_fd, buffer, sizeof(buffer) - 1, 0);
+    if (bytes_received <= 0)
+    {
+        this->set_error(errno + ERRNO_OFFSET);
+        return (1);
+    }
+    buffer[bytes_received] = '\0';
+    response = buffer;
+    accept_line = ft_strstr(response.c_str(), "Sec-WebSocket-Accept: ");
+    if (!accept_line)
+    {
+        this->set_error(FT_EINVAL);
+        return (1);
+    }
+    accept_line += ft_strlen("Sec-WebSocket-Accept: ");
+    line_end = ft_strstr(accept_line, "\r\n");
+    accept_key.clear();
+    if (line_end)
+    {
+        byte_index = 0;
+        while (accept_line + byte_index < line_end)
+        {
+            accept_key.append(accept_line[byte_index]);
+            byte_index++;
+        }
+    }
+    else
+    {
+        std::size_t index_value = 0;
+        while (accept_line[index_value] != '\0')
+        {
+            accept_key.append(accept_line[index_value]);
+            index_value++;
+        }
+    }
+    compute_accept_key(key_string, expected);
+    if (accept_key != expected)
+    {
+        this->set_error(FT_EINVAL);
+        return (1);
+    }
+    this->_error_code = ER_SUCCESS;
+    return (0);
+}
+
+int ft_websocket_client::connect(const char *host, uint16_t port, const char *path)
+{
+    struct addrinfo address_hints;
+    struct addrinfo *address_info;
+    char port_string[8];
+    int result;
+
+    std::memset(&address_hints, 0, sizeof(address_hints));
+    address_hints.ai_family = AF_UNSPEC;
+    address_hints.ai_socktype = SOCK_STREAM;
+    std::snprintf(port_string, sizeof(port_string), "%u", port);
+    if (getaddrinfo(host, port_string, &address_hints, &address_info) != 0)
+    {
+        this->set_error(errno + ERRNO_OFFSET);
+        return (1);
+    }
+    this->_socket_fd = nw_socket(address_info->ai_family, address_info->ai_socktype, address_info->ai_protocol);
+    if (this->_socket_fd < 0)
+    {
+        freeaddrinfo(address_info);
+        this->set_error(errno + ERRNO_OFFSET);
+        return (1);
+    }
+    result = nw_connect(this->_socket_fd, address_info->ai_addr, address_info->ai_addrlen);
+    freeaddrinfo(address_info);
+    if (result < 0)
+    {
+        this->set_error(errno + ERRNO_OFFSET);
+        this->close();
+        return (1);
+    }
+    if (this->perform_handshake(host, path) != 0)
+    {
+        this->close();
+        return (1);
+    }
+    this->_error_code = ER_SUCCESS;
+    return (0);
+}
+
+int ft_websocket_client::send_pong(const unsigned char *payload, std::size_t length)
+{
+    ft_string frame;
+    uint32_t mask_value;
+    unsigned char mask_key[4];
+    std::size_t index_value;
+
+    mask_value = ft_random_uint32();
+    index_value = 0;
+    while (index_value < 4)
+    {
+        mask_key[index_value] = static_cast<unsigned char>(mask_value >> (index_value * 8));
+        index_value++;
+    }
+    frame.append(static_cast<char>(0x8A));
+    if (length <= 125)
+        frame.append(static_cast<char>(0x80 | static_cast<unsigned char>(length)));
+    else if (length <= 65535)
+    {
+        frame.append(static_cast<char>(0x80 | 126));
+        frame.append(static_cast<char>((length >> 8) & 0xFF));
+        frame.append(static_cast<char>(length & 0xFF));
+    }
+    else
+    {
+        frame.append(static_cast<char>(0x80 | 127));
+        index_value = 0;
+        while (index_value < 8)
+        {
+            frame.append(static_cast<char>((length >> ((7 - index_value) * 8)) & 0xFF));
+            index_value++;
+        }
+    }
+    index_value = 0;
+    while (index_value < 4)
+    {
+        frame.append(static_cast<char>(mask_key[index_value]));
+        index_value++;
+    }
+    index_value = 0;
+    while (index_value < length)
+    {
+        char masked_char = static_cast<char>(payload[index_value] ^ mask_key[index_value % 4]);
+        frame.append(masked_char);
+        index_value++;
+    }
+    nw_send(this->_socket_fd, frame.c_str(), frame.size(), 0);
+    return (0);
+}
+
+int ft_websocket_client::send_text(const ft_string &message)
+{
+    ft_string frame;
+    uint32_t mask_value;
+    unsigned char mask_key[4];
+    std::size_t index_value;
+    std::size_t length;
+
+    if (this->_socket_fd < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return (1);
+    }
+    mask_value = ft_random_uint32();
+    index_value = 0;
+    while (index_value < 4)
+    {
+        mask_key[index_value] = static_cast<unsigned char>(mask_value >> (index_value * 8));
+        index_value++;
+    }
+    frame.append(static_cast<char>(0x81));
+    length = message.size();
+    const char *message_data = message.c_str();
+    if (length <= 125)
+        frame.append(static_cast<char>(0x80 | static_cast<unsigned char>(length)));
+    else if (length <= 65535)
+    {
+        frame.append(static_cast<char>(0x80 | 126));
+        frame.append(static_cast<char>((length >> 8) & 0xFF));
+        frame.append(static_cast<char>(length & 0xFF));
+    }
+    else
+    {
+        frame.append(static_cast<char>(0x80 | 127));
+        index_value = 0;
+        while (index_value < 8)
+        {
+            frame.append(static_cast<char>((length >> ((7 - index_value) * 8)) & 0xFF));
+            index_value++;
+        }
+    }
+    index_value = 0;
+    while (index_value < 4)
+    {
+        frame.append(static_cast<char>(mask_key[index_value]));
+        index_value++;
+    }
+    index_value = 0;
+    while (index_value < length)
+    {
+        char masked_char = static_cast<char>(message_data[index_value] ^ mask_key[index_value % 4]);
+        frame.append(masked_char);
+        index_value++;
+    }
+    nw_send(this->_socket_fd, frame.c_str(), frame.size(), 0);
+    this->_error_code = ER_SUCCESS;
+    return (0);
+}
+
+int ft_websocket_client::receive_text(ft_string &message)
+{
+    unsigned char header[2];
+    unsigned char mask_key[4];
+    std::size_t payload_length;
+    ssize_t bytes_received;
+    unsigned char *payload;
+    std::size_t index_value;
+    unsigned char opcode;
+
+    message.clear();
+    if (this->_socket_fd < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return (1);
+    }
+    while (true)
+    {
+        bytes_received = nw_recv(this->_socket_fd, header, 2, 0);
+        if (bytes_received <= 0)
+        {
+            this->set_error(errno + ERRNO_OFFSET);
+            return (1);
+        }
+        opcode = header[0] & 0x0F;
+        payload_length = static_cast<std::size_t>(header[1] & 0x7F);
+        if (payload_length == 126)
+        {
+            unsigned char extended[2];
+            bytes_received = nw_recv(this->_socket_fd, extended, 2, 0);
+            if (bytes_received <= 0)
+            {
+                this->set_error(errno + ERRNO_OFFSET);
+                return (1);
+            }
+            payload_length = static_cast<std::size_t>((extended[0] << 8) | extended[1]);
+        }
+        else if (payload_length == 127)
+        {
+            unsigned char extended[8];
+            std::size_t shift_index;
+            bytes_received = nw_recv(this->_socket_fd, extended, 8, 0);
+            if (bytes_received <= 0)
+            {
+                this->set_error(errno + ERRNO_OFFSET);
+                return (1);
+            }
+            payload_length = 0;
+            shift_index = 0;
+            while (shift_index < 8)
+            {
+                payload_length = (payload_length << 8) | extended[shift_index];
+                shift_index++;
+            }
+        }
+        bytes_received = nw_recv(this->_socket_fd, mask_key, 4, 0);
+        if (bytes_received <= 0)
+        {
+            this->set_error(errno + ERRNO_OFFSET);
+            return (1);
+        }
+        payload = static_cast<unsigned char *>(cma_malloc(payload_length));
+        if (!payload)
+        {
+            this->set_error(FT_EINVAL);
+            return (1);
+        }
+        index_value = 0;
+        while (index_value < payload_length)
+        {
+            bytes_received = nw_recv(this->_socket_fd, payload + index_value, payload_length - index_value, 0);
+            if (bytes_received <= 0)
+            {
+                cma_free(payload);
+                this->set_error(errno + ERRNO_OFFSET);
+                return (1);
+            }
+            index_value += static_cast<std::size_t>(bytes_received);
+        }
+        index_value = 0;
+        while (index_value < payload_length)
+        {
+            payload[index_value] = static_cast<unsigned char>(payload[index_value] ^ mask_key[index_value % 4]);
+            index_value++;
+        }
+        if (opcode == 0x9)
+        {
+            this->send_pong(payload, payload_length);
+            cma_free(payload);
+            continue ;
+        }
+        if (opcode == 0xA)
+        {
+            cma_free(payload);
+            continue ;
+        }
+        if (opcode == 0x1)
+        {
+            message.clear();
+            index_value = 0;
+            while (index_value < payload_length)
+            {
+                message.append(static_cast<char>(payload[index_value]));
+                index_value++;
+            }
+            cma_free(payload);
+            this->_error_code = ER_SUCCESS;
+            return (0);
+        }
+        cma_free(payload);
+        this->set_error(FT_EINVAL);
+        return (1);
+    }
+}
+
+int ft_websocket_client::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char *ft_websocket_client::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}

--- a/Networking/websocket_client.hpp
+++ b/Networking/websocket_client.hpp
@@ -1,0 +1,29 @@
+#ifndef WEBSOCKET_CLIENT_HPP
+#define WEBSOCKET_CLIENT_HPP
+
+#include "../CPP_class/class_string_class.hpp"
+#include <cstdint>
+
+class ft_websocket_client
+{
+    private:
+        int _socket_fd;
+        mutable int _error_code;
+
+        int perform_handshake(const char *host, const char *path);
+        int send_pong(const unsigned char *payload, std::size_t length);
+        void set_error(int error_code) const;
+
+    public:
+        ft_websocket_client();
+        ~ft_websocket_client();
+
+        int connect(const char *host, uint16_t port, const char *path);
+        int send_text(const ft_string &message);
+        int receive_text(ft_string &message);
+        void close();
+        int get_error() const;
+        const char *get_error_str() const;
+};
+
+#endif

--- a/Networking/websocket_server.cpp
+++ b/Networking/websocket_server.cpp
@@ -1,0 +1,328 @@
+#include "websocket_server.hpp"
+#include "networking.hpp"
+#include "socket_class.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Compression/compression.hpp"
+#include "../CMA/CMA.hpp"
+#include "../Encryption/encryption_sha256.hpp"
+#include "../Libft/libft.hpp"
+#include "../Errno/errno.hpp"
+#include <cstring>
+#include <cstdio>
+#include <cerrno>
+
+static void compute_accept_key(const ft_string &key, ft_string &accept)
+{
+    unsigned char digest[32];
+    unsigned char *encoded;
+    std::size_t encoded_size;
+    ft_string magic;
+
+    magic = key;
+    magic.append("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    sha256_hash(magic.c_str(), magic.size(), digest);
+    accept.clear();
+    encoded = ft_base64_encode(digest, 32, &encoded_size);
+    if (encoded)
+    {
+        std::size_t index_value = 0;
+        while (index_value < encoded_size)
+        {
+            accept.append(reinterpret_cast<char *>(encoded)[index_value]);
+            index_value++;
+        }
+        cma_free(encoded);
+    }
+    return ;
+}
+
+ft_websocket_server::ft_websocket_server() : _server_socket(ft_nullptr), _error_code(ER_SUCCESS)
+{
+    return ;
+}
+
+ft_websocket_server::~ft_websocket_server()
+{
+    if (this->_server_socket)
+    {
+        this->_server_socket->close_socket();
+        delete this->_server_socket;
+        this->_server_socket = ft_nullptr;
+    }
+    return ;
+}
+
+void ft_websocket_server::set_error(int error_code) const
+{
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
+}
+
+int ft_websocket_server::start(const char *ip, uint16_t port, int address_family, bool non_blocking)
+{
+    SocketConfig configuration;
+
+    configuration._type = SocketType::SERVER;
+    configuration._ip = ip;
+    configuration._port = port;
+    configuration._address_family = address_family;
+    configuration._non_blocking = non_blocking;
+    configuration._recv_timeout = 5000;
+    configuration._send_timeout = 5000;
+    if (this->_server_socket)
+    {
+        delete this->_server_socket;
+        this->_server_socket = ft_nullptr;
+    }
+    this->_server_socket = new ft_socket(configuration);
+    if (!this->_server_socket || this->_server_socket->get_error() != ER_SUCCESS)
+    {
+        if (this->_server_socket)
+        {
+            this->set_error(this->_server_socket->get_error());
+        }
+        else
+        {
+            this->set_error(FT_EINVAL);
+        }
+        return (1);
+    }
+    this->_error_code = ER_SUCCESS;
+    return (0);
+}
+
+int ft_websocket_server::perform_handshake(int client_fd)
+{
+    char buffer[1024];
+    ssize_t bytes_received;
+    ft_string request;
+    const char *key_line;
+    const char *line_end;
+    ft_string key;
+    ft_string accept;
+    ft_string response;
+
+    bytes_received = nw_recv(client_fd, buffer, sizeof(buffer) - 1, 0);
+    if (bytes_received <= 0)
+    {
+        this->set_error(errno + ERRNO_OFFSET);
+        return (1);
+    }
+    buffer[bytes_received] = '\0';
+    request = buffer;
+    key_line = ft_strstr(request.c_str(), "Sec-WebSocket-Key: ");
+    if (!key_line)
+    {
+        this->set_error(FT_EINVAL);
+        return (1);
+    }
+    key_line += ft_strlen("Sec-WebSocket-Key: ");
+    line_end = ft_strstr(key_line, "\r\n");
+    key.clear();
+    if (line_end)
+    {
+        std::size_t index_value = 0;
+        while (key_line + index_value < line_end)
+        {
+            key.append(key_line[index_value]);
+            index_value++;
+        }
+    }
+    else
+    {
+        std::size_t index_value = 0;
+        while (key_line[index_value] != '\0')
+        {
+            key.append(key_line[index_value]);
+            index_value++;
+        }
+    }
+    compute_accept_key(key, accept);
+    response.append("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ");
+    response.append(accept);
+    response.append("\r\n\r\n");
+    nw_send(client_fd, response.c_str(), response.size(), 0);
+    return (0);
+}
+
+int ft_websocket_server::send_pong(int client_fd, const unsigned char *payload, std::size_t length)
+{
+    ft_string frame;
+    std::size_t index_value;
+
+    frame.append(static_cast<char>(0x8A));
+    if (length <= 125)
+        frame.append(static_cast<char>(static_cast<unsigned char>(length)));
+    else if (length <= 65535)
+    {
+        frame.append(static_cast<char>(126));
+        frame.append(static_cast<char>((length >> 8) & 0xFF));
+        frame.append(static_cast<char>(length & 0xFF));
+    }
+    else
+    {
+        frame.append(static_cast<char>(127));
+        index_value = 0;
+        while (index_value < 8)
+        {
+            frame.append(static_cast<char>((length >> ((7 - index_value) * 8)) & 0xFF));
+            index_value++;
+        }
+    }
+    index_value = 0;
+    while (index_value < length)
+    {
+        frame.append(static_cast<char>(payload[index_value]));
+        index_value++;
+    }
+    nw_send(client_fd, frame.c_str(), frame.size(), 0);
+    return (0);
+}
+
+int ft_websocket_server::receive_frame(int client_fd, ft_string &message)
+{
+    unsigned char header[2];
+    unsigned char mask_key[4];
+    std::size_t payload_length;
+    ssize_t bytes_received;
+    unsigned char *payload;
+    std::size_t index_value;
+    unsigned char opcode;
+
+    message.clear();
+    while (true)
+    {
+        bytes_received = nw_recv(client_fd, header, 2, 0);
+        if (bytes_received <= 0)
+        {
+            this->set_error(errno + ERRNO_OFFSET);
+            return (1);
+        }
+        opcode = header[0] & 0x0F;
+        payload_length = static_cast<std::size_t>(header[1] & 0x7F);
+        if (payload_length == 126)
+        {
+            unsigned char extended[2];
+            bytes_received = nw_recv(client_fd, extended, 2, 0);
+            if (bytes_received <= 0)
+            {
+                this->set_error(errno + ERRNO_OFFSET);
+                return (1);
+            }
+            payload_length = static_cast<std::size_t>((extended[0] << 8) | extended[1]);
+        }
+        else if (payload_length == 127)
+        {
+            unsigned char extended[8];
+            std::size_t shift_index;
+            bytes_received = nw_recv(client_fd, extended, 8, 0);
+            if (bytes_received <= 0)
+            {
+                this->set_error(errno + ERRNO_OFFSET);
+                return (1);
+            }
+            payload_length = 0;
+            shift_index = 0;
+            while (shift_index < 8)
+            {
+                payload_length = (payload_length << 8) | extended[shift_index];
+                shift_index++;
+            }
+        }
+        bytes_received = nw_recv(client_fd, mask_key, 4, 0);
+        if (bytes_received <= 0)
+        {
+            this->set_error(errno + ERRNO_OFFSET);
+            return (1);
+        }
+        payload = static_cast<unsigned char *>(cma_malloc(payload_length));
+        if (!payload)
+        {
+            this->set_error(FT_EINVAL);
+            return (1);
+        }
+        index_value = 0;
+        while (index_value < payload_length)
+        {
+            bytes_received = nw_recv(client_fd, payload + index_value, payload_length - index_value, 0);
+            if (bytes_received <= 0)
+            {
+                cma_free(payload);
+                this->set_error(errno + ERRNO_OFFSET);
+                return (1);
+            }
+            index_value += static_cast<std::size_t>(bytes_received);
+        }
+        index_value = 0;
+        while (index_value < payload_length)
+        {
+            payload[index_value] = static_cast<unsigned char>(payload[index_value] ^ mask_key[index_value % 4]);
+            index_value++;
+        }
+        if (opcode == 0x9)
+        {
+            this->send_pong(client_fd, payload, payload_length);
+            cma_free(payload);
+            continue ;
+        }
+        if (opcode == 0xA)
+        {
+            cma_free(payload);
+            continue ;
+        }
+        if (opcode == 0x1)
+        {
+            message.clear();
+            index_value = 0;
+            while (index_value < payload_length)
+            {
+                message.append(static_cast<char>(payload[index_value]));
+                index_value++;
+            }
+            cma_free(payload);
+            this->_error_code = ER_SUCCESS;
+            return (0);
+        }
+        cma_free(payload);
+        this->set_error(FT_EINVAL);
+        return (1);
+    }
+}
+
+int ft_websocket_server::run_once(ft_string &message)
+{
+    struct sockaddr_storage client_address;
+    socklen_t address_length;
+    int client_fd;
+    int result;
+
+    address_length = sizeof(client_address);
+    client_fd = nw_accept(this->_server_socket->get_fd(), reinterpret_cast<struct sockaddr*>(&client_address), &address_length);
+    if (client_fd < 0)
+    {
+        this->set_error(errno + ERRNO_OFFSET);
+        return (1);
+    }
+    if (this->perform_handshake(client_fd) != 0)
+    {
+        FT_CLOSE_SOCKET(client_fd);
+        return (1);
+    }
+    result = this->receive_frame(client_fd, message);
+    FT_CLOSE_SOCKET(client_fd);
+    if (result != 0)
+        return (1);
+    this->_error_code = ER_SUCCESS;
+    return (0);
+}
+
+int ft_websocket_server::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char *ft_websocket_server::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}

--- a/Networking/websocket_server.hpp
+++ b/Networking/websocket_server.hpp
@@ -1,0 +1,35 @@
+#ifndef WEBSOCKET_SERVER_HPP
+#define WEBSOCKET_SERVER_HPP
+
+#include "../CPP_class/class_string_class.hpp"
+#include <cstdint>
+#ifdef _WIN32
+# include <winsock2.h>
+#else
+# include <netinet/in.h>
+#endif
+
+class ft_socket;
+
+class ft_websocket_server
+{
+    private:
+        ft_socket *_server_socket;
+        mutable int _error_code;
+
+        void set_error(int error_code) const;
+        int perform_handshake(int client_fd);
+        int receive_frame(int client_fd, ft_string &message);
+        int send_pong(int client_fd, const unsigned char *payload, std::size_t length);
+
+    public:
+        ft_websocket_server();
+        ~ft_websocket_server();
+
+        int start(const char *ip, uint16_t port, int address_family = AF_INET, bool non_blocking = false);
+        int run_once(ft_string &message);
+        int get_error() const;
+        const char *get_error_str() const;
+};
+
+#endif

--- a/README.md
+++ b/README.md
@@ -614,6 +614,42 @@ int main()
 }
 ```
 
+#### WebSocket client and server
+
+`Networking/websocket_client.hpp` and `websocket_server.hpp` add helpers for
+the WebSocket protocol including the opening handshake, frame parsing and
+basic ping/pong handling.
+
+```c++
+#include "Networking/websocket_client.hpp"
+
+int main()
+{
+    ft_websocket_client client;
+    ft_string message;
+
+    client.connect("example.com", 80, "/chat");
+    client.send_text("hello");
+    client.receive_text(message);
+    client.close();
+    return (0);
+}
+```
+
+```c++
+#include "Networking/websocket_server.hpp"
+
+int main()
+{
+    ft_websocket_server server;
+    ft_string message;
+
+    server.start("127.0.0.1", 8080);
+    server.run_once(message);
+    return (0);
+}
+```
+
 ### Logger
 
 `Logger/logger.hpp` provides leveled logging with timestamps, formatted output


### PR DESCRIPTION
## Summary
- add `ft_websocket_client` and `ft_websocket_server` for basic WebSocket handshake, frame parsing, and ping/pong logic
- expose WebSocket headers through `networking.hpp` and Makefile
- document client and server usage examples in README

## Testing
- `make -C Networking`

------
https://chatgpt.com/codex/tasks/task_e_68c48cbd4a4483319ea9d26140ffe317