### PR TITLE
Add cross-platform file watcher

### DIFF
--- a/File/Makefile
+++ b/File/Makefile
@@ -9,10 +9,12 @@ SRCS := file_opendir.cpp \
         file_exists.cpp \
         file_delete.cpp \
         file_path_join.cpp \
-        file_path_normalize.cpp
+        file_path_normalize.cpp \
+        file_watch.cpp
 
 HEADERS := open_dir.hpp \
-           file_utils.hpp
+           file_utils.hpp \
+           file_watch.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/File/file_watch.cpp
+++ b/File/file_watch.cpp
@@ -1,0 +1,201 @@
+#include "file_watch.hpp"
+#ifdef __linux__
+#include <sys/inotify.h>
+#include <unistd.h>
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/event.h>
+#include <fcntl.h>
+#include <unistd.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#endif
+
+ft_file_watch::ft_file_watch()
+    : _path(), _callback(ft_nullptr), _user_data(ft_nullptr), _thread(), _running(false), _error_code(ER_SUCCESS)
+#ifdef __linux__
+    , _fd(-1), _watch(-1)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+    , _kqueue(-1), _fd(-1)
+#elif defined(_WIN32)
+    , _handle(ft_nullptr)
+#endif
+{
+    return ;
+}
+
+ft_file_watch::~ft_file_watch()
+{
+    this->stop();
+    return ;
+}
+
+void ft_file_watch::set_error(int error) const
+{
+    this->_error_code = error;
+    ft_errno = error;
+    return ;
+}
+
+int ft_file_watch::watch_directory(const char *path, void (*callback)(const char *, int, void *), void *user_data)
+{
+    if (path == ft_nullptr || callback == ft_nullptr)
+    {
+        this->set_error(FT_EINVAL);
+        return (-1);
+    }
+    this->_path = ft_string(path);
+    this->_callback = callback;
+    this->_user_data = user_data;
+#ifdef __linux__
+    this->_fd = inotify_init();
+    if (this->_fd < 0)
+    {
+        this->set_error(FILE_INVALID_FD);
+        return (-1);
+    }
+    this->_watch = inotify_add_watch(this->_fd, path, IN_CREATE | IN_MODIFY | IN_DELETE);
+    if (this->_watch < 0)
+    {
+        this->set_error(FILE_INVALID_FD);
+        return (-1);
+    }
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+    this->_fd = open(path, O_EVTONLY);
+    if (this->_fd < 0)
+    {
+        this->set_error(FILE_INVALID_FD);
+        return (-1);
+    }
+    this->_kqueue = kqueue();
+    if (this->_kqueue < 0)
+    {
+        close(this->_fd);
+        this->_fd = -1;
+        this->set_error(FILE_INVALID_FD);
+        return (-1);
+    }
+#elif defined(_WIN32)
+    this->_handle = CreateFileA(path, FILE_LIST_DIRECTORY,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        ft_nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, ft_nullptr);
+    if (this->_handle == INVALID_HANDLE_VALUE)
+    {
+        this->_handle = ft_nullptr;
+        this->set_error(FILE_INVALID_FD);
+        return (-1);
+    }
+#endif
+    this->_running = true;
+    this->_thread = std::thread(&ft_file_watch::event_loop, this);
+    return (0);
+}
+
+void ft_file_watch::stop()
+{
+    if (this->_running == false)
+        return ;
+    this->_running = false;
+    if (this->_thread.joinable())
+        this->_thread.join();
+#ifdef __linux__
+    if (this->_watch >= 0)
+        inotify_rm_watch(this->_fd, this->_watch);
+    if (this->_fd >= 0)
+        close(this->_fd);
+    this->_watch = -1;
+    this->_fd = -1;
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+    if (this->_fd >= 0)
+        close(this->_fd);
+    if (this->_kqueue >= 0)
+        close(this->_kqueue);
+    this->_fd = -1;
+    this->_kqueue = -1;
+#elif defined(_WIN32)
+    if (this->_handle != ft_nullptr)
+        CloseHandle(this->_handle);
+    this->_handle = ft_nullptr;
+#endif
+    return ;
+}
+
+int ft_file_watch::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char *ft_file_watch::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}
+
+void ft_file_watch::event_loop()
+{
+#ifdef __linux__
+    char buffer[4096];
+    while (this->_running)
+    {
+        int length;
+        char *pointer;
+        struct inotify_event *event;
+
+        length = read(this->_fd, buffer, sizeof(buffer));
+        if (length <= 0)
+            continue;
+        pointer = buffer;
+        while (pointer < buffer + length)
+        {
+            event = (struct inotify_event*)pointer;
+            if (this->_callback != ft_nullptr)
+            {
+                if (event->mask & IN_CREATE)
+                    this->_callback(event->name, FILE_WATCH_EVENT_CREATE, this->_user_data);
+                else if (event->mask & IN_MODIFY)
+                    this->_callback(event->name, FILE_WATCH_EVENT_MODIFY, this->_user_data);
+                else if (event->mask & IN_DELETE)
+                    this->_callback(event->name, FILE_WATCH_EVENT_DELETE, this->_user_data);
+            }
+            pointer += sizeof(struct inotify_event) + event->len;
+        }
+    }
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+    struct kevent change_event;
+    struct kevent event;
+    EV_SET(&change_event, this->_fd, EVFILT_VNODE, EV_ADD | EV_CLEAR, NOTE_WRITE | NOTE_EXTEND | NOTE_DELETE | NOTE_RENAME, 0, ft_nullptr);
+    while (this->_running)
+    {
+        int event_count;
+        event_count = kevent(this->_kqueue, &change_event, 1, &event, 1, ft_nullptr);
+        if (event_count > 0 && this->_callback != ft_nullptr)
+        {
+            if (event.fflags & NOTE_DELETE)
+                this->_callback(this->_path.c_str(), FILE_WATCH_EVENT_DELETE, this->_user_data);
+            else if ((event.fflags & NOTE_WRITE) || (event.fflags & NOTE_EXTEND) || (event.fflags & NOTE_RENAME))
+                this->_callback(this->_path.c_str(), FILE_WATCH_EVENT_MODIFY, this->_user_data);
+        }
+    }
+#elif defined(_WIN32)
+    char buffer[1024];
+    DWORD bytes_transferred;
+    FILE_NOTIFY_INFORMATION *notification;
+    while (this->_running)
+    {
+        if (ReadDirectoryChangesW(this->_handle, buffer, sizeof(buffer), FALSE,
+            FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE,
+            &bytes_transferred, ft_nullptr, ft_nullptr))
+        {
+            notification = (FILE_NOTIFY_INFORMATION*)buffer;
+            if (this->_callback != ft_nullptr)
+            {
+                if (notification->Action == FILE_ACTION_ADDED)
+                    this->_callback("", FILE_WATCH_EVENT_CREATE, this->_user_data);
+                else if (notification->Action == FILE_ACTION_MODIFIED)
+                    this->_callback("", FILE_WATCH_EVENT_MODIFY, this->_user_data);
+                else if (notification->Action == FILE_ACTION_REMOVED)
+                    this->_callback("", FILE_WATCH_EVENT_DELETE, this->_user_data);
+            }
+        }
+    }
+#endif
+    return ;
+}

--- a/File/file_watch.hpp
+++ b/File/file_watch.hpp
@@ -1,0 +1,48 @@
+#ifndef FILE_WATCH_HPP
+#define FILE_WATCH_HPP
+
+#include "../Errno/errno.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../CPP_class/class_string_class.hpp"
+
+#include <thread>
+
+enum file_watch_event_type
+{
+    FILE_WATCH_EVENT_CREATE = 1,
+    FILE_WATCH_EVENT_MODIFY,
+    FILE_WATCH_EVENT_DELETE
+};
+
+class ft_file_watch
+{
+    private:
+        ft_string _path;
+        void (*_callback)(const char *, int, void *);
+        void *_user_data;
+        std::thread _thread;
+        bool _running;
+        mutable int _error_code;
+#ifdef __linux__
+        int _fd;
+        int _watch;
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+        int _kqueue;
+        int _fd;
+#elif defined(_WIN32)
+        void *_handle;
+#endif
+        void set_error(int error) const;
+        void event_loop();
+
+    public:
+        ft_file_watch();
+        ~ft_file_watch();
+
+        int watch_directory(const char *path, void (*callback)(const char *, int, void *), void *user_data);
+        void stop();
+        int get_error() const;
+        const char *get_error_str() const;
+};
+
+#endif

--- a/README.md
+++ b/README.md
@@ -1056,6 +1056,23 @@ ft_string normalized = file_path_normalize("dir//sub\\file.txt");
 
 On POSIX systems these evaluate to `dir/file.txt` and `dir/sub/file.txt` respectively.
 
+`File/file_watch.hpp` offers a simple `ft_file_watch` class for monitoring
+directories. It invokes a user supplied callback whenever files are created,
+modified or deleted in the watched directory:
+
+```
+void on_file_event(const char *name, int event, void *data);
+
+ft_file_watch watcher;
+watcher.watch_directory("dir", on_file_event, ft_nullptr);
+/* ... */
+watcher.stop();
+```
+
+The implementation uses inotify on Linux, kqueue on BSD and macOS and
+`ReadDirectoryChangesW` on Windows. These platform APIs must be available when
+building the library.
+
 `System_utils/system_utils.hpp` provides cross-platform file descriptor utilities:
 
 ```


### PR DESCRIPTION
## Summary
- add ft_file_watch class with Linux, BSD/macOS, and Windows backends
- document file watcher usage and platform dependencies
- include file_watch in File module build

## Testing
- `make -C File`


------
https://chatgpt.com/codex/tasks/task_e_68c522ad372083318ac29386046c97de