### PR TITLE
Add syslog and network logging sinks

### DIFF
--- a/Compatebility/Compatebility_syslog.cpp
+++ b/Compatebility/Compatebility_syslog.cpp
@@ -1,0 +1,39 @@
+#include "compatebility_internal.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+int cmp_syslog_open(const char *identifier)
+{
+    (void)identifier;
+    return (-1);
+}
+
+void cmp_syslog_write(const char *message)
+{
+    (void)message;
+    return ;
+}
+
+void cmp_syslog_close(void)
+{
+    return ;
+}
+#else
+#include <syslog.h>
+int cmp_syslog_open(const char *identifier)
+{
+    openlog(identifier, LOG_PID | LOG_CONS, LOG_USER);
+    return (0);
+}
+
+void cmp_syslog_write(const char *message)
+{
+    syslog(LOG_INFO, "%s", message);
+    return ;
+}
+
+void cmp_syslog_close(void)
+{
+    closelog();
+    return ;
+}
+#endif

--- a/Compatebility/Makefile
+++ b/Compatebility/Makefile
@@ -3,7 +3,7 @@ DEBUG_TARGET := Compatebility_debug.a
 
 .RECIPEPREFIX := >
 
-SRCS := Compatebility_file_io.cpp Compatebility_file_ops.cpp Compatebility_file_dir.cpp Compatebility_file_path.cpp Compatebility_rng.cpp Compatebility_readline.cpp Compatebility_pthread.cpp Compatebility_system.cpp Compatebility_write.cpp
+SRCS := Compatebility_file_io.cpp Compatebility_file_ops.cpp Compatebility_file_dir.cpp Compatebility_file_path.cpp Compatebility_rng.cpp Compatebility_readline.cpp Compatebility_pthread.cpp Compatebility_system.cpp Compatebility_write.cpp Compatebility_syslog.cpp
 HEADERS := compatebility_internal.hpp
 ifeq ($(OS),Windows_NT)
 MKDIR   = mkdir

--- a/Compatebility/compatebility_internal.hpp
+++ b/Compatebility/compatebility_internal.hpp
@@ -78,4 +78,8 @@ unsigned long long cmp_get_total_memory(void);
 
 ssize_t cmp_su_write(int file_descriptor, const char *buffer, size_t length);
 
+int cmp_syslog_open(const char *identifier);
+void cmp_syslog_write(const char *message);
+void cmp_syslog_close(void);
+
 #endif

--- a/Logger/Makefile
+++ b/Logger/Makefile
@@ -22,9 +22,11 @@ SRCS := \
     logger_log_warn.cpp \
     logger_log_error.cpp \
     logger_log_async.cpp \
-    logger_logger.cpp
+    logger_logger.cpp \
+    logger_syslog.cpp \
+    logger_network.cpp
 
-HEADERS := logger.hpp logger_internal.hpp logger_log_async.hpp
+HEADERS := logger.hpp logger_internal.hpp logger_log_async.hpp logger_syslog.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Logger/logger.hpp
+++ b/Logger/logger.hpp
@@ -27,6 +27,9 @@ bool    ft_log_get_api_logging();
 void    ft_log_set_color(bool enable);
 bool    ft_log_get_color();
 void    ft_json_sink(const char *message, void *user_data);
+int     ft_log_set_syslog(const char *identifier);
+int     ft_log_set_remote_sink(const char *host, unsigned short port,
+                               bool use_tcp);
 
 void ft_log_debug(const char *fmt, ...);
 void ft_log_info(const char *fmt, ...);
@@ -60,6 +63,9 @@ class ft_logger
         void set_color(bool enable) noexcept;
         bool get_color() const noexcept;
         void close() noexcept;
+        int  set_syslog(const char *identifier) noexcept;
+        int  set_remote_sink(const char *host, unsigned short port,
+                             bool use_tcp) noexcept;
 
         void debug(const char *fmt, ...) noexcept;
         void info(const char *fmt, ...) noexcept;

--- a/Logger/logger_internal.hpp
+++ b/Logger/logger_internal.hpp
@@ -7,6 +7,7 @@
 #include "../Errno/errno.hpp"
 #include "logger.hpp"
 #include "logger_log_async.hpp"
+#include "logger_syslog.hpp"
 
 extern ft_logger *g_logger;
 extern t_log_level g_level;
@@ -28,10 +29,16 @@ struct s_file_sink
     size_t    max_size;
 };
 
+struct s_network_sink
+{
+    int socket_fd;
+};
+
 extern ft_vector<s_log_sink> g_sinks;
 
 void ft_log_rotate(s_file_sink *sink);
 void ft_file_sink(const char *message, void *user_data);
+void ft_network_sink(const char *message, void *user_data);
 const char *ft_level_to_str(t_log_level level);
 void ft_log_vwrite(t_log_level level, const char *fmt, va_list args);
 

--- a/Logger/logger_log_close.cpp
+++ b/Logger/logger_log_close.cpp
@@ -1,4 +1,5 @@
 #include "logger_internal.hpp"
+#include "../Compatebility/compatebility_internal.hpp"
 #include <unistd.h>
 
 void ft_log_close()
@@ -16,6 +17,21 @@ void ft_log_close()
             if (sink)
             {
                 close(sink->fd);
+                delete sink;
+            }
+        }
+        else if (g_sinks[index].function == ft_syslog_sink)
+        {
+            cmp_syslog_close();
+        }
+        else if (g_sinks[index].function == ft_network_sink)
+        {
+            s_network_sink *sink;
+
+            sink = static_cast<s_network_sink *>(g_sinks[index].user_data);
+            if (sink)
+            {
+                cmp_close(sink->socket_fd);
                 delete sink;
             }
         }

--- a/Logger/logger_logger.cpp
+++ b/Logger/logger_logger.cpp
@@ -80,6 +80,17 @@ void ft_logger::close() noexcept
     ft_log_close();
 }
 
+int ft_logger::set_syslog(const char *identifier) noexcept
+{
+    return (ft_log_set_syslog(identifier));
+}
+
+int ft_logger::set_remote_sink(const char *host, unsigned short port,
+                               bool use_tcp) noexcept
+{
+    return (ft_log_set_remote_sink(host, port, use_tcp));
+}
+
 void ft_logger::debug(const char *fmt, ...) noexcept
 {
     va_list args;

--- a/Logger/logger_network.cpp
+++ b/Logger/logger_network.cpp
@@ -1,0 +1,69 @@
+#include "logger_internal.hpp"
+#include "../Networking/socket_class.hpp"
+#include "../Compatebility/compatebility_internal.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Libft/libft.hpp"
+
+int ft_log_set_remote_sink(const char *host, unsigned short port, bool use_tcp)
+{
+    s_network_sink *sink;
+    struct sockaddr_in address;
+    int socket_fd;
+    int socket_type;
+
+    if (!host)
+        return (-1);
+    socket_type = SOCK_DGRAM;
+    if (use_tcp)
+        socket_type = SOCK_STREAM;
+    socket_fd = nw_socket(AF_INET, socket_type, 0);
+    if (socket_fd < 0)
+        return (-1);
+    ft_memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_port = htons(port);
+    if (nw_inet_pton(AF_INET, host, &address.sin_addr) != 1)
+    {
+        cmp_close(socket_fd);
+        return (-1);
+    }
+    if (use_tcp)
+    {
+        if (nw_connect(socket_fd, reinterpret_cast<struct sockaddr *>(&address), sizeof(address)) != 0)
+        {
+            cmp_close(socket_fd);
+            return (-1);
+        }
+    }
+    else
+    {
+        nw_connect(socket_fd, reinterpret_cast<struct sockaddr *>(&address), sizeof(address));
+    }
+    sink = new s_network_sink;
+    if (!sink)
+    {
+        cmp_close(socket_fd);
+        return (-1);
+    }
+    sink->socket_fd = socket_fd;
+    if (ft_log_add_sink(ft_network_sink, sink) != 0)
+    {
+        cmp_close(socket_fd);
+        delete sink;
+        return (-1);
+    }
+    return (0);
+}
+
+void ft_network_sink(const char *message, void *user_data)
+{
+    s_network_sink *sink;
+    size_t length;
+
+    sink = static_cast<s_network_sink *>(user_data);
+    if (!sink)
+        return ;
+    length = ft_strlen(message);
+    nw_send(sink->socket_fd, message, length, 0);
+    return ;
+}

--- a/Logger/logger_syslog.cpp
+++ b/Logger/logger_syslog.cpp
@@ -1,0 +1,23 @@
+#include "logger_internal.hpp"
+#include "../Compatebility/compatebility_internal.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "logger_syslog.hpp"
+
+int ft_log_set_syslog(const char *identifier)
+{
+    if (cmp_syslog_open(identifier) != 0)
+        return (-1);
+    if (ft_log_add_sink(ft_syslog_sink, ft_nullptr) != 0)
+    {
+        cmp_syslog_close();
+        return (-1);
+    }
+    return (0);
+}
+
+void ft_syslog_sink(const char *message, void *user_data)
+{
+    (void)user_data;
+    cmp_syslog_write(message);
+    return ;
+}

--- a/Logger/logger_syslog.hpp
+++ b/Logger/logger_syslog.hpp
@@ -1,0 +1,7 @@
+#ifndef LOGGER_SYSLOG_HPP
+#define LOGGER_SYSLOG_HPP
+
+void ft_syslog_sink(const char *message, void *user_data);
+int ft_log_set_syslog(const char *identifier);
+
+#endif

--- a/README.md
+++ b/README.md
@@ -660,7 +660,9 @@ Template module for internal storage.
 
 Colorized terminal output can be toggled with `ft_log_set_color`, and a
 predefined `ft_json_sink` helper emits each entry as a JSON object for
-downstream processing.
+downstream processing. A syslog sink writes entries to the host's system
+logger and `ft_log_set_remote_sink` forwards messages to a remote server over
+UDP or TCP.
 
 Asynchronous logging is enabled with `ft_log_enable_async(true)` and later
 disabled with `ft_log_enable_async(false)` to flush pending messages. This
@@ -688,6 +690,9 @@ bool ft_log_get_alloc_logging();
 void ft_log_set_color(bool enable);
 bool ft_log_get_color();
 void ft_json_sink(const char *message, void *user_data);
+int  ft_log_set_syslog(const char *identifier);
+int  ft_log_set_remote_sink(const char *host, unsigned short port,
+                            bool use_tcp);
 
 void ft_log_info(const char *fmt, ...);
 void ft_log_warn(const char *fmt, ...);
@@ -703,6 +708,8 @@ closes the log when the object is destroyed:
     ft_logger log("app.log", 1024 * 1024, LOG_LEVEL_DEBUG);
     log.set_global();
     log.info("starting up");
+    log.set_syslog("myapp");
+    log.set_remote_sink("203.0.113.5", 9000, true);
 }
 ```
 


### PR DESCRIPTION
## Summary
- Add syslog sink with compatibility wrappers and helper configuration methods
- Provide network sink to forward logs to remote servers over UDP or TCP
- Document new logging sinks and update logger API

## Testing
- `make -C Compatebility`
- `make -C Logger`

------
https://chatgpt.com/codex/tasks/task_e_68c524f491b48331a3b60030ec1c3f11