### PR TITLE
Add ECC module with key exchange and signing support

### DIFF
--- a/Encryption/Makefile
+++ b/Encryption/Makefile
@@ -6,13 +6,15 @@ SRCS := encryption_basic_encryption.cpp \
         encryption_aes.cpp \
         encryption_rsa.cpp \
         encryption_sha256.cpp \
-        encryption_hmac_sha256.cpp
+        encryption_hmac_sha256.cpp \
+        encryption_ecc.cpp
 
 HEADERS := basic_encryption.hpp \
         aes.hpp \
         rsa.hpp \
         encryption_sha256.hpp \
-        encryption_hmac_sha256.hpp
+        encryption_hmac_sha256.hpp \
+        ecc.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Encryption/README
+++ b/Encryption/README
@@ -64,3 +64,33 @@ This implementation uses small primes for demonstration and relies on 64-bit
 arithmetic. Large key sizes drastically slow down operations and may exceed
 the limits of this module. For real-world security, use keys of at least 2048
 bits and a vetted cryptographic library.
+
+## ECC
+
+`ecc.hpp` exposes helpers for generating Curve25519 key pairs, deriving shared
+secrets and signing messages.
+
+### Usage
+
+```
+unsigned char public_key[ECT_PUBLIC_KEY_SIZE];
+unsigned char private_key[ECT_PRIVATE_KEY_SIZE];
+unsigned char peer_public[ECT_PUBLIC_KEY_SIZE];
+unsigned char peer_private[ECT_PRIVATE_KEY_SIZE];
+unsigned char shared_secret[ECT_SHARED_SECRET_SIZE];
+unsigned char signature[ECT_SIGNATURE_SIZE];
+const unsigned char message[] = "hello";
+
+ect_generate_keypair(public_key, private_key);
+ect_generate_keypair(peer_public, peer_private);
+ect_compute_shared_secret(shared_secret, private_key, peer_public);
+ect_sign(private_key, message, 5, signature);
+if (ect_verify(public_key, message, 5, signature) == 0)
+    ;
+```
+
+### Warning
+
+Curve25519 offers strong security with small key sizes, but signature and
+shared secret helpers in this module are thin wrappers around `libsodium`.
+Always validate inputs and keep private keys confidential.

--- a/Encryption/ecc.hpp
+++ b/Encryption/ecc.hpp
@@ -1,0 +1,31 @@
+#ifndef ECT_HPP
+#define ECT_HPP
+
+#include <cstddef>
+#include <string>
+
+constexpr std::size_t ECT_PUBLIC_KEY_SIZE = 32;
+constexpr std::size_t ECT_PRIVATE_KEY_SIZE = 64;
+constexpr std::size_t ECT_SIGNATURE_SIZE = 64;
+constexpr std::size_t ECT_SHARED_SECRET_SIZE = 32;
+
+int ect_generate_keypair(unsigned char *public_key, unsigned char *private_key);
+int ect_compute_shared_secret(unsigned char *shared_secret,
+                              const unsigned char *private_key,
+                              const unsigned char *peer_public_key);
+int ect_sign(const unsigned char *private_key,
+             const unsigned char *message,
+             unsigned long long message_length,
+             unsigned char *signature);
+int ect_verify(const unsigned char *public_key,
+               const unsigned char *message,
+               unsigned long long message_length,
+               const unsigned char *signature);
+int ect_public_key_to_hex(const unsigned char *public_key, std::string &hex);
+int ect_public_key_from_hex(const std::string &hex, unsigned char *public_key);
+int ect_private_key_to_hex(const unsigned char *private_key, std::string &hex);
+int ect_private_key_from_hex(const std::string &hex, unsigned char *private_key);
+int ect_signature_to_hex(const unsigned char *signature, std::string &hex);
+int ect_signature_from_hex(const std::string &hex, unsigned char *signature);
+
+#endif

--- a/Encryption/encryption_ecc.cpp
+++ b/Encryption/encryption_ecc.cpp
@@ -1,0 +1,127 @@
+#include "ecc.hpp"
+#include <sodium.h>
+
+int ect_generate_keypair(unsigned char *public_key, unsigned char *private_key)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    if (crypto_sign_keypair(public_key, private_key) != 0)
+        return (-1);
+    return (0);
+}
+
+int ect_compute_shared_secret(unsigned char *shared_secret,
+                              const unsigned char *private_key,
+                              const unsigned char *peer_public_key)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    unsigned char curve_private[ECT_SHARED_SECRET_SIZE];
+    unsigned char curve_public[ECT_SHARED_SECRET_SIZE];
+    if (crypto_sign_ed25519_sk_to_curve25519(curve_private, private_key) != 0)
+        return (-1);
+    if (crypto_sign_ed25519_pk_to_curve25519(curve_public, peer_public_key) != 0)
+        return (-1);
+    if (crypto_scalarmult(shared_secret, curve_private, curve_public) != 0)
+        return (-1);
+    return (0);
+}
+
+int ect_sign(const unsigned char *private_key,
+             const unsigned char *message,
+             unsigned long long message_length,
+             unsigned char *signature)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    unsigned long long signature_length = 0;
+    if (crypto_sign_detached(signature, &signature_length, message, message_length, private_key) != 0)
+        return (-1);
+    if (signature_length != ECT_SIGNATURE_SIZE)
+        return (-1);
+    return (0);
+}
+
+int ect_verify(const unsigned char *public_key,
+               const unsigned char *message,
+               unsigned long long message_length,
+               const unsigned char *signature)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    if (crypto_sign_verify_detached(signature, message, message_length, public_key) != 0)
+        return (-1);
+    return (0);
+}
+
+int ect_public_key_to_hex(const unsigned char *public_key, std::string &hex)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    char buffer[ECT_PUBLIC_KEY_SIZE * 2 + 1];
+    sodium_bin2hex(buffer, sizeof(buffer), public_key, ECT_PUBLIC_KEY_SIZE);
+    hex.assign(buffer);
+    return (0);
+}
+
+int ect_public_key_from_hex(const std::string &hex, unsigned char *public_key)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    size_t binary_length = 0;
+    if (sodium_hex2bin(public_key, ECT_PUBLIC_KEY_SIZE,
+                       hex.c_str(), hex.size(),
+                       NULL, &binary_length, NULL) != 0)
+        return (-1);
+    if (binary_length != ECT_PUBLIC_KEY_SIZE)
+        return (-1);
+    return (0);
+}
+
+int ect_private_key_to_hex(const unsigned char *private_key, std::string &hex)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    char buffer[ECT_PRIVATE_KEY_SIZE * 2 + 1];
+    sodium_bin2hex(buffer, sizeof(buffer), private_key, ECT_PRIVATE_KEY_SIZE);
+    hex.assign(buffer);
+    return (0);
+}
+
+int ect_private_key_from_hex(const std::string &hex, unsigned char *private_key)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    size_t binary_length = 0;
+    if (sodium_hex2bin(private_key, ECT_PRIVATE_KEY_SIZE,
+                       hex.c_str(), hex.size(),
+                       NULL, &binary_length, NULL) != 0)
+        return (-1);
+    if (binary_length != ECT_PRIVATE_KEY_SIZE)
+        return (-1);
+    return (0);
+}
+
+int ect_signature_to_hex(const unsigned char *signature, std::string &hex)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    char buffer[ECT_SIGNATURE_SIZE * 2 + 1];
+    sodium_bin2hex(buffer, sizeof(buffer), signature, ECT_SIGNATURE_SIZE);
+    hex.assign(buffer);
+    return (0);
+}
+
+int ect_signature_from_hex(const std::string &hex, unsigned char *signature)
+{
+    if (sodium_init() < 0)
+        return (-1);
+    size_t binary_length = 0;
+    if (sodium_hex2bin(signature, ECT_SIGNATURE_SIZE,
+                       hex.c_str(), hex.size(),
+                       NULL, &binary_length, NULL) != 0)
+        return (-1);
+    if (binary_length != ECT_SIGNATURE_SIZE)
+        return (-1);
+    return (0);
+}

--- a/README.md
+++ b/README.md
@@ -906,6 +906,10 @@ uint64_t    rsa_encrypt(uint64_t message, uint64_t public_key, uint64_t modulus)
 uint64_t    rsa_decrypt(uint64_t cipher, uint64_t private_key, uint64_t modulus);
 void        sha256_hash(const void *data, size_t length, unsigned char *digest);
 void        hmac_sha256(const unsigned char *key, size_t key_len, const void *data, size_t len, unsigned char *digest);
+int         ect_generate_keypair(unsigned char *public_key, unsigned char *private_key);
+int         ect_compute_shared_secret(unsigned char *shared_secret, const unsigned char *private_key, const unsigned char *peer_public_key);
+int         ect_sign(const unsigned char *private_key, const unsigned char *message, unsigned long long message_length, unsigned char *signature);
+int         ect_verify(const unsigned char *public_key, const unsigned char *message, unsigned long long message_length, const unsigned char *signature);
 ```
 
 RSA helpers operate on 64-bit integers and are intended for small demonstrations. Key generation with large sizes significantly impacts performance.

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -6,7 +6,7 @@ EFF_SRCS :=
 SRCS := main.cpp test_atoi.cpp test_isdigit.cpp test_memset.cpp test_strcmp.cpp \
        test_strlen.cpp test_promise.cpp test_networking.cpp test_linear_algebra.cpp test_validate_int.cpp \
        test_task_scheduler.cpp test_json_validate.cpp test_rng.cpp test_http_server.cpp test_logger.cpp test_logger_async.cpp test_yaml.cpp \
-       test_quaternion.cpp test_string_view.cpp
+       test_quaternion.cpp test_string_view.cpp test_encryption_ecc.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR = mkdir
@@ -41,7 +41,7 @@ CXX       := g++
 COMPILE_FLAGS ?= -Wall -Wextra -Werror -std=c++17
 COMPILE_FLAGS += $(OPT_FLAGS) -pthread
 CFLAGS := $(COMPILE_FLAGS)
-LDFLAGS := -lz
+LDFLAGS := -lz -lsodium
 export COMPILE_FLAGS
 
 OBJDIR       := objs

--- a/Test/test_encryption_ecc.cpp
+++ b/Test/test_encryption_ecc.cpp
@@ -1,0 +1,36 @@
+#include "../Encryption/ecc.hpp"
+#include "../System_utils/test_runner.hpp"
+
+FT_TEST(test_ect_key_exchange, "ect shared secret")
+{
+    unsigned char alice_public[ECT_PUBLIC_KEY_SIZE];
+    unsigned char alice_private[ECT_PRIVATE_KEY_SIZE];
+    unsigned char bob_public[ECT_PUBLIC_KEY_SIZE];
+    unsigned char bob_private[ECT_PRIVATE_KEY_SIZE];
+    FT_ASSERT_EQ(0, ect_generate_keypair(alice_public, alice_private));
+    FT_ASSERT_EQ(0, ect_generate_keypair(bob_public, bob_private));
+    unsigned char alice_shared[ECT_SHARED_SECRET_SIZE];
+    unsigned char bob_shared[ECT_SHARED_SECRET_SIZE];
+    FT_ASSERT_EQ(0, ect_compute_shared_secret(alice_shared, alice_private, bob_public));
+    FT_ASSERT_EQ(0, ect_compute_shared_secret(bob_shared, bob_private, alice_public));
+    std::size_t index = 0;
+    while (index < ECT_SHARED_SECRET_SIZE)
+    {
+        if (alice_shared[index] != bob_shared[index])
+            return (0);
+        index = index + 1;
+    }
+    return (1);
+}
+
+FT_TEST(test_ect_sign_verify, "ect sign verify")
+{
+    unsigned char public_key[ECT_PUBLIC_KEY_SIZE];
+    unsigned char private_key[ECT_PRIVATE_KEY_SIZE];
+    FT_ASSERT_EQ(0, ect_generate_keypair(public_key, private_key));
+    const unsigned char message[] = "hello";
+    unsigned char signature[ECT_SIGNATURE_SIZE];
+    FT_ASSERT_EQ(0, ect_sign(private_key, message, 5, signature));
+    FT_ASSERT_EQ(0, ect_verify(public_key, message, 5, signature));
+    return (1);
+}


### PR DESCRIPTION
## Summary
- Replace ecc_ function and constant prefixes with ect_ across ECC utilities
- Update ECC documentation and tests for new ect_ names

## Testing
- `make tests` *(fails: fatal error: sodium.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c539c6f4148331bbbac46704d04c6c