### PR TITLE
Add equipment system with serialization

### DIFF
--- a/Game/Makefile
+++ b/Game/Makefile
@@ -2,11 +2,11 @@ TARGET := Game.a
 DEBUG_TARGET := Game_debug.a
 
 SRCS := game_map3d.cpp game_character.cpp game_quest.cpp game_achievement.cpp game_reputation.cpp game_buff.cpp game_debuff.cpp \
-game_upgrade.cpp game_event.cpp game_world.cpp game_item.cpp game_inventory.cpp game_save.cpp game_load.cpp \
+game_upgrade.cpp game_event.cpp game_world.cpp game_item.cpp game_inventory.cpp game_equipment.cpp game_save.cpp game_load.cpp \
 game_experience_table.cpp game_pathfinding.cpp
 
 HEADERS := map3d.hpp character.hpp quest.hpp achievement.hpp reputation.hpp buff.hpp debuff.hpp \
-   upgrade.hpp event.hpp world.hpp item.hpp inventory.hpp \
+   upgrade.hpp event.hpp world.hpp item.hpp inventory.hpp equipment.hpp \
    experience_table.hpp pathfinding.hpp
 
 ifeq ($(OS),Windows_NT)

--- a/Game/README
+++ b/Game/README
@@ -10,7 +10,16 @@ world.save_to_file("save.json", character, inventory);
 world.load_from_file("save.json", character, inventory);
 ```
 
-Both helpers use the JSon module to read and write the `world`, `character`, and `inventory` groups.
+Both helpers use the JSon module to read and write the `world`, `character`, `inventory`, and `equipment` groups.
+
+Characters manage gear through an `ft_equipment` container. Slots such as head, chest, and weapon can be equipped or unequipped and the appropriate stat modifiers are applied automatically.
+
+```
+ft_item sword;
+sword.set_modifier1_id(2);
+sword.set_modifier1_value(5);
+hero.equip_item(EQUIP_WEAPON, sword);
+```
 
 ## Pathfinding
 

--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -9,6 +9,7 @@
 #include "debuff.hpp"
 #include "upgrade.hpp"
 #include "inventory.hpp"
+#include "equipment.hpp"
 #include "experience_table.hpp"
 
 struct json_group;
@@ -52,9 +53,11 @@ class ft_character
         ft_map<int, ft_achievement> _achievements;
         ft_reputation             _reputation;
         ft_inventory            _inventory;
+        ft_equipment            _equipment;
         mutable int               _error;
 
         void    set_error(int err) const noexcept;
+        void    apply_modifier(const ft_item_modifier &mod, int sign) noexcept;
 
     public:
         ft_character() noexcept;
@@ -152,6 +155,11 @@ class ft_character
 
         ft_experience_table       &get_experience_table() noexcept;
         const ft_experience_table &get_experience_table() const noexcept;
+
+        int equip_item(int slot, const ft_item &item) noexcept;
+        void unequip_item(int slot) noexcept;
+        ft_item *get_equipped_item(int slot) noexcept;
+        const ft_item *get_equipped_item(int slot) const noexcept;
 
         int get_level() const noexcept;
 

--- a/Game/equipment.hpp
+++ b/Game/equipment.hpp
@@ -1,0 +1,40 @@
+#ifndef EQUIPMENT_HPP
+#define EQUIPMENT_HPP
+
+#include "item.hpp"
+#include "../Errno/errno.hpp"
+
+enum ft_equipment_slot
+{
+    EQUIP_HEAD,
+    EQUIP_CHEST,
+    EQUIP_WEAPON
+};
+
+class ft_equipment
+{
+    private:
+        ft_item _head;
+        ft_item _chest;
+        ft_item _weapon;
+        bool _has_head;
+        bool _has_chest;
+        bool _has_weapon;
+        mutable int _error;
+
+        void set_error(int err) const noexcept;
+
+    public:
+        ft_equipment() noexcept;
+        virtual ~ft_equipment() = default;
+
+        int equip(int slot, const ft_item &item) noexcept;
+        void unequip(int slot) noexcept;
+        ft_item *get_item(int slot) noexcept;
+        const ft_item *get_item(int slot) const noexcept;
+
+        int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
+};
+
+#endif

--- a/Game/game_character.cpp
+++ b/Game/game_character.cpp
@@ -162,7 +162,7 @@ ft_character::ft_character() noexcept
       _coins(0), _valor(0), _experience(0), _x(0), _y(0), _z(0),
       _fire_res{0, 0}, _frost_res{0, 0}, _lightning_res{0, 0},
       _air_res{0, 0}, _earth_res{0, 0}, _chaos_res{0, 0},
-      _physical_res{0, 0}, _buffs(), _debuffs(), _upgrades(), _quests(), _achievements(), _reputation(),
+      _physical_res{0, 0}, _buffs(), _debuffs(), _upgrades(), _quests(), _achievements(), _reputation(), _inventory(), _equipment(),
       _error(ER_SUCCESS)
 {
     if (this->_buffs.get_error() != ER_SUCCESS)
@@ -534,6 +534,73 @@ const ft_experience_table &ft_character::get_experience_table() const noexcept
 int ft_character::get_level() const noexcept
 {
     return (this->_experience_table.get_level(this->_experience));
+}
+
+void ft_character::apply_modifier(const ft_item_modifier &mod, int sign) noexcept
+{
+    if (mod.id == 1)
+        this->_armor += mod.value * sign;
+    else if (mod.id == 2)
+        this->_might += mod.value * sign;
+    else if (mod.id == 3)
+        this->_agility += mod.value * sign;
+    else if (mod.id == 4)
+        this->_endurance += mod.value * sign;
+    else if (mod.id == 5)
+        this->_reason += mod.value * sign;
+    else if (mod.id == 6)
+        this->_insigh += mod.value * sign;
+    else if (mod.id == 7)
+        this->_presence += mod.value * sign;
+    else if (mod.id == 8)
+        this->_hit_points += mod.value * sign;
+    return ;
+}
+
+int ft_character::equip_item(int slot, const ft_item &item) noexcept
+{
+    ft_item *current = this->_equipment.get_item(slot);
+    if (current)
+    {
+        this->apply_modifier(current->get_modifier1(), -1);
+        this->apply_modifier(current->get_modifier2(), -1);
+        this->apply_modifier(current->get_modifier3(), -1);
+        this->apply_modifier(current->get_modifier4(), -1);
+    }
+    if (this->_equipment.equip(slot, item) != ER_SUCCESS)
+    {
+        this->set_error(this->_equipment.get_error());
+        return (this->_error);
+    }
+    this->apply_modifier(item.get_modifier1(), 1);
+    this->apply_modifier(item.get_modifier2(), 1);
+    this->apply_modifier(item.get_modifier3(), 1);
+    this->apply_modifier(item.get_modifier4(), 1);
+    return (ER_SUCCESS);
+}
+
+void ft_character::unequip_item(int slot) noexcept
+{
+    ft_item *item = this->_equipment.get_item(slot);
+    if (item)
+    {
+        this->apply_modifier(item->get_modifier1(), -1);
+        this->apply_modifier(item->get_modifier2(), -1);
+        this->apply_modifier(item->get_modifier3(), -1);
+        this->apply_modifier(item->get_modifier4(), -1);
+    }
+    this->_equipment.unequip(slot);
+    return ;
+}
+
+ft_item *ft_character::get_equipped_item(int slot) noexcept
+{
+    return (this->_equipment.get_item(slot));
+}
+
+const ft_item *ft_character::get_equipped_item(int slot) const noexcept
+{
+    return (this->_equipment.get_item(slot));
 }
 
 int ft_character::get_error() const noexcept

--- a/Game/game_equipment.cpp
+++ b/Game/game_equipment.cpp
@@ -1,0 +1,114 @@
+#include "equipment.hpp"
+#include "../Libft/libft.hpp"
+
+ft_equipment::ft_equipment() noexcept
+    : _head(), _chest(), _weapon(),
+      _has_head(false), _has_chest(false), _has_weapon(false),
+      _error(ER_SUCCESS)
+{
+    return ;
+}
+
+void ft_equipment::set_error(int err) const noexcept
+{
+    ft_errno = err;
+    this->_error = err;
+    return ;
+}
+
+int ft_equipment::equip(int slot, const ft_item &item) noexcept
+{
+    this->_error = ER_SUCCESS;
+    if (slot == EQUIP_HEAD)
+    {
+        this->_head = item;
+        this->_has_head = true;
+    }
+    else if (slot == EQUIP_CHEST)
+    {
+        this->_chest = item;
+        this->_has_chest = true;
+    }
+    else if (slot == EQUIP_WEAPON)
+    {
+        this->_weapon = item;
+        this->_has_weapon = true;
+    }
+    else
+    {
+        this->set_error(GAME_GENERAL_ERROR);
+        return (this->_error);
+    }
+    return (ER_SUCCESS);
+}
+
+void ft_equipment::unequip(int slot) noexcept
+{
+    if (slot == EQUIP_HEAD)
+        this->_has_head = false;
+    else if (slot == EQUIP_CHEST)
+        this->_has_chest = false;
+    else if (slot == EQUIP_WEAPON)
+        this->_has_weapon = false;
+    else
+        this->set_error(GAME_GENERAL_ERROR);
+    return ;
+}
+
+ft_item *ft_equipment::get_item(int slot) noexcept
+{
+    if (slot == EQUIP_HEAD)
+    {
+        if (this->_has_head)
+            return (&this->_head);
+        return (ft_nullptr);
+    }
+    else if (slot == EQUIP_CHEST)
+    {
+        if (this->_has_chest)
+            return (&this->_chest);
+        return (ft_nullptr);
+    }
+    else if (slot == EQUIP_WEAPON)
+    {
+        if (this->_has_weapon)
+            return (&this->_weapon);
+        return (ft_nullptr);
+    }
+    this->set_error(GAME_GENERAL_ERROR);
+    return (ft_nullptr);
+}
+
+const ft_item *ft_equipment::get_item(int slot) const noexcept
+{
+    if (slot == EQUIP_HEAD)
+    {
+        if (this->_has_head)
+            return (&this->_head);
+        return (ft_nullptr);
+    }
+    else if (slot == EQUIP_CHEST)
+    {
+        if (this->_has_chest)
+            return (&this->_chest);
+        return (ft_nullptr);
+    }
+    else if (slot == EQUIP_WEAPON)
+    {
+        if (this->_has_weapon)
+            return (&this->_weapon);
+        return (ft_nullptr);
+    }
+    this->set_error(GAME_GENERAL_ERROR);
+    return (ft_nullptr);
+}
+
+int ft_equipment::get_error() const noexcept
+{
+    return (this->_error);
+}
+
+const char *ft_equipment::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}

--- a/Game/game_load.cpp
+++ b/Game/game_load.cpp
@@ -10,6 +10,7 @@
 int deserialize_character(ft_character &character, json_group *group);
 int deserialize_world(ft_world &world, json_group *group);
 int deserialize_inventory(ft_inventory &inventory, json_group *group);
+int deserialize_equipment(ft_character &character, json_group *group);
 
 static int parse_item_field(json_group *group, const ft_string &key, int &out_value)
 {
@@ -155,6 +156,44 @@ int deserialize_inventory(ft_inventory &inventory, json_group *group)
             return (inventory.get_error());
         item_index++;
     }
+    return (ER_SUCCESS);
+}
+
+int deserialize_equipment(ft_character &character, json_group *group)
+{
+    json_item *present = json_find_item(group, "head_present");
+    if (present && ft_atoi(present->value) == 1)
+    {
+        ft_item item;
+        if (build_item_from_group(item, group, "head") != ER_SUCCESS)
+            return (GAME_GENERAL_ERROR);
+        if (character.equip_item(EQUIP_HEAD, item) != ER_SUCCESS)
+            return (character.get_error());
+    }
+    else
+        character.unequip_item(EQUIP_HEAD);
+    present = json_find_item(group, "chest_present");
+    if (present && ft_atoi(present->value) == 1)
+    {
+        ft_item item;
+        if (build_item_from_group(item, group, "chest") != ER_SUCCESS)
+            return (GAME_GENERAL_ERROR);
+        if (character.equip_item(EQUIP_CHEST, item) != ER_SUCCESS)
+            return (character.get_error());
+    }
+    else
+        character.unequip_item(EQUIP_CHEST);
+    present = json_find_item(group, "weapon_present");
+    if (present && ft_atoi(present->value) == 1)
+    {
+        ft_item item;
+        if (build_item_from_group(item, group, "weapon") != ER_SUCCESS)
+            return (GAME_GENERAL_ERROR);
+        if (character.equip_item(EQUIP_WEAPON, item) != ER_SUCCESS)
+            return (character.get_error());
+    }
+    else
+        character.unequip_item(EQUIP_WEAPON);
     return (ER_SUCCESS);
 }
 

--- a/Game/game_save.cpp
+++ b/Game/game_save.cpp
@@ -10,6 +10,7 @@
 json_group *serialize_character(const ft_character &character);
 json_group *serialize_world(const ft_world &world);
 json_group *serialize_inventory(const ft_inventory &inventory);
+json_group *serialize_equipment(const ft_character &character);
 
 static int add_item_field(json_group *group, const ft_string &key, int value)
 {
@@ -146,6 +147,53 @@ json_group *serialize_inventory(const ft_inventory &inventory)
         if (serialize_item_fields(group, item_start[item_index].value, item_prefix) != ER_SUCCESS)
             return (ft_nullptr);
         item_index++;
+    }
+    return (group);
+}
+
+json_group *serialize_equipment(const ft_character &character)
+{
+    json_group *group = json_create_json_group("equipment");
+    if (!group)
+        return (ft_nullptr);
+    const ft_item *head = character.get_equipped_item(EQUIP_HEAD);
+    json_item *present = json_create_item("head_present", head ? 1 : 0);
+    if (!present)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, present);
+    if (head && serialize_item_fields(group, *head, "head") != ER_SUCCESS)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    const ft_item *chest = character.get_equipped_item(EQUIP_CHEST);
+    present = json_create_item("chest_present", chest ? 1 : 0);
+    if (!present)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, present);
+    if (chest && serialize_item_fields(group, *chest, "chest") != ER_SUCCESS)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    const ft_item *weapon = character.get_equipped_item(EQUIP_WEAPON);
+    present = json_create_item("weapon_present", weapon ? 1 : 0);
+    if (!present)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, present);
+    if (weapon && serialize_item_fields(group, *weapon, "weapon") != ER_SUCCESS)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
     }
     return (group);
 }

--- a/Game/game_world.cpp
+++ b/Game/game_world.cpp
@@ -12,6 +12,8 @@ json_group *serialize_world(const ft_world &world);
 int deserialize_world(ft_world &world, json_group *group);
 json_group *serialize_inventory(const ft_inventory &inventory);
 int deserialize_inventory(ft_inventory &inventory, json_group *group);
+json_group *serialize_equipment(const ft_character &character);
+int deserialize_equipment(ft_character &character, json_group *group);
 
 ft_world::ft_world() noexcept
     : _events(), _error(ER_SUCCESS)
@@ -57,6 +59,14 @@ int ft_world::save_to_file(const char *file_path, const ft_character &character,
         return (this->_error);
     }
     json_append_group(&groups, inventory_group);
+    json_group *equipment_group = serialize_equipment(character);
+    if (!equipment_group)
+    {
+        json_free_groups(groups);
+        this->set_error(ft_errno);
+        return (this->_error);
+    }
+    json_append_group(&groups, equipment_group);
     if (json_write_to_file(file_path, groups) != 0)
     {
         json_free_groups(groups);
@@ -79,7 +89,8 @@ int ft_world::load_from_file(const char *file_path, ft_character &character, ft_
     json_group *world_group = json_find_group(groups, "world");
     json_group *character_group = json_find_group(groups, "character");
     json_group *inventory_group = json_find_group(groups, "inventory");
-    if (!world_group || !character_group || !inventory_group)
+    json_group *equipment_group = json_find_group(groups, "equipment");
+    if (!world_group || !character_group || !inventory_group || !equipment_group)
     {
         json_free_groups(groups);
         this->set_error(GAME_GENERAL_ERROR);
@@ -89,7 +100,8 @@ int ft_world::load_from_file(const char *file_path, ft_character &character, ft_
     inventory.get_items().clear();
     if (deserialize_world(*this, world_group) != ER_SUCCESS ||
         deserialize_character(character, character_group) != ER_SUCCESS ||
-        deserialize_inventory(inventory, inventory_group) != ER_SUCCESS)
+        deserialize_inventory(inventory, inventory_group) != ER_SUCCESS ||
+        deserialize_equipment(character, equipment_group) != ER_SUCCESS)
     {
         json_free_groups(groups);
         this->set_error(ft_errno);

--- a/README.md
+++ b/README.md
@@ -1431,7 +1431,7 @@ xml_node *get_root() const noexcept;
 
 #### Game
 Basic game related classes include `ft_character`, `ft_item`, `ft_inventory`,
-`ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`,
+`ft_equipment`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`,
 `ft_buff`, `ft_debuff`, `ft_achievement`, and `ft_experience_table`. Each class
 is summarized below.
 
@@ -1501,6 +1501,10 @@ ft_reputation       &get_reputation() noexcept;
 const ft_reputation &get_reputation() const noexcept;
 ft_experience_table       &get_experience_table() noexcept;
 const ft_experience_table &get_experience_table() const noexcept;
+int equip_item(int slot, const ft_item &item) noexcept;
+void unequip_item(int slot) noexcept;
+ft_item *get_equipped_item(int slot) noexcept;
+const ft_item *get_equipped_item(int slot) const noexcept;
 int get_level() const noexcept;
 int get_error() const noexcept;
 const char *get_error_str() const noexcept;

--- a/Test/Test/test_equipment.cpp
+++ b/Test/Test/test_equipment.cpp
@@ -1,0 +1,33 @@
+#include "../../Game/character.hpp"
+#include "../../Game/item.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_equipment_equip, "equip item increases stats")
+{
+    ft_character hero;
+    ft_item helm;
+    helm.set_item_id(1);
+    helm.set_modifier1_id(1);
+    helm.set_modifier1_value(5);
+    FT_ASSERT_EQ(ER_SUCCESS, hero.equip_item(EQUIP_HEAD, helm));
+    FT_ASSERT_EQ(5, hero.get_armor());
+    const ft_item *found = hero.get_equipped_item(EQUIP_HEAD);
+    FT_ASSERT(found != ft_nullptr);
+    return (1);
+}
+
+FT_TEST(test_equipment_unequip, "unequip removes stats")
+{
+    ft_character hero;
+    ft_item helm;
+    helm.set_item_id(1);
+    helm.set_modifier1_id(1);
+    helm.set_modifier1_value(5);
+    hero.equip_item(EQUIP_HEAD, helm);
+    hero.unequip_item(EQUIP_HEAD);
+    FT_ASSERT_EQ(0, hero.get_armor());
+    FT_ASSERT(hero.get_equipped_item(EQUIP_HEAD) == ft_nullptr);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- Introduce `ft_equipment` to manage head, chest, and weapon slots with equip/unequip helpers
- Allow characters to equip gear, adjust stats, and persist equipment in saves
- Cover equipping and unequipping behaviors with new unit tests

## Testing
- `make -C Game`
- `make -C Test`
- `./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c58697b8d483319e6076275eb1927b