### PR TITLE
Implement world event expiration processing

### DIFF
--- a/Game/README
+++ b/Game/README
@@ -10,6 +10,8 @@ world.save_to_file("save.json", character, inventory);
 world.load_from_file("save.json", character, inventory);
 ```
 
+Call `ft_world::process_events` each tick to decrement event durations and remove expired entries.
+
 Both helpers use the JSon module to read and write the `world`, `character`, `inventory`, and `equipment` groups.
 
 Characters manage gear through an `ft_equipment` container. Slots such as head, chest, and weapon can be equipped or unequipped and the appropriate stat modifiers are applied automatically.

--- a/Game/game_world.cpp
+++ b/Game/game_world.cpp
@@ -33,6 +33,22 @@ const ft_map<int, ft_event> &ft_world::get_events() const noexcept
     return (this->_events);
 }
 
+void ft_world::process_events(int ticks) noexcept
+{
+    Pair<int, ft_event> *pair_pointer = this->_events.end();
+    size_t current_index = this->_events.size();
+    while (current_index > 0)
+    {
+        --current_index;
+        --pair_pointer;
+        ft_event &current_event = pair_pointer->value;
+        current_event.sub_duration(ticks);
+        if (current_event.get_duration() <= 0)
+            this->_events.remove(pair_pointer->key);
+    }
+    return ;
+}
+
 int ft_world::save_to_file(const char *file_path, const ft_character &character, const ft_inventory &inventory) const noexcept
 {
     json_group *groups = ft_nullptr;

--- a/Game/world.hpp
+++ b/Game/world.hpp
@@ -24,6 +24,8 @@ class ft_world
         ft_map<int, ft_event>       &get_events() noexcept;
         const ft_map<int, ft_event> &get_events() const noexcept;
 
+        void process_events(int ticks) noexcept;
+
         int save_to_file(const char *file_path, const ft_character &character, const ft_inventory &inventory) const noexcept;
         int load_from_file(const char *file_path, ft_character &character, ft_inventory &inventory) noexcept;
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The current suite exercises components across multiple modules:
 - **String**: `ft_string_view`
 - **JSon**: schema validation
 - **YAML**: round-trip parsing
-- **Game**: `ft_world::plan_route` and `ft_pathfinding`
+- **Game**: `ft_world::process_events`, `ft_world::plan_route` and `ft_pathfinding`
 - **Encryption**: key generation utilities
 
 Additional cases verify whitespace parsing, overlapping ranges, truncating copies, partial zeroing, empty needles,
@@ -1600,6 +1600,7 @@ void sub_modifier4(int mod) noexcept;
 ```
 ft_map<int, ft_event>       &get_events() noexcept;
 const ft_map<int, ft_event> &get_events() const noexcept;
+void process_events(int ticks) noexcept;
 int save_to_file(const char *file_path, const ft_character &character, const ft_inventory &inventory) const noexcept;
 int load_from_file(const char *file_path, ft_character &character, ft_inventory &inventory) noexcept;
 int plan_route(const ft_map3d &grid, size_t start_x, size_t start_y, size_t start_z, size_t goal_x, size_t goal_y, size_t goal_z, ft_vector<ft_path_step> &path) const noexcept;

--- a/Test/Test/test_game.cpp
+++ b/Test/Test/test_game.cpp
@@ -74,8 +74,9 @@ int test_game_simulation(void)
     meeting.set_id(1);
     meeting.set_duration(5);
     overworld.get_events().insert(meeting.get_id(), meeting);
+    overworld.process_events(1);
     Pair<int, ft_event>* eentry = overworld.get_events().find(1);
-    if (!eentry || eentry->value.get_duration() != 5)
+    if (!eentry || eentry->value.get_duration() != 4)
         return (0);
 
     ft_inventory pack(2);

--- a/Test/Test/test_world_events.cpp
+++ b/Test/Test/test_world_events.cpp
@@ -1,0 +1,23 @@
+#include "../../Game/world.hpp"
+#include "../../Game/event.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_world_process_events, "ft_world event expiration")
+{
+    ft_world world;
+    ft_event event;
+    event.set_id(1);
+    event.set_duration(3);
+    world.get_events().insert(event.get_id(), event);
+
+    world.process_events(1);
+    Pair<int, ft_event>* event_entry = world.get_events().find(1);
+    if (!event_entry || event_entry->value.get_duration() != 2)
+        return (0);
+
+    world.process_events(2);
+    if (world.get_events().find(1))
+        return (0);
+
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add `ft_world::process_events` to decrement event durations and purge expired events
- call `process_events` during game simulation and add dedicated event-expiration test
- document event processing in Game module

## Testing
- `make tests COMPILE_FLAGS="-Wall -Wextra -std=c++17"`
- `./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c58b56ce5883319d13654d3394e8bd