### PR TITLE
Add crafting system with recipe registry

### DIFF
--- a/Game/Makefile
+++ b/Game/Makefile
@@ -3,11 +3,11 @@ DEBUG_TARGET := Game_debug.a
 
 SRCS := game_map3d.cpp game_character.cpp game_quest.cpp game_achievement.cpp game_reputation.cpp game_buff.cpp game_debuff.cpp \
 game_upgrade.cpp game_event.cpp game_world.cpp game_item.cpp game_inventory.cpp game_equipment.cpp game_save.cpp game_load.cpp \
-game_experience_table.cpp game_pathfinding.cpp
+game_experience_table.cpp game_pathfinding.cpp game_crafting.cpp
 
 HEADERS := map3d.hpp character.hpp quest.hpp achievement.hpp reputation.hpp buff.hpp debuff.hpp \
    upgrade.hpp event.hpp world.hpp item.hpp inventory.hpp equipment.hpp \
-   experience_table.hpp pathfinding.hpp
+   experience_table.hpp pathfinding.hpp crafting.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Game/README
+++ b/Game/README
@@ -40,3 +40,16 @@ finder.astar_grid(grid, 0, 0, 0, 2, 2, 0, path);
 ft_world world;
 world.plan_route(grid, 0, 0, 0, 2, 2, 0, path);
 ```
+
+## Crafting
+
+`ft_crafting` stores crafting recipes and converts ingredients into new items.
+
+```
+ft_crafting crafting;
+ft_vector<int> ingredients;
+ingredients.push_back(1);
+ingredients.push_back(2);
+crafting.register_recipe(1, ft_move(ingredients));
+crafting.craft_item(inventory, 1, sword);
+```

--- a/Game/crafting.hpp
+++ b/Game/crafting.hpp
@@ -1,0 +1,32 @@
+#ifndef CRAFTING_HPP
+#define CRAFTING_HPP
+
+#include "../Template/map.hpp"
+#include "../Template/vector.hpp"
+#include "inventory.hpp"
+#include "item.hpp"
+#include "../Errno/errno.hpp"
+
+class ft_crafting
+{
+    private:
+        ft_map<int, ft_vector<int>> _recipes;
+        mutable int _error_code;
+
+        void set_error(int error_code) const noexcept;
+
+    public:
+        ft_crafting() noexcept;
+        virtual ~ft_crafting() = default;
+
+        ft_map<int, ft_vector<int>>       &get_recipes() noexcept;
+        const ft_map<int, ft_vector<int>> &get_recipes() const noexcept;
+
+        int  get_error() const noexcept;
+        const char *get_error_str() const noexcept;
+
+        int register_recipe(int recipe_id, ft_vector<int> &&ingredients) noexcept;
+        int craft_item(ft_inventory &inventory, int recipe_id, const ft_item &result) noexcept;
+};
+
+#endif

--- a/Game/game_crafting.cpp
+++ b/Game/game_crafting.cpp
@@ -1,0 +1,100 @@
+#include "crafting.hpp"
+
+ft_crafting::ft_crafting() noexcept
+    : _recipes(), _error_code(ER_SUCCESS)
+{
+    return ;
+}
+
+ft_map<int, ft_vector<int>> &ft_crafting::get_recipes() noexcept
+{
+    return (this->_recipes);
+}
+
+const ft_map<int, ft_vector<int>> &ft_crafting::get_recipes() const noexcept
+{
+    return (this->_recipes);
+}
+
+int ft_crafting::get_error() const noexcept
+{
+    return (this->_error_code);
+}
+
+const char *ft_crafting::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error_code));
+}
+
+void ft_crafting::set_error(int error_code) const noexcept
+{
+    ft_errno = error_code;
+    this->_error_code = error_code;
+    return ;
+}
+
+int ft_crafting::register_recipe(int recipe_id, ft_vector<int> &&ingredients) noexcept
+{
+    this->_error_code = ER_SUCCESS;
+    this->_recipes.insert(recipe_id, ft_move(ingredients));
+    if (this->_recipes.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_recipes.get_error());
+        return (this->_error_code);
+    }
+    return (ER_SUCCESS);
+}
+
+int ft_crafting::craft_item(ft_inventory &inventory, int recipe_id, const ft_item &result) noexcept
+{
+    this->_error_code = ER_SUCCESS;
+    Pair<int, ft_vector<int>> *recipe_entry = this->_recipes.find(recipe_id);
+    if (!recipe_entry)
+    {
+        this->set_error(GAME_GENERAL_ERROR);
+        return (GAME_GENERAL_ERROR);
+    }
+
+    ft_vector<int> &ingredients = recipe_entry->value;
+    size_t index = 0;
+    while (index < ingredients.size())
+    {
+        if (!inventory.has_item(ingredients[index]))
+        {
+            this->set_error(GAME_GENERAL_ERROR);
+            return (GAME_GENERAL_ERROR);
+        }
+        ++index;
+    }
+
+    index = 0;
+    while (index < ingredients.size())
+    {
+        int ingredient_id = ingredients[index];
+        ft_map<int, ft_item> &items = inventory.get_items();
+        Pair<int, ft_item> *item_ptr = items.end() - items.size();
+        Pair<int, ft_item> *item_end = items.end();
+        bool ingredient_removed = false;
+        while (item_ptr != item_end && ingredient_removed == false)
+        {
+            if (item_ptr->value.get_item_id() == ingredient_id)
+            {
+                item_ptr->value.sub_from_stack(1);
+                if (item_ptr->value.get_current_stack() == 0)
+                    items.remove(item_ptr->key);
+                ingredient_removed = true;
+            }
+            ++item_ptr;
+        }
+        ++index;
+    }
+
+    inventory.add_item(result);
+    if (inventory.get_error() != ER_SUCCESS)
+    {
+        this->set_error(inventory.get_error());
+        return (this->_error_code);
+    }
+    return (ER_SUCCESS);
+}
+

--- a/README.md
+++ b/README.md
@@ -1432,7 +1432,7 @@ xml_node *get_root() const noexcept;
 #### Game
 Basic game related classes include `ft_character`, `ft_item`, `ft_inventory`,
 `ft_equipment`, `ft_upgrade`, `ft_world`, `ft_event`, `ft_map3d`, `ft_quest`, `ft_reputation`,
-`ft_buff`, `ft_debuff`, `ft_achievement`, and `ft_experience_table`. Each class
+`ft_buff`, `ft_debuff`, `ft_achievement`, `ft_experience_table`, and `ft_crafting`. Each class
 is summarized below.
 
 #### `ft_character`
@@ -1757,6 +1757,16 @@ void set_progress(int id, int progress) noexcept;
 void add_progress(int id, int value) noexcept;
 bool is_goal_complete(int id) const noexcept;
 bool is_complete() const noexcept;
+```
+
+#### `ft_crafting`
+```
+ft_map<int, ft_vector<int>>       &get_recipes() noexcept;
+const ft_map<int, ft_vector<int>> &get_recipes() const noexcept;
+int register_recipe(int recipe_id, ft_vector<int> &&ingredients) noexcept;
+int craft_item(ft_inventory &inventory, int recipe_id, const ft_item &result) noexcept;
+int get_error() const noexcept;
+const char *get_error_str() const noexcept;
 ```
 
 #### `ft_experience_table`

--- a/Template/pair.hpp
+++ b/Template/pair.hpp
@@ -1,6 +1,8 @@
 #ifndef PAIR_HPP
 # define PAIR_HPP
 
+#include "move.hpp"
+
 template <typename KeyType, typename ValueType>
 struct Pair
 {
@@ -9,11 +11,19 @@ struct Pair
 
     Pair() = default;
     Pair(const KeyType &k, const ValueType &v);
+    Pair(const KeyType &k, ValueType &&v);
 };
 
 template <typename KeyType, typename ValueType>
 Pair<KeyType, ValueType>::Pair(const KeyType &k, const ValueType &v)
         : key(k), value(v)
+{
+    return ;
+}
+
+template <typename KeyType, typename ValueType>
+Pair<KeyType, ValueType>::Pair(const KeyType &k, ValueType &&v)
+        : key(k), value(ft_move(v))
 {
     return ;
 }

--- a/Test/Test/test_crafting.cpp
+++ b/Test/Test/test_crafting.cpp
@@ -1,0 +1,60 @@
+#include "../../Game/crafting.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_crafting_success, "crafting succeeds")
+{
+    ft_crafting crafting;
+    ft_vector<int> ingredients;
+    ingredients.push_back(1);
+    ingredients.push_back(2);
+    crafting.register_recipe(1, ft_move(ingredients));
+
+    ft_inventory inventory(5);
+    ft_item ingredient_one;
+    ingredient_one.set_item_id(1);
+    ingredient_one.set_max_stack(1);
+    ingredient_one.set_current_stack(1);
+    ft_item ingredient_two;
+    ingredient_two.set_item_id(2);
+    ingredient_two.set_max_stack(1);
+    ingredient_two.set_current_stack(1);
+    inventory.add_item(ingredient_one);
+    inventory.add_item(ingredient_two);
+
+    ft_item crafted;
+    crafted.set_item_id(3);
+    crafted.set_max_stack(1);
+    crafted.set_current_stack(1);
+
+    FT_ASSERT_EQ(ER_SUCCESS, crafting.craft_item(inventory, 1, crafted));
+    FT_ASSERT_EQ(1, inventory.count_item(3));
+    FT_ASSERT_EQ(0, inventory.count_item(1));
+    FT_ASSERT_EQ(0, inventory.count_item(2));
+    return (1);
+}
+
+FT_TEST(test_crafting_missing_ingredient, "crafting fails with missing ingredient")
+{
+    ft_crafting crafting;
+    ft_vector<int> ingredients;
+    ingredients.push_back(1);
+    ingredients.push_back(2);
+    crafting.register_recipe(1, ft_move(ingredients));
+
+    ft_inventory inventory(5);
+    ft_item ingredient_one;
+    ingredient_one.set_item_id(1);
+    ingredient_one.set_max_stack(1);
+    ingredient_one.set_current_stack(1);
+    inventory.add_item(ingredient_one);
+
+    ft_item crafted;
+    crafted.set_item_id(3);
+    crafted.set_max_stack(1);
+    crafted.set_current_stack(1);
+
+    FT_ASSERT_EQ(GAME_GENERAL_ERROR, crafting.craft_item(inventory, 1, crafted));
+    FT_ASSERT_EQ(0, inventory.count_item(3));
+    FT_ASSERT_EQ(1, inventory.count_item(1));
+    return (1);
+}


### PR DESCRIPTION
## Summary
- Introduce `ft_crafting` with a recipe registry mapping recipe IDs to ingredient lists
- Provide `craft_item` to consume ingredients from an inventory and add the crafted item
- Allow moving values into `ft_map` and `Pair` to support move-only types
- Document crafting and cover success and failure scenarios in tests

## Testing
- `make tests COMPILE_FLAGS="-Wall -Wextra -std=c++17"`
- `./Test/libft_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c58ea445948331b6197f2aa6c5b539