### PR TITLE
Add separate armor types and damage calculations

### DIFF
--- a/Game/character.hpp
+++ b/Game/character.hpp
@@ -11,6 +11,14 @@
 #include "inventory.hpp"
 #include "equipment.hpp"
 #include "experience_table.hpp"
+#include <cstdint>
+
+#define FT_DAMAGE_PHYSICAL 0
+#define FT_DAMAGE_MAGICAL 1
+#define FT_ARMOR_POINT_REDUCTION 0.95
+#define FT_DAMAGE_RULE_FLAT 0
+#define FT_DAMAGE_RULE_SCALED 1
+#define FT_DAMAGE_RULE_BUFFER 2
 
 struct json_group;
 
@@ -24,7 +32,13 @@ class ft_character
 {
     protected:
         int _hit_points;
-        int _armor;
+        int _physical_armor;
+        int _magic_armor;
+        int _current_physical_armor;
+        int _current_magic_armor;
+        double _physical_damage_multiplier;
+        double _magic_damage_multiplier;
+        uint8_t _damage_rule;
         int _might;
         int _agility;
         int _endurance;
@@ -68,8 +82,23 @@ class ft_character
 
         bool is_alive() const noexcept;
 
-        int get_armor() const noexcept;
-        void set_armor(int armor) noexcept;
+        int get_physical_armor() const noexcept;
+        void set_physical_armor(int armor) noexcept;
+        int get_magic_armor() const noexcept;
+        void set_magic_armor(int armor) noexcept;
+        int get_current_physical_armor() const noexcept;
+        void set_current_physical_armor(int armor) noexcept;
+        int get_current_magic_armor() const noexcept;
+        void set_current_magic_armor(int armor) noexcept;
+        void restore_physical_armor() noexcept;
+        void restore_magic_armor() noexcept;
+        void restore_armor() noexcept;
+        void set_damage_rule(uint8_t rule) noexcept;
+        uint8_t get_damage_rule() const noexcept;
+        void take_damage(long long damage, uint8_t type) noexcept;
+        void take_damage_flat(long long damage, uint8_t type) noexcept;
+        void take_damage_scaled(long long damage, uint8_t type) noexcept;
+        void take_damage_buffer(long long damage, uint8_t type) noexcept;
 
         int get_might() const noexcept;
         void set_might(int might) noexcept;

--- a/README.md
+++ b/README.md
@@ -1501,12 +1501,30 @@ crafting.craft_item(inventory, 1, sword);
 ```
 
 #### `ft_character`
+Use `FT_DAMAGE_PHYSICAL` or `FT_DAMAGE_MAGICAL` to tag incoming damage and
+select the handling method with `FT_DAMAGE_RULE_FLAT`,
+`FT_DAMAGE_RULE_SCALED`, or `FT_DAMAGE_RULE_BUFFER`.
 ```
 int get_hit_points() const noexcept;
 void set_hit_points(int hp) noexcept;
 bool is_alive() const noexcept;
-int get_armor() const noexcept;
-void set_armor(int armor) noexcept;
+int get_physical_armor() const noexcept;
+void set_physical_armor(int armor) noexcept;
+int get_magic_armor() const noexcept;
+void set_magic_armor(int armor) noexcept;
+int get_current_physical_armor() const noexcept;
+void set_current_physical_armor(int armor) noexcept;
+int get_current_magic_armor() const noexcept;
+void set_current_magic_armor(int armor) noexcept;
+void restore_physical_armor() noexcept;
+void restore_magic_armor() noexcept;
+void restore_armor() noexcept;
+void set_damage_rule(uint8_t rule) noexcept;
+uint8_t get_damage_rule() const noexcept;
+void take_damage(long long damage, uint8_t type) noexcept;
+void take_damage_flat(long long damage, uint8_t type) noexcept;
+void take_damage_scaled(long long damage, uint8_t type) noexcept;
+void take_damage_buffer(long long damage, uint8_t type) noexcept;
 int get_might() const noexcept;
 void set_might(int might) noexcept;
 int get_agility() const noexcept;

--- a/Test/Test/test_equipment.cpp
+++ b/Test/Test/test_equipment.cpp
@@ -12,7 +12,7 @@ FT_TEST(test_equipment_equip, "equip item increases stats")
     helm.set_modifier1_id(1);
     helm.set_modifier1_value(5);
     FT_ASSERT_EQ(ER_SUCCESS, hero.equip_item(EQUIP_HEAD, helm));
-    FT_ASSERT_EQ(5, hero.get_armor());
+    FT_ASSERT_EQ(5, hero.get_physical_armor());
     const ft_item *found = hero.get_equipped_item(EQUIP_HEAD);
     FT_ASSERT(found != ft_nullptr);
     return (1);
@@ -27,7 +27,7 @@ FT_TEST(test_equipment_unequip, "unequip removes stats")
     helm.set_modifier1_value(5);
     hero.equip_item(EQUIP_HEAD, helm);
     hero.unequip_item(EQUIP_HEAD);
-    FT_ASSERT_EQ(0, hero.get_armor());
+    FT_ASSERT_EQ(0, hero.get_physical_armor());
     FT_ASSERT(hero.get_equipped_item(EQUIP_HEAD) == ft_nullptr);
     return (1);
 }


### PR DESCRIPTION
## Summary
- Allow selecting combat rules with macros and setters, including per-type armor restoration helpers
- Serialize current armor and combat rule in character save data
- Test individual armor restoration and combat rule persistence

## Testing
- `make tests`
- `./Test/libft_tests`


------
https://chatgpt.com/codex/tasks/task_e_68c5a0585e6c83319e783476040eb549