### PR TITLE
Add statistical math helpers

### DIFF
--- a/Math/Makefile
+++ b/Math/Makefile
@@ -24,6 +24,7 @@ SRCS := math_abs.cpp \
         math_tan.cpp \
         math_deg2rad.cpp \
         math_rad2deg.cpp \
+        math_statistics.cpp \
         math_roll.cpp \
         math_eval.cpp \
         math_roll_utilities.cpp \

--- a/Math/math.hpp
+++ b/Math/math.hpp
@@ -45,6 +45,11 @@ double      ft_tan(double value);
 double      math_deg2rad(double degrees);
 int         math_validate_int(const char *input);
 double      math_rad2deg(double radians);
+double      ft_mean(const double *values, int array_size);
+double      ft_median(const double *values, int array_size);
+double      ft_mode(const double *values, int array_size);
+double      ft_variance(const double *values, int array_size);
+double      ft_stddev(const double *values, int array_size);
 
 # include "linear_algebra.hpp"
 

--- a/Math/math_statistics.cpp
+++ b/Math/math_statistics.cpp
@@ -1,0 +1,144 @@
+#include "math.hpp"
+
+static void copy_array(double *destination, const double *source, int array_size)
+{
+    int array_index;
+
+    array_index = 0;
+    while (array_index < array_size)
+    {
+        destination[array_index] = source[array_index];
+        array_index++;
+    }
+    return ;
+}
+
+static void sort_array(double *array, int array_size)
+{
+    int outer_index;
+    int inner_index;
+    double temporary_value;
+
+    outer_index = 0;
+    while (outer_index < array_size - 1)
+    {
+        inner_index = 0;
+        while (inner_index < array_size - outer_index - 1)
+        {
+            if (array[inner_index] > array[inner_index + 1])
+            {
+                temporary_value = array[inner_index];
+                array[inner_index] = array[inner_index + 1];
+                array[inner_index + 1] = temporary_value;
+            }
+            inner_index++;
+        }
+        outer_index++;
+    }
+    return ;
+}
+
+double ft_mean(const double *values, int array_size)
+{
+    int array_index;
+    double sum;
+
+    if (array_size <= 0)
+        return (0.0);
+    array_index = 0;
+    sum = 0.0;
+    while (array_index < array_size)
+    {
+        sum += values[array_index];
+        array_index++;
+    }
+    return (sum / array_size);
+}
+
+double ft_median(const double *values, int array_size)
+{
+    double *sorted_values;
+    double median_value;
+    double temporary_array[2];
+
+    if (array_size <= 0)
+        return (0.0);
+    sorted_values = new double[array_size];
+    copy_array(sorted_values, values, array_size);
+    sort_array(sorted_values, array_size);
+    if (array_size % 2 == 1)
+        median_value = sorted_values[array_size / 2];
+    else
+    {
+        temporary_array[0] = sorted_values[array_size / 2 - 1];
+        temporary_array[1] = sorted_values[array_size / 2];
+        median_value = ft_mean(temporary_array, 2);
+    }
+    delete [] sorted_values;
+    return (median_value);
+}
+
+double ft_mode(const double *values, int array_size)
+{
+    double *sorted_values;
+    int array_index;
+    int current_count;
+    int best_count;
+    double mode_value;
+
+    if (array_size <= 0)
+        return (0.0);
+    sorted_values = new double[array_size];
+    copy_array(sorted_values, values, array_size);
+    sort_array(sorted_values, array_size);
+    array_index = 1;
+    current_count = 1;
+    best_count = 1;
+    mode_value = sorted_values[0];
+    while (array_index < array_size)
+    {
+        if (sorted_values[array_index] == sorted_values[array_index - 1])
+        {
+            current_count++;
+            if (current_count > best_count)
+            {
+                best_count = current_count;
+                mode_value = sorted_values[array_index];
+            }
+        }
+        else
+            current_count = 1;
+        array_index++;
+    }
+    delete [] sorted_values;
+    return (mode_value);
+}
+
+double ft_variance(const double *values, int array_size)
+{
+    int array_index;
+    double mean_value;
+    double sum;
+    double difference;
+
+    if (array_size <= 0)
+        return (0.0);
+    mean_value = ft_mean(values, array_size);
+    array_index = 0;
+    sum = 0.0;
+    while (array_index < array_size)
+    {
+        difference = values[array_index] - mean_value;
+        sum += difference * difference;
+        array_index++;
+    }
+    return (sum / array_size);
+}
+
+double ft_stddev(const double *values, int array_size)
+{
+    double variance_value;
+
+    variance_value = ft_variance(values, array_size);
+    return (math_sqrt(variance_value));
+}

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ double      ft_tan(double value);
 double      math_deg2rad(double degrees);
 int         math_validate_int(const char *input);
 double      math_rad2deg(double radians);
+double      ft_mean(const double *values, int array_size);
+double      ft_median(const double *values, int array_size);
+double      ft_mode(const double *values, int array_size);
+double      ft_variance(const double *values, int array_size);
+double      ft_stddev(const double *values, int array_size);
 ```
 
 Example usage:
@@ -178,6 +183,12 @@ Example usage:
 ```
 double sine = ft_sin(math_deg2rad(90.0));
 double tangent = ft_tan(math_deg2rad(45.0));
+double numbers[] = {1.0, 2.0, 2.0, 3.0};
+double mean = ft_mean(numbers, 4);
+double median = ft_median(numbers, 4);
+double mode = ft_mode(numbers, 4);
+double variance = ft_variance(numbers, 4);
+double standard_deviation = ft_stddev(numbers, 4);
 ```
 
 Basic linear algebra types are provided in `linear_algebra.hpp`.


### PR DESCRIPTION
## Summary
- add mean, median, mode, variance, and standard deviation utilities for numeric arrays
- expose statistics APIs directly from the main math header and adjust build configuration
- document statistics helpers with examples

## Testing
- `make -C Math`


------
https://chatgpt.com/codex/tasks/task_e_68c5ac2a02448331b6d569fe1717a2c3