### PR TITLE
Add time parsing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,8 @@ void    time_sleep(unsigned int seconds);
 void    time_sleep_ms(unsigned int milliseconds);
 size_t  time_strftime(char *buffer, size_t size, const char *format, const t_time_info *time_info);
 ft_string    time_format_iso8601(t_time time_value);
+bool    time_parse_iso8601(const char *string_input, std::tm *time_output, t_time *timestamp_output);
+bool    time_parse_custom(const char *string_input, const char *format, std::tm *time_output, t_time *timestamp_output);
 ```
 
 `t_time` stores seconds since the Unix epoch and `t_time_info` holds the broken-down components.
@@ -1198,6 +1200,15 @@ Example:
 ```
 ft_string timestamp = time_format_iso8601(0);
 // timestamp == "1970-01-01T00:00:00Z"
+
+t_time parsed_epoch;
+if (time_parse_iso8601("1970-01-01T00:00:00Z", NULL, &parsed_epoch))
+{
+    // parsed_epoch == 0
+}
+
+std::tm time_data;
+time_parse_custom("1970/01/01", "%Y/%m/%d", &time_data, NULL);
 ```
 
 `timer.hpp` defines a small timer class:

--- a/Time/Makefile
+++ b/Time/Makefile
@@ -10,7 +10,8 @@ SRCS := time_now.cpp \
         time_fps.cpp \
         time_timer.cpp \
         time_strftime.cpp \
-        time_format.cpp
+        time_format.cpp \
+        time_parse.cpp
 
 HEADERS := time.hpp \
            fps.hpp \

--- a/Time/time.hpp
+++ b/Time/time.hpp
@@ -2,6 +2,7 @@
 # define TIME_HPP
 
 #include <cstddef>
+#include <ctime>
 #include "../CPP_class/class_string_class.hpp"
 
 typedef long t_time;
@@ -27,5 +28,7 @@ void    time_sleep(unsigned int seconds);
 void    time_sleep_ms(unsigned int milliseconds);
 size_t  time_strftime(char *buffer, size_t size, const char *format, const t_time_info *time_info);
 ft_string    time_format_iso8601(t_time time_value);
+bool    time_parse_iso8601(const char *string_input, std::tm *time_output, t_time *timestamp_output);
+bool    time_parse_custom(const char *string_input, const char *format, std::tm *time_output, t_time *timestamp_output);
 
 #endif

--- a/Time/time_parse.cpp
+++ b/Time/time_parse.cpp
@@ -1,0 +1,71 @@
+#include "time.hpp"
+#include <ctime>
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+#include <iomanip>
+
+bool    time_parse_iso8601(const char *string_input, std::tm *time_output, t_time *timestamp_output)
+{
+    std::tm parsed_time;
+    int year;
+    int month;
+    int day;
+    int hours;
+    int minutes;
+    int seconds;
+    char timezone_character;
+    std::time_t epoch_time;
+
+    if (!string_input)
+        return (false);
+    std::memset(&parsed_time, 0, sizeof(parsed_time));
+    if (std::sscanf(string_input, "%d-%d-%dT%d:%d:%d%c", &year, &month, &day, &hours, &minutes, &seconds, &timezone_character) != 7)
+        return (false);
+    if (timezone_character != 'Z')
+        return (false);
+    parsed_time.tm_year = year - 1900;
+    parsed_time.tm_mon = month - 1;
+    parsed_time.tm_mday = day;
+    parsed_time.tm_hour = hours;
+    parsed_time.tm_min = minutes;
+    parsed_time.tm_sec = seconds;
+    parsed_time.tm_isdst = 0;
+    if (time_output)
+        *time_output = parsed_time;
+    if (timestamp_output)
+    {
+        epoch_time = std::mktime(&parsed_time);
+        if (epoch_time == static_cast<std::time_t>(-1))
+            return (false);
+        *timestamp_output = static_cast<t_time>(epoch_time);
+    }
+    return (true);
+}
+
+bool    time_parse_custom(const char *string_input, const char *format, std::tm *time_output, t_time *timestamp_output)
+{
+    std::tm parsed_time;
+    std::istringstream input_stream;
+    std::time_t epoch_time;
+
+    if (!string_input || !format)
+        return (false);
+    std::memset(&parsed_time, 0, sizeof(parsed_time));
+    input_stream.str(string_input);
+    input_stream >> std::get_time(&parsed_time, format);
+    if (input_stream.fail())
+        return (false);
+    parsed_time.tm_isdst = 0;
+    if (time_output)
+        *time_output = parsed_time;
+    if (timestamp_output)
+    {
+        epoch_time = std::mktime(&parsed_time);
+        if (epoch_time == static_cast<std::time_t>(-1))
+            return (false);
+        *timestamp_output = static_cast<t_time>(epoch_time);
+    }
+    return (true);
+}
+


### PR DESCRIPTION
## Summary
- parse ISO8601 time strings into `std::tm` or epoch seconds
- parse custom-formatted time strings with a user format
- document time parsing helpers

## Testing
- `make -C Time`


------
https://chatgpt.com/codex/tasks/task_e_68c5b6ab6288833197c1a6f65b0a30dd