### PR TITLE
Add JSON-backed key-value storage module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ SUBDIRS :=  CMA \
             Networking \
             API \
              Compatebility \
-             Compression Encryption RNG JSon YAML File HTML Game Time XML Concurrency
+             Compression Encryption RNG JSon YAML File HTML Game Time XML Concurrency Storage
 
 LIB_BASES := \
   CMA/CustomMemoryAllocator \
@@ -75,7 +75,8 @@ LIB_BASES := \
   Game/Game \
   Time/time \
   XML/XMLParser \
-  Concurrency/Concurrency
+  Concurrency/Concurrency \
+  Storage/storage
 
 LIBS       := $(addsuffix .a, $(LIB_BASES))
 DEBUG_LIBS := $(addsuffix _debug.a, $(LIB_BASES))

--- a/README.md
+++ b/README.md
@@ -1165,6 +1165,30 @@ long    su_ftell(su_file *stream);
 `System_utils_file_open.cpp`, `System_utils_file_io.cpp` and
 `System_utils_file_stream.cpp` contain the implementations, keeping each source
 file focused and small.
+#### Storage
+`Storage/kv_store.hpp` offers a lightweight JSON-backed key-value database:
+
+```
+int kv_set(const char *key_string, const char *value_string);
+const char *kv_get(const char *key_string) const;
+int kv_delete(const char *key_string);
+int kv_flush() const;
+```
+
+Create an instance with the path to a JSON file. Values are kept in memory
+until `kv_flush` writes them to disk.
+
+```
+kv_store store("data.json");
+store.kv_set("theme", "dark");
+const char *theme = store.kv_get("theme");
+store.kv_delete("unused");
+store.kv_flush();
+```
+
+Errors set the thread-local `ft_errno` and are accessible through `get_error`
+and `get_error_str`.
+
 #### Config
 `Config/config.hpp` parses simple configuration files:
 

--- a/Storage/Makefile
+++ b/Storage/Makefile
@@ -1,0 +1,70 @@
+TARGET         := storage.a
+DEBUG_TARGET   := storage_debug.a
+
+SRCS := storage_kv_store.cpp
+
+HEADERS := kv_store.hpp
+
+ifeq ($(OS),Windows_NT)
+    MKDIR   = mkdir
+    RM      = del /F /Q
+else
+    MKDIR   = mkdir -p
+    RM      = rm -f
+endif
+
+ifdef COMPILE_FLAGS
+    CFLAGS := $(COMPILE_FLAGS)
+endif
+
+CXX       := g++
+AR        := ar
+ARFLAGS   := rcs
+
+OBJDIR         := objs
+DEBUG_OBJDIR   := objs_debug
+
+OBJS       := $(patsubst %.cpp,$(OBJDIR)/%.o,$(SRCS))
+DEBUG_OBJS := $(patsubst %.cpp,$(DEBUG_OBJDIR)/%.o,$(SRCS))
+
+CFLAGS   ?= -Wall -Wextra -Werror -g -O0 -std=c++17
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJDIR)/%.o: %.cpp $(HEADERS) | $(OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+debug: CXXFLAGS += -DDEBUG=1
+debug: $(DEBUG_TARGET)
+
+$(DEBUG_TARGET): $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(DEBUG_OBJDIR)/%.o: %.cpp $(HEADERS) | $(DEBUG_OBJDIR)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR) $(DEBUG_OBJDIR):
+	$(MKDIR) $@
+
+CLEAN_OBJS := $(wildcard $(OBJDIR)/*.o) $(wildcard $(DEBUG_OBJDIR)/*.o)
+
+ifeq ($(OS),Windows_NT)
+    CLEAN_FILES := $(subst /,\\,$(CLEAN_OBJS))
+else
+    CLEAN_FILES := $(CLEAN_OBJS)
+endif
+
+clean:
+	-$(RM) $(CLEAN_FILES)
+
+fclean: clean
+	-$(RM) $(TARGET) $(DEBUG_TARGET)
+
+re: fclean all
+
+both: all debug
+
+.PHONY: all clean fclean re debug both

--- a/Storage/kv_store.hpp
+++ b/Storage/kv_store.hpp
@@ -1,0 +1,31 @@
+#ifndef KV_STORE_HPP
+#define KV_STORE_HPP
+
+#include "../Errno/errno.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../JSon/json.hpp"
+#include <map>
+#include <string>
+
+class kv_store
+{
+    private:
+        std::map<std::string, std::string> _data;
+        std::string _file_path;
+        mutable int _error_code;
+
+        void set_error(int error_code) const;
+
+    public:
+        kv_store(const char *file_path);
+        ~kv_store();
+
+        int kv_set(const char *key_string, const char *value_string);
+        const char *kv_get(const char *key_string) const;
+        int kv_delete(const char *key_string);
+        int kv_flush() const;
+        int get_error() const;
+        const char *get_error_str() const;
+};
+
+#endif

--- a/Storage/storage_kv_store.cpp
+++ b/Storage/storage_kv_store.cpp
@@ -1,0 +1,136 @@
+#include "kv_store.hpp"
+
+kv_store::kv_store(const char *file_path)
+    : _data(), _file_path(file_path), _error_code(ER_SUCCESS)
+{
+    json_group *group_head;
+    json_group *store_group;
+    json_item *item_pointer;
+
+    group_head = json_read_from_file(file_path);
+    if (group_head != ft_nullptr)
+    {
+        store_group = json_find_group(group_head, "kv_store");
+        if (store_group != ft_nullptr)
+        {
+            item_pointer = store_group->items;
+            while (item_pointer != ft_nullptr)
+            {
+                this->_data[item_pointer->key] = item_pointer->value;
+                item_pointer = item_pointer->next;
+            }
+        }
+        json_free_groups(group_head);
+    }
+    return ;
+}
+
+kv_store::~kv_store()
+{
+    return ;
+}
+
+void kv_store::set_error(int error_code) const
+{
+    this->_error_code = error_code;
+    ft_errno = error_code;
+    return ;
+}
+
+int kv_store::kv_set(const char *key_string, const char *value_string)
+{
+    if (key_string == ft_nullptr || value_string == ft_nullptr)
+    {
+        this->set_error(FT_EINVAL);
+        return (-1);
+    }
+    this->_data[key_string] = value_string;
+    return (0);
+}
+
+const char *kv_store::kv_get(const char *key_string) const
+{
+    std::map<std::string, std::string>::const_iterator map_iterator;
+
+    if (key_string == ft_nullptr)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    map_iterator = this->_data.find(key_string);
+    if (map_iterator == this->_data.end())
+    {
+        this->set_error(MAP_KEY_NOT_FOUND);
+        return (ft_nullptr);
+    }
+    return (map_iterator->second.c_str());
+}
+
+int kv_store::kv_delete(const char *key_string)
+{
+    std::map<std::string, std::string>::iterator map_iterator;
+
+    if (key_string == ft_nullptr)
+    {
+        this->set_error(FT_EINVAL);
+        return (-1);
+    }
+    map_iterator = this->_data.find(key_string);
+    if (map_iterator == this->_data.end())
+    {
+        this->set_error(MAP_KEY_NOT_FOUND);
+        return (-1);
+    }
+    this->_data.erase(map_iterator);
+    return (0);
+}
+
+int kv_store::kv_flush() const
+{
+    json_group *store_group;
+    json_group *head_group;
+    json_item *item_pointer;
+    std::map<std::string, std::string>::const_iterator map_iterator;
+    int result;
+
+    store_group = json_create_json_group("kv_store");
+    if (store_group == ft_nullptr)
+    {
+        this->set_error(JSON_MALLOC_FAIL);
+        return (-1);
+    }
+    map_iterator = this->_data.begin();
+    while (map_iterator != this->_data.end())
+    {
+        item_pointer = json_create_item(map_iterator->first.c_str(), map_iterator->second.c_str());
+        if (item_pointer == ft_nullptr)
+        {
+            json_free_groups(store_group);
+            this->set_error(JSON_MALLOC_FAIL);
+            return (-1);
+        }
+        json_add_item_to_group(store_group, item_pointer);
+        ++map_iterator;
+    }
+    head_group = ft_nullptr;
+    json_append_group(&head_group, store_group);
+    result = json_write_to_file(this->_file_path.c_str(), head_group);
+    json_free_groups(head_group);
+    if (result != 0)
+    {
+        this->set_error(result);
+        return (-1);
+    }
+    return (0);
+}
+
+int kv_store::get_error() const
+{
+    return (this->_error_code);
+}
+
+const char *kv_store::get_error_str() const
+{
+    return (ft_strerror(this->_error_code));
+}
+


### PR DESCRIPTION
## Summary
- add Storage module with kv_store class for JSON-based key/value persistence
- document Storage module usage and configuration in README
- wire Storage into build system

## Testing
- `make -C Storage`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_68c5d5b05ec48331b33f27d6bdae2db8