### PR TITLE
Add client tracking and auth to game server

### DIFF
--- a/Game/game_server.hpp
+++ b/Game/game_server.hpp
@@ -5,6 +5,7 @@
 #include "game_event.hpp"
 #include "../Networking/websocket_server.hpp"
 #include "../JSon/json.hpp"
+#include "../Template/map.hpp"
 #include "../CPP_class/class_string_class.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../Libft/libft.hpp"
@@ -15,19 +16,28 @@ class ft_game_server
     private:
         ft_websocket_server _server;
         ft_world           *_world;
+        ft_map<int, int>   _clients;
+        ft_string          _auth_token;
+        void              (*_on_join)(int);
+        void              (*_on_leave)(int);
         mutable int         _error_code;
 
         void set_error(int error) const noexcept;
-        int handle_message(const ft_string &message) noexcept;
+        int handle_message(int client_handle, const ft_string &message) noexcept;
         int serialize_world(ft_string &out) const noexcept;
+        void join_client(int client_id, int client_handle) noexcept;
+        void leave_client(int client_id) noexcept;
 
     public:
-        ft_game_server(ft_world &world) noexcept;
+        ft_game_server(ft_world &world, const char *auth_token = ft_nullptr) noexcept;
         ~ft_game_server();
         ft_game_server(const ft_game_server &other) noexcept;
         ft_game_server &operator=(const ft_game_server &other) noexcept;
         ft_game_server(ft_game_server &&other) noexcept;
         ft_game_server &operator=(ft_game_server &&other) noexcept;
+
+        void set_join_callback(void (*callback)(int)) noexcept;
+        void set_leave_callback(void (*callback)(int)) noexcept;
 
         int start(const char *ip, uint16_t port) noexcept;
         void run_once() noexcept;

--- a/Networking/websocket_server.hpp
+++ b/Networking/websocket_server.hpp
@@ -27,7 +27,8 @@ class ft_websocket_server
         ~ft_websocket_server();
 
         int start(const char *ip, uint16_t port, int address_family = AF_INET, bool non_blocking = false);
-        int run_once(ft_string &message);
+        int run_once(int &client_fd, ft_string &message);
+        int send_text(int client_fd, const ft_string &message);
         int get_error() const;
         const char *get_error_str() const;
 };


### PR DESCRIPTION
## Summary
- Track connected WebSocket clients in game server and support join/leave callbacks
- Add optional authentication token validation for joining clients
- Broadcast serialized world state to all clients using new WebSocket send helpers

## Testing
- `make -C Networking clean && make`
- `make -C Game clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68c708b73bc88331b441395de7e108fa