### PR TITLE
Add matrix factories and vector arithmetic helpers

### DIFF
--- a/Math/linear_algebra.cpp
+++ b/Math/linear_algebra.cpp
@@ -254,6 +254,76 @@ matrix4 matrix4::invert() const
     return (result);
 }
 
+matrix4 matrix4::make_translation(double x, double y, double z)
+{
+    matrix4 result;
+
+    result._m[0][3] = x;
+    result._m[1][3] = y;
+    result._m[2][3] = z;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+matrix4 matrix4::make_scale(double x, double y, double z)
+{
+    matrix4 result;
+
+    result._m[0][0] = x;
+    result._m[1][1] = y;
+    result._m[2][2] = z;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+matrix4 matrix4::make_rotation_x(double angle)
+{
+    double cos_angle;
+    double sin_angle;
+    matrix4 result;
+
+    cos_angle = math_cos(angle);
+    sin_angle = ft_sin(angle);
+    result._m[1][1] = cos_angle;
+    result._m[1][2] = -sin_angle;
+    result._m[2][1] = sin_angle;
+    result._m[2][2] = cos_angle;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+matrix4 matrix4::make_rotation_y(double angle)
+{
+    double cos_angle;
+    double sin_angle;
+    matrix4 result;
+
+    cos_angle = math_cos(angle);
+    sin_angle = ft_sin(angle);
+    result._m[0][0] = cos_angle;
+    result._m[0][2] = sin_angle;
+    result._m[2][0] = -sin_angle;
+    result._m[2][2] = cos_angle;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
+matrix4 matrix4::make_rotation_z(double angle)
+{
+    double cos_angle;
+    double sin_angle;
+    matrix4 result;
+
+    cos_angle = math_cos(angle);
+    sin_angle = ft_sin(angle);
+    result._m[0][0] = cos_angle;
+    result._m[0][1] = -sin_angle;
+    result._m[1][0] = sin_angle;
+    result._m[1][1] = cos_angle;
+    result.set_error(ER_SUCCESS);
+    return (result);
+}
+
 void    matrix4::set_error(int error_code) const
 {
     ft_errno = error_code;

--- a/Math/linear_algebra.hpp
+++ b/Math/linear_algebra.hpp
@@ -16,6 +16,8 @@ class vector2
         ~vector2();
         double  get_x() const;
         double  get_y() const;
+        vector2 add(const vector2 &other) const;
+        vector2 subtract(const vector2 &other) const;
         double  dot(const vector2 &other) const;
         double  length() const;
         vector2 normalize() const;
@@ -40,6 +42,8 @@ class vector3
         double  get_x() const;
         double  get_y() const;
         double  get_z() const;
+        vector3 add(const vector3 &other) const;
+        vector3 subtract(const vector3 &other) const;
         double  dot(const vector3 &other) const;
         vector3 cross(const vector3 &other) const;
         double  length() const;
@@ -67,6 +71,8 @@ class vector4
         double  get_y() const;
         double  get_z() const;
         double  get_w() const;
+        vector4 add(const vector4 &other) const;
+        vector4 subtract(const vector4 &other) const;
         double  dot(const vector4 &other) const;
         double  length() const;
         vector4 normalize() const;
@@ -130,6 +136,11 @@ class matrix4
                 double m20, double m21, double m22, double m23,
                 double m30, double m31, double m32, double m33);
         ~matrix4();
+        static matrix4 make_translation(double x, double y, double z);
+        static matrix4 make_scale(double x, double y, double z);
+        static matrix4 make_rotation_x(double angle);
+        static matrix4 make_rotation_y(double angle);
+        static matrix4 make_rotation_z(double angle);
         vector4 transform(const vector4 &vector) const;
         matrix4 multiply(const matrix4 &other) const;
         matrix4 invert() const;

--- a/Math/linear_algebra_vector2.cpp
+++ b/Math/linear_algebra_vector2.cpp
@@ -12,6 +12,28 @@ double  vector2::get_y() const
     return (this->_y);
 }
 
+vector2 vector2::add(const vector2 &other) const
+{
+    vector2 result;
+
+    result._x = this->_x + other._x;
+    result._y = this->_y + other._y;
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
+vector2 vector2::subtract(const vector2 &other) const
+{
+    vector2 result;
+
+    result._x = this->_x - other._x;
+    result._y = this->_y - other._y;
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
 double  vector2::dot(const vector2 &other) const
 {
     this->set_error(ER_SUCCESS);

--- a/Math/linear_algebra_vector3.cpp
+++ b/Math/linear_algebra_vector3.cpp
@@ -17,6 +17,30 @@ double  vector3::get_z() const
     return (this->_z);
 }
 
+vector3 vector3::add(const vector3 &other) const
+{
+    vector3 result;
+
+    result._x = this->_x + other._x;
+    result._y = this->_y + other._y;
+    result._z = this->_z + other._z;
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
+vector3 vector3::subtract(const vector3 &other) const
+{
+    vector3 result;
+
+    result._x = this->_x - other._x;
+    result._y = this->_y - other._y;
+    result._z = this->_z - other._z;
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
 double  vector3::dot(const vector3 &other) const
 {
     this->set_error(ER_SUCCESS);

--- a/Math/linear_algebra_vector4.cpp
+++ b/Math/linear_algebra_vector4.cpp
@@ -22,6 +22,32 @@ double  vector4::get_w() const
     return (this->_w);
 }
 
+vector4 vector4::add(const vector4 &other) const
+{
+    vector4 result;
+
+    result._x = this->_x + other._x;
+    result._y = this->_y + other._y;
+    result._z = this->_z + other._z;
+    result._w = this->_w + other._w;
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
+vector4 vector4::subtract(const vector4 &other) const
+{
+    vector4 result;
+
+    result._x = this->_x - other._x;
+    result._y = this->_y - other._y;
+    result._z = this->_z - other._z;
+    result._w = this->_w - other._w;
+    result.set_error(ER_SUCCESS);
+    this->set_error(ER_SUCCESS);
+    return (result);
+}
+
 double  vector4::dot(const vector4 &other) const
 {
     this->set_error(ER_SUCCESS);

--- a/README.md
+++ b/README.md
@@ -200,17 +200,23 @@ shared constructors and destructors for clarity:
 
 ```
 vector2(double x, double y);
+vector2 add(const vector2 &other) const;
+vector2 subtract(const vector2 &other) const;
 double dot(const vector2 &other) const;
 double length() const;
 vector2 normalize() const;
 
 vector3(double x, double y, double z);
 vector3 cross(const vector3 &other) const;
+vector3 add(const vector3 &other) const;
+vector3 subtract(const vector3 &other) const;
 double dot(const vector3 &other) const;
 double length() const;
 vector3 normalize() const;
 
 vector4(double x, double y, double z, double w);
+vector4 add(const vector4 &other) const;
+vector4 subtract(const vector4 &other) const;
 double dot(const vector4 &other) const;
 double length() const;
 vector4 normalize() const;
@@ -235,6 +241,11 @@ matrix4(double m00, double m01, double m02, double m03,
         double m10, double m11, double m12, double m13,
         double m20, double m21, double m22, double m23,
         double m30, double m31, double m32, double m33);
+static matrix4 make_translation(double x, double y, double z);
+static matrix4 make_scale(double x, double y, double z);
+static matrix4 make_rotation_x(double angle);
+static matrix4 make_rotation_y(double angle);
+static matrix4 make_rotation_z(double angle);
 matrix4 multiply(const matrix4 &other) const;
 matrix4 invert() const;
 vector4 transform(const vector4 &vector) const;
@@ -248,6 +259,18 @@ quaternion normalize() const;
 ```
 
 Normalization routines treat near-zero lengths as invalid using an epsilon check.
+
+Basic transformations can be built with the matrix factories and combined with
+vector utilities:
+
+```
+vector3 position(1.0, 2.0, 3.0);
+vector3 offset(0.5, 0.0, -1.0);
+vector3 moved = position.add(offset);
+matrix4 translation = matrix4::make_translation(0.5, 0.0, -1.0);
+vector4 homogenous(moved.get_x(), moved.get_y(), moved.get_z(), 1.0);
+vector4 transformed = translation.transform(homogenous);
+```
 
 Additional helpers for parsing expressions are available. They allocate a
 single `int` holding the result, which the caller must release with


### PR DESCRIPTION
## Summary
- add vector addition and subtraction utilities
- implement matrix4 translation, scale, and rotation factories
- document linear algebra helpers and usage

## Testing
- `make -C Math`


------
https://chatgpt.com/codex/tasks/task_e_68c7aa0882ac83319ff85b89edbcfc9f