### PR TITLE
Add event cancellation and rescheduling to scheduler

### DIFF
--- a/Game/game_event_scheduler.hpp
+++ b/Game/game_event_scheduler.hpp
@@ -34,7 +34,9 @@ class ft_event_scheduler
         ft_event_scheduler &operator=(ft_event_scheduler &&other) noexcept;
 
         void schedule_event(const ft_sharedptr<ft_event> &event) noexcept;
-        void update_events(ft_world &world, int ticks, const char *log_file_path = ft_nullptr, ft_string *log_buffer = ft_nullptr) noexcept;
+        void cancel_event(int id) noexcept;
+        void reschedule_event(int id, int new_duration) noexcept;
+        void update_events(ft_sharedptr<ft_world> &world, int ticks, const char *log_file_path = ft_nullptr, ft_string *log_buffer = ft_nullptr) noexcept;
 
         void dump_events(ft_vector<ft_sharedptr<ft_event> > &out) const noexcept;
         size_t size() const noexcept;
@@ -47,7 +49,7 @@ class ft_event_scheduler
 int log_event_to_file(const ft_event &event, const char *file_path) noexcept;
 void log_event_to_buffer(const ft_event &event, ft_string &buffer) noexcept;
 
-json_group *serialize_event_scheduler(const ft_event_scheduler &scheduler);
-int deserialize_event_scheduler(ft_event_scheduler &scheduler, json_group *group);
+json_group *serialize_event_scheduler(const ft_sharedptr<ft_event_scheduler> &scheduler);
+int deserialize_event_scheduler(ft_sharedptr<ft_event_scheduler> &scheduler, json_group *group);
 
 #endif

--- a/Game/game_world.hpp
+++ b/Game/game_world.hpp
@@ -27,7 +27,7 @@ class ft_world
         ft_world &operator=(ft_world &&other) noexcept;
 
         void schedule_event(const ft_sharedptr<ft_event> &event) noexcept;
-        void update_events(int ticks, const char *log_file_path = ft_nullptr, ft_string *log_buffer = ft_nullptr) noexcept;
+        void update_events(ft_sharedptr<ft_world> &self, int ticks, const char *log_file_path = ft_nullptr, ft_string *log_buffer = ft_nullptr) noexcept;
 
         ft_sharedptr<ft_event_scheduler>       &get_event_scheduler() noexcept;
         const ft_sharedptr<ft_event_scheduler> &get_event_scheduler() const noexcept;


### PR DESCRIPTION
## Summary
- add cancel_event and reschedule_event APIs to ft_event_scheduler
- document how to cancel and reschedule queued events
- pass ft_world and scheduler objects via shared pointers for event updates and serialization

## Testing
- `make -C Game`
- `make tests` *(fails: cannot convert `ft_sharedptr<ft_item>` to `const ft_item*` in Test/test_equipment.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b40426148331a4bb00b05cbc1ad7