### PR TITLE
Add UDP socket wrapper and datagram helpers

### DIFF
--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -29,6 +29,7 @@
 #include "Math/roll.hpp"
 #include "Networking/networking.hpp"
 #include "Networking/socket_class.hpp"
+#include "Networking/udp_socket.hpp"
 #include "Networking/ssl_wrapper.hpp"
 #include "PThread/pthread.hpp"
 #include "PThread/thread.hpp"

--- a/Networking/Makefile
+++ b/Networking/Makefile
@@ -5,6 +5,7 @@ SRCS := networking_socket_class.cpp \
         networking.cpp \
         networking_setup_server.cpp \
         networking_setup_client.cpp \
+        networking_setup_udp.cpp \
         networking_socket_wrapper_functions.cpp \
         networking_ssl_wrapper.cpp \
         networking_nonblocking.cpp \
@@ -35,6 +36,7 @@ endif
 
 HEADERS := socket_class.hpp \
            networking.hpp \
+           udp_socket.hpp \
            ssl_wrapper.hpp \
            http_client.hpp \
            http_server.hpp \

--- a/Networking/networking.hpp
+++ b/Networking/networking.hpp
@@ -23,6 +23,10 @@ int nw_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 int nw_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 int nw_listen(int sockfd, int backlog);
 int nw_socket(int domain, int type, int protocol);
+ssize_t nw_sendto(int sockfd, const void *buf, size_t len, int flags,
+                  const struct sockaddr *dest_addr, socklen_t addrlen);
+ssize_t nw_recvfrom(int sockfd, void *buf, size_t len, int flags,
+                    struct sockaddr *src_addr, socklen_t *addrlen);
 int nw_inet_pton(int family, const char *ip_address, void *destination);
 int nw_set_nonblocking(int socket_fd);
 int nw_poll(int *read_file_descriptors, int read_count,

--- a/Networking/networking_socket_wrapper_functions.cpp
+++ b/Networking/networking_socket_wrapper_functions.cpp
@@ -73,6 +73,26 @@ static inline ssize_t recv_platform(int sockfd, void *buf, size_t len, int flags
         return (-1);
     return (ret);
 }
+
+static inline ssize_t sendto_platform(int sockfd, const void *buf, size_t len, int flags,
+                                      const struct sockaddr *dest_addr, socklen_t addrlen)
+{
+    int ret = ::sendto(static_cast<SOCKET>(sockfd), static_cast<const char*>(buf),
+                       static_cast<int>(len), flags, dest_addr, addrlen);
+    if (ret == SOCKET_ERROR)
+        return (-1);
+    return (ret);
+}
+
+static inline ssize_t recvfrom_platform(int sockfd, void *buf, size_t len, int flags,
+                                        struct sockaddr *src_addr, socklen_t *addrlen)
+{
+    int ret = ::recvfrom(static_cast<SOCKET>(sockfd), static_cast<char*>(buf),
+                         static_cast<int>(len), flags, src_addr, addrlen);
+    if (ret == SOCKET_ERROR)
+        return (-1);
+    return (ret);
+}
 #else
 static inline int bind_platform(int sockfd, const struct sockaddr *addr, socklen_t len)
 {
@@ -120,6 +140,18 @@ static inline ssize_t recv_platform(int sockfd, void *buf, size_t len, int flags
 {
     return (::recv(sockfd, buf, len, flags));
 }
+
+static inline ssize_t sendto_platform(int sockfd, const void *buf, size_t len, int flags,
+                                      const struct sockaddr *dest_addr, socklen_t addrlen)
+{
+    return (::sendto(sockfd, buf, len, flags, dest_addr, addrlen));
+}
+
+static inline ssize_t recvfrom_platform(int sockfd, void *buf, size_t len, int flags,
+                                        struct sockaddr *src_addr, socklen_t *addrlen)
+{
+    return (::recvfrom(sockfd, buf, len, flags, src_addr, addrlen));
+}
 #endif
 
 int nw_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
@@ -155,6 +187,18 @@ ssize_t nw_send(int sockfd, const void *buf, size_t len, int flags)
 ssize_t nw_recv(int sockfd, void *buf, size_t len, int flags)
 {
     return (recv_platform(sockfd, buf, len, flags));
+}
+
+ssize_t nw_sendto(int sockfd, const void *buf, size_t len, int flags,
+                  const struct sockaddr *dest_addr, socklen_t addrlen)
+{
+    return (sendto_platform(sockfd, buf, len, flags, dest_addr, addrlen));
+}
+
+ssize_t nw_recvfrom(int sockfd, void *buf, size_t len, int flags,
+                    struct sockaddr *src_addr, socklen_t *addrlen)
+{
+    return (recvfrom_platform(sockfd, buf, len, flags, src_addr, addrlen));
 }
 
 int nw_inet_pton(int family, const char *ip_address, void *destination)

--- a/Networking/udp_socket.hpp
+++ b/Networking/udp_socket.hpp
@@ -1,0 +1,48 @@
+#ifndef NETWORKING_UDP_SOCKET_HPP
+#define NETWORKING_UDP_SOCKET_HPP
+
+#include "networking.hpp"
+#include "../Errno/errno.hpp"
+#ifdef _WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
+# define FT_CLOSE_SOCKET(fd) closesocket(fd)
+#else
+# include <sys/socket.h>
+# include <unistd.h>
+# include <arpa/inet.h>
+# define FT_CLOSE_SOCKET(fd) close(fd)
+#endif
+
+class udp_socket
+{
+    private:
+        int     create_socket(const SocketConfig &config);
+        int     set_non_blocking(const SocketConfig &config);
+        int     set_timeouts(const SocketConfig &config);
+        int     configure_address(const SocketConfig &config);
+        int     bind_socket(const SocketConfig &config);
+        int     connect_socket(const SocketConfig &config);
+        void    handle_error(int error_code);
+
+        struct sockaddr_storage _address;
+        int     _socket_fd;
+        int     _error;
+
+    public:
+        udp_socket();
+        ~udp_socket();
+
+        int     initialize(const SocketConfig &config);
+        ssize_t send_to(const void *data, size_t size, int flags,
+                        const struct sockaddr *dest_addr, socklen_t addr_len);
+        ssize_t receive_from(void *buffer, size_t size, int flags,
+                             struct sockaddr *src_addr, socklen_t *addr_len);
+        bool    close_socket();
+        int     get_error() const;
+        const char  *get_error_str() const;
+        int     get_fd() const;
+        const struct sockaddr_storage &get_address() const;
+};
+
+#endif

--- a/Test/Test/test_networking.cpp
+++ b/Test/Test/test_networking.cpp
@@ -1,5 +1,6 @@
 #include "../../Networking/socket_class.hpp"
 #include "../../Networking/networking.hpp"
+#include "../../Networking/udp_socket.hpp"
 #include "../../Libft/libft.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include <cstring>
@@ -37,6 +38,43 @@ FT_TEST(test_network_send_receive, "nw_send/nw_recv IPv4")
     if (bytes_received < 0)
         return (0);
     buffer[bytes_received] = '\0';
+    return (ft_strcmp(buffer, message) == 0);
+}
+
+FT_TEST(test_udp_send_receive, "nw_sendto/nw_recvfrom IPv4")
+{
+    SocketConfig server_configuration;
+    server_configuration._port = 54329;
+    server_configuration._type = SocketType::SERVER;
+    server_configuration._protocol = IPPROTO_UDP;
+    udp_socket server(server_configuration);
+    if (server.get_error() != ER_SUCCESS)
+        return (0);
+
+    SocketConfig client_configuration;
+    client_configuration._port = 54329;
+    client_configuration._type = SocketType::CLIENT;
+    client_configuration._protocol = IPPROTO_UDP;
+    udp_socket client(client_configuration);
+    if (client.get_error() != ER_SUCCESS)
+        return (0);
+
+    struct sockaddr_storage dest;
+    dest = server.get_address();
+    const char *message = "data";
+    ssize_t sent = client.send_to(message, ft_strlen(message), 0,
+                                  reinterpret_cast<const struct sockaddr*>(&dest),
+                                  sizeof(struct sockaddr_in));
+    if (sent != static_cast<ssize_t>(ft_strlen(message)))
+        return (0);
+    char buffer[16];
+    socklen_t addr_len = sizeof(dest);
+    ssize_t received = server.receive_from(buffer, sizeof(buffer) - 1, 0,
+                                          reinterpret_cast<struct sockaddr*>(&dest),
+                                          &addr_len);
+    if (received < 0)
+        return (0);
+    buffer[received] = '\0';
     return (ft_strcmp(buffer, message) == 0);
 }
 


### PR DESCRIPTION
## Summary
- Add `udp_socket` class and UDP setup path
- Provide `nw_sendto`/`nw_recvfrom` datagram helpers
- Document UDP usage and reference module

## Testing
- `make -C Networking`
- `make tests` *(fails: interrupted due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bd0596688331b25f40c4554822bb