### PR TITLE
Add thread and string helpers

### DIFF
--- a/Concurrency/Concurrency_task_scheduler.cpp
+++ b/Concurrency/Concurrency_task_scheduler.cpp
@@ -1,4 +1,5 @@
 #include "task_scheduler.hpp"
+#include "this_thread.hpp"
 
 ft_task_scheduler::ft_task_scheduler(size_t thread_count)
     : _queue(), _workers(), _timer_thread(), _scheduled(), _scheduled_mutex(), _running(true), _error_code(ER_SUCCESS)
@@ -50,7 +51,7 @@ void ft_task_scheduler::worker_loop()
         if (this->_queue.pop(task))
             task();
         else
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            ft_this_thread_sleep_for(std::chrono::milliseconds(1));
     }
     return ;
 }
@@ -59,7 +60,7 @@ void ft_task_scheduler::timer_loop()
 {
     while (this->_running)
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        ft_this_thread_sleep_for(std::chrono::milliseconds(1));
         std::unique_lock<std::mutex> lock(this->_scheduled_mutex);
         size_t index;
         auto now = std::chrono::steady_clock::now();

--- a/Concurrency/Concurrency_this_thread.cpp
+++ b/Concurrency/Concurrency_this_thread.cpp
@@ -1,0 +1,24 @@
+#include "this_thread.hpp"
+
+std::thread::id ft_this_thread_get_id()
+{
+    return (std::this_thread::get_id());
+}
+
+void ft_this_thread_sleep_for(std::chrono::milliseconds duration)
+{
+    std::this_thread::sleep_for(duration);
+    return ;
+}
+
+void ft_this_thread_sleep_until(std::chrono::steady_clock::time_point time_point)
+{
+    std::this_thread::sleep_until(time_point);
+    return ;
+}
+
+void ft_this_thread_yield()
+{
+    std::this_thread::yield();
+    return ;
+}

--- a/Concurrency/Makefile
+++ b/Concurrency/Makefile
@@ -1,9 +1,10 @@
 TARGET := Concurrency.a
 DEBUG_TARGET := Concurrency_debug.a
 
-SRCS := Concurrency_task_scheduler.cpp
+SRCS := Concurrency_task_scheduler.cpp \
+    Concurrency_this_thread.cpp
 
-HEADERS := task_scheduler.hpp
+HEADERS := task_scheduler.hpp this_thread.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Concurrency/this_thread.hpp
+++ b/Concurrency/this_thread.hpp
@@ -1,0 +1,12 @@
+#ifndef THIS_THREAD_HPP
+#define THIS_THREAD_HPP
+
+#include <thread>
+#include <chrono>
+
+std::thread::id ft_this_thread_get_id();
+void ft_this_thread_sleep_for(std::chrono::milliseconds duration);
+void ft_this_thread_sleep_until(std::chrono::steady_clock::time_point time_point);
+void ft_this_thread_yield();
+
+#endif

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -77,6 +77,7 @@
 #include "Template/future.hpp"
 #include "Template/promise.hpp"
 #include "Concurrency/task_scheduler.hpp"
+#include "Concurrency/this_thread.hpp"
 #include "System_utils/system_utils.hpp"
 #include "Compression/compression.hpp"
 #include "Encryption/basic_encryption.hpp"

--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -43,7 +43,8 @@ SRCS := libft_atoi.cpp \
     libft_fclose.cpp \
     libft_fgets.cpp \
     libft_time.cpp \
-    libft_validate_int.cpp
+    libft_validate_int.cpp \
+    libft_to_string.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/libft.hpp
+++ b/Libft/libft.hpp
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include "../PThread/mutex.hpp"
+#include "../CPP_class/class_string_class.hpp"
 
 size_t             ft_strlen_size_t(const char *string);
 int                ft_strlen(const char *string);
@@ -60,5 +61,6 @@ int             ft_fclose(FILE *stream);
 char            *ft_fgets(char *string, int size, FILE *stream);
 long            ft_time_ms(void);
 char            *ft_time_format(char *buffer, size_t buffer_size);
+ft_string        ft_to_string(long number);
 
 #endif

--- a/Libft/libft_to_string.cpp
+++ b/Libft/libft_to_string.cpp
@@ -1,0 +1,10 @@
+#include "libft.hpp"
+#include <sstream>
+
+ft_string ft_to_string(long number)
+{
+    std::ostringstream stream;
+    stream << number;
+    ft_string number_string(stream.str().c_str());
+    return (number_string);
+}

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ The current suite exercises components across multiple modules:
 - **Libft**: `ft_atoi`, `ft_atol`, `ft_bzero`, `ft_isdigit`, `ft_isalpha`, `ft_isalnum`, `ft_islower`, `ft_isupper`, `ft_isprint`, `ft_isspace`, `ft_memchr`,
   `ft_memcmp`, `ft_memcpy`, `ft_memdup`, `ft_memmove`, `ft_memset`, `ft_strchr`, `ft_strcmp`, `ft_strjoin_multiple`, `ft_strlcat`, `ft_strlcpy`, `ft_strncpy`, `ft_strlen`, `ft_strncmp`,
   `ft_strnstr`, `ft_strstr`, `ft_strrchr`, `ft_strmapi`, `ft_striteri`, `ft_strtok`, `ft_strtol`, `ft_strtoul`, `ft_setenv`, `ft_unsetenv`, `ft_getenv`, `ft_to_lower`, `ft_to_upper`,
-  `ft_fopen`, `ft_fclose`, `ft_fgets`, `ft_time_ms`, `ft_time_format`
-- **Concurrency**: `ft_promise`, `ft_task_scheduler`
+`ft_fopen`, `ft_fclose`, `ft_fgets`, `ft_time_ms`, `ft_time_format`, `ft_to_string`
+- **Concurrency**: `ft_promise`, `ft_task_scheduler`, `ft_this_thread`
 - **Networking**: IPv4 and IPv6 send/receive paths, UDP datagrams, and a simple HTTP server
 - **Logger**: color toggling, JSON sink, asynchronous logging
 - **Math**: vector, matrix, and quaternion helpers
@@ -111,6 +111,7 @@ FILE   *ft_fopen(const char *filename, const char *mode);
 int     ft_fclose(FILE *stream);
 long    ft_time_ms(void);
 char   *ft_time_format(char *buffer, size_t buffer_size);
+ft_string ft_to_string(long number);
 ```
 
 `limits.hpp` exposes integer boundary constants:
@@ -926,6 +927,15 @@ const char *get_error_str() const;
 
 
 #### Concurrency
+`Concurrency/this_thread.hpp` provides helpers for the current thread:
+
+```
+std::thread::id ft_this_thread_get_id();
+void ft_this_thread_sleep_for(std::chrono::milliseconds duration);
+void ft_this_thread_sleep_until(std::chrono::steady_clock::time_point time_point);
+void ft_this_thread_yield();
+```
+
 `Concurrency/task_scheduler.hpp` offers `ft_task_scheduler`, combining a
 lock-free queue, thread pool and scheduler. Tasks may be submitted for
 immediate execution, delayed execution or recurring intervals and each

--- a/Test/Test/test_atoi.cpp
+++ b/Test/Test/test_atoi.cpp
@@ -1,7 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include <climits>
-#include <string>
 
 FT_TEST(test_atoi_simple, "ft_atoi simple")
 {
@@ -17,18 +16,18 @@ FT_TEST(test_atoi_negative, "ft_atoi negative")
 
 FT_TEST(test_atoi_intmax, "ft_atoi INT_MAX")
 {
-    std::string integer_string;
+    ft_string integer_string;
 
-    integer_string = std::to_string(INT_MAX);
+    integer_string = ft_to_string(INT_MAX);
     FT_ASSERT_EQ(INT_MAX, ft_atoi(integer_string.c_str()));
     return (1);
 }
 
 FT_TEST(test_atoi_intmin, "ft_atoi INT_MIN")
 {
-    std::string integer_string;
+    ft_string integer_string;
 
-    integer_string = std::to_string(INT_MIN);
+    integer_string = ft_to_string(INT_MIN);
     FT_ASSERT_EQ(INT_MIN, ft_atoi(integer_string.c_str()));
     return (1);
 }

--- a/Test/Test/test_extra_libft.cpp
+++ b/Test/Test/test_extra_libft.cpp
@@ -8,7 +8,6 @@
 #include "../../CMA/CMA.hpp"
 #include <cstring>
 #include <cstdlib>
-#include <string>
 
 int test_strlen_size_t_null(void)
 {
@@ -322,18 +321,18 @@ int test_atol_whitespace(void)
 
 int test_atol_longmax(void)
 {
-    std::string str;
+    ft_string number_string;
 
-    str = std::to_string(FT_LONG_MAX);
-    return (ft_atol(str.c_str()) == FT_LONG_MAX);
+    number_string = ft_to_string(FT_LONG_MAX);
+    return (ft_atol(number_string.c_str()) == FT_LONG_MAX);
 }
 
 int test_atol_longmin(void)
 {
-    std::string str;
+    ft_string number_string;
 
-    str = std::to_string(FT_LONG_MIN);
-    return (ft_atol(str.c_str()) == FT_LONG_MIN);
+    number_string = ft_to_string(FT_LONG_MIN);
+    return (ft_atol(number_string.c_str()) == FT_LONG_MIN);
 }
 
 int test_atol_plus_sign(void)


### PR DESCRIPTION
## Summary
- provide ft_this_thread wrappers for common thread operations
- add ft_to_string helper and update tests
- document new utilities and include in aggregate headers

## Testing
- `make tests` *(fails: cannot convert ‘ft_sharedptr<ft_item>’ to ‘const ft_item*’ in Test/test_equipment.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dbf4aab88331a652db936e0e91bf