### PR TITLE
Adjust magic shield damage handling

### DIFF
--- a/Game/game_character_misc.cpp
+++ b/Game/game_character_misc.cpp
@@ -121,6 +121,19 @@ void ft_character::take_damage_magic_shield(long long damage, uint8_t type) noex
     damage = this->apply_skill_modifiers(damage);
     if (damage < 0)
         damage = 0;
+    if (this->_current_magic_armor > 0)
+    {
+        if (damage <= this->_current_magic_armor)
+        {
+            this->_current_magic_armor = this->_current_magic_armor - static_cast<int>(damage);
+            damage = 0;
+        }
+        else
+        {
+            damage = damage - this->_current_magic_armor;
+            this->_current_magic_armor = 0;
+        }
+    }
     if (type == FT_DAMAGE_PHYSICAL)
     {
 #if FT_PHYSICAL_DAMAGE_REDUCTION == FT_DAMAGE_RULE_FLAT
@@ -132,19 +145,6 @@ void ft_character::take_damage_magic_shield(long long damage, uint8_t type) noex
     }
     else if (type == FT_DAMAGE_MAGICAL)
     {
-        if (this->_current_magic_armor > 0)
-        {
-            if (damage <= this->_current_magic_armor)
-            {
-                this->_current_magic_armor = this->_current_magic_armor - static_cast<int>(damage);
-                damage = 0;
-            }
-            else
-            {
-                damage = damage - this->_current_magic_armor;
-                this->_current_magic_armor = 0;
-            }
-        }
 #if FT_MAGIC_DAMAGE_REDUCTION == FT_DAMAGE_RULE_FLAT
         damage = damage - this->_magic_armor;
 #elif FT_MAGIC_DAMAGE_REDUCTION == FT_DAMAGE_RULE_SCALED

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The current suite exercises components across multiple modules:
 - **JSon**: schema validation
 - **YAML**: round-trip parsing
 - **Game**: `ft_game_state` centralizes worlds and character data with vectors of shared pointers for RAII cleanup, `ft_world` persistence and a shared-pointer-based `ft_event_scheduler` for timed actions via `ft_world::schedule_event` and `ft_world::update_events`, `ft_equipment`, `ft_inventory`, and `ft_quest` store items through shared pointers, `ft_crafting` consumes and produces shared items, `ft_world::plan_route`, `ft_pathfinding`, and copy/move constructors across game classes
-- The combat system introduces `FT_DAMAGE_RULE_MAGIC_SHIELD`, which treats magic armor as a shield and applies flat or percentage reduction through the `FT_PHYSICAL_DAMAGE_REDUCTION` and `FT_MAGIC_DAMAGE_REDUCTION` macros.
+- The combat system introduces `FT_DAMAGE_RULE_MAGIC_SHIELD`, which treats magic armor as a shield. Armor-based reduction is applied only to the damage that reaches health after the shield is exhausted and uses the `FT_PHYSICAL_DAMAGE_REDUCTION` and `FT_MAGIC_DAMAGE_REDUCTION` macros.
 - Shared pointers expose their own `get_error` while managed objects may define their own; call `shared_ptr.get_error()` for allocation issues and `shared_ptr->get_error()` for object-specific errors.
 - Game classes validate both the shared pointer and its managed object for errors before use so failures surface consistently.
 - `ft_item` tracks its own error code so equipment, inventory, and crafting verify both the item pointer and the item itself before applying modifiers or stacking quantities.


### PR DESCRIPTION
## Summary
- ensure armor reduction only applies to health after the magic shield absorbs incoming damage
- document magic shield behaviour in README

## Testing
- `make tests` *(fails: build interrupted due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f747b3748331b60b1717ab1bf49c