### PR TITLE
docs: fix game item references and revise tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ make tests
 ./Test/libft_tests
 ```
 
-Functional tests reside in `Test/Test` and performance benchmarks in `Test/Efficiency`.
+Functional tests reside in `Test/Test` and performance benchmarks in `Test/Efficiency`. The test suite is currently incomplete
+and some files may fail to compile until they are updated for recent interface changes.
 
 The test runner prints `OK` or `KO` for each registered case and
 summarizes the total. Detailed assertion failures are written to
@@ -1825,8 +1826,8 @@ ft_experience_table       &get_experience_table() noexcept;
 const ft_experience_table &get_experience_table() const noexcept;
 int equip_item(int slot, const ft_item &item) noexcept;
 void unequip_item(int slot) noexcept;
-ft_item *get_equipped_item(int slot) noexcept;
-const ft_item *get_equipped_item(int slot) const noexcept;
+ft_sharedptr<ft_item> get_equipped_item(int slot) noexcept;
+ft_sharedptr<ft_item> get_equipped_item(int slot) const noexcept;
 int get_level() const noexcept;
 int get_error() const noexcept;
 const char *get_error_str() const noexcept;

--- a/Test/Test/test_equipment.cpp
+++ b/Test/Test/test_equipment.cpp
@@ -13,8 +13,8 @@ FT_TEST(test_equipment_equip, "equip item increases stats")
     helm.set_modifier1_value(5);
     FT_ASSERT_EQ(ER_SUCCESS, hero.equip_item(EQUIP_HEAD, helm));
     FT_ASSERT_EQ(5, hero.get_physical_armor());
-    const ft_item *found = hero.get_equipped_item(EQUIP_HEAD);
-    FT_ASSERT(found != ft_nullptr);
+    ft_sharedptr<ft_item> found = hero.get_equipped_item(EQUIP_HEAD);
+    FT_ASSERT(found.get() != ft_nullptr);
     return (1);
 }
 
@@ -28,6 +28,6 @@ FT_TEST(test_equipment_unequip, "unequip removes stats")
     hero.equip_item(EQUIP_HEAD, helm);
     hero.unequip_item(EQUIP_HEAD);
     FT_ASSERT_EQ(0, hero.get_physical_armor());
-    FT_ASSERT(hero.get_equipped_item(EQUIP_HEAD) == ft_nullptr);
+    FT_ASSERT(hero.get_equipped_item(EQUIP_HEAD).get() == ft_nullptr);
     return (1);
 }

--- a/Test/Test/test_game.cpp
+++ b/Test/Test/test_game.cpp
@@ -10,6 +10,7 @@
 #include "../../Game/game_event.hpp"
 #include "../../Game/game_inventory.hpp"
 #include "../../Template/vector.hpp"
+#include "../../Template/shared_ptr.hpp"
 #include "../../Errno/errno.hpp"
 #include "../../JSon/json.hpp"
 #include <cstdio>
@@ -71,31 +72,31 @@ int test_game_simulation(void)
         hero.get_reputation().get_total_rep() != 4)
         return (0);
 
-    ft_world overworld;
-    ft_event meeting;
-    meeting.set_id(1);
-    meeting.set_duration(5);
-    overworld.schedule_event(meeting);
-    overworld.update_events(1);
-    ft_vector<ft_event> events;
-    overworld.get_event_scheduler().dump_events(events);
-    if (events.size() != 1 || events[0].get_duration() != 4)
+    ft_sharedptr<ft_world> overworld(new ft_world());
+    ft_sharedptr<ft_event> meeting(new ft_event());
+    meeting->set_id(1);
+    meeting->set_duration(5);
+    overworld->schedule_event(meeting);
+    overworld->update_events(overworld, 1);
+    ft_vector<ft_sharedptr<ft_event> > events;
+    overworld->get_event_scheduler()->dump_events(events);
+    if (events.size() != 1 || events[0]->get_duration() != 4)
         return (0);
 
     ft_inventory pack(2);
-    ft_item potion;
-    potion.set_item_id(1);
-    potion.set_max_stack(10);
-    potion.set_stack_size(5);
+    ft_sharedptr<ft_item> potion(new ft_item());
+    potion->set_item_id(1);
+    potion->set_max_stack(10);
+    potion->set_stack_size(5);
     if (pack.add_item(potion) != ER_SUCCESS)
         return (0);
-    ft_item more;
-    more.set_item_id(1);
-    more.set_max_stack(10);
-    more.set_stack_size(3);
+    ft_sharedptr<ft_item> more(new ft_item());
+    more->set_item_id(1);
+    more->set_max_stack(10);
+    more->set_stack_size(3);
     pack.add_item(more);
-    Pair<int, ft_item>* ientry = pack.get_items().find(0);
-    if (!ientry || ientry->value.get_stack_size() != 8)
+    Pair<int, ft_sharedptr<ft_item> > *ientry = pack.get_items().find(0);
+    if (!ientry || ientry->value->get_stack_size() != 8)
         return (0);
 
     if (grid.get(hero.get_x(), hero.get_y(), hero.get_z()) != 1)
@@ -126,20 +127,20 @@ int test_item_basic(void)
 int test_inventory_slots(void)
 {
     ft_inventory inventory(4);
-    ft_item bulky;
-    bulky.set_item_id(1);
-    bulky.set_max_stack(1);
-    bulky.set_stack_size(1);
-    bulky.set_width(2);
-    bulky.set_height(2);
+    ft_sharedptr<ft_item> bulky(new ft_item());
+    bulky->set_item_id(1);
+    bulky->set_max_stack(1);
+    bulky->set_stack_size(1);
+    bulky->set_width(2);
+    bulky->set_height(2);
     if (inventory.add_item(bulky) != ER_SUCCESS)
         return (0);
     if (inventory.get_used() != 4)
         return (0);
-    ft_item small;
-    small.set_item_id(2);
-    small.set_max_stack(1);
-    small.set_stack_size(1);
+    ft_sharedptr<ft_item> small(new ft_item());
+    small->set_item_id(2);
+    small->set_max_stack(1);
+    small->set_stack_size(1);
     if (inventory.add_item(small) != CHARACTER_INVENTORY_FULL)
         return (0);
     return (1);
@@ -148,16 +149,16 @@ int test_inventory_slots(void)
 int test_inventory_count(void)
 {
     ft_inventory inv(5);
-    ft_item potion;
-    potion.set_item_id(1);
-    potion.set_max_stack(10);
-    potion.set_stack_size(7);
+    ft_sharedptr<ft_item> potion(new ft_item());
+    potion->set_item_id(1);
+    potion->set_max_stack(10);
+    potion->set_stack_size(7);
     inv.add_item(potion);
 
-    ft_item more;
-    more.set_item_id(1);
-    more.set_max_stack(10);
-    more.set_stack_size(4);
+    ft_sharedptr<ft_item> more(new ft_item());
+    more->set_item_id(1);
+    more->set_max_stack(10);
+    more->set_stack_size(4);
     inv.add_item(more);
 
     if (!inv.has_item(1) || inv.count_item(1) != 11)
@@ -170,10 +171,10 @@ int test_inventory_count(void)
 int test_inventory_full(void)
 {
     ft_inventory inv(1);
-    ft_item item;
-    item.set_item_id(1);
-    item.set_max_stack(5);
-    item.set_stack_size(5);
+    ft_sharedptr<ft_item> item(new ft_item());
+    item->set_item_id(1);
+    item->set_max_stack(5);
+    item->set_stack_size(5);
     if (inv.is_full())
         return (0);
     if (inv.add_item(item) != ER_SUCCESS)
@@ -211,9 +212,9 @@ int test_game_save_load(void)
     ft_character hero;
     hero.set_hit_points(42);
     ft_world world;
-    ft_event event;
-    event.set_id(1);
-    event.set_duration(5);
+    ft_sharedptr<ft_event> event(new ft_event());
+    event->set_id(1);
+    event->set_duration(5);
     world.schedule_event(event);
     ft_inventory inventory;
     if (world.save_to_file("test_save.json", hero, inventory) != ER_SUCCESS)
@@ -223,12 +224,12 @@ int test_game_save_load(void)
     ft_inventory loaded_inventory;
     if (loaded_world.load_from_file("test_save.json", loaded_hero, loaded_inventory) != ER_SUCCESS)
         return (0);
-    ft_vector<ft_event> loaded_events;
-    loaded_world.get_event_scheduler().dump_events(loaded_events);
+    ft_vector<ft_sharedptr<ft_event> > loaded_events;
+    loaded_world.get_event_scheduler()->dump_events(loaded_events);
     remove("test_save.json");
     if (loaded_events.size() != 1)
         return (0);
-    if (loaded_events[0].get_duration() != 5)
+    if (loaded_events[0]->get_duration() != 5)
         return (0);
     if (loaded_hero.get_hit_points() != 42)
         return (0);

--- a/Test/Test/test_networking.cpp
+++ b/Test/Test/test_networking.cpp
@@ -47,16 +47,16 @@ FT_TEST(test_udp_send_receive, "nw_sendto/nw_recvfrom IPv4")
     server_configuration._port = 54329;
     server_configuration._type = SocketType::SERVER;
     server_configuration._protocol = IPPROTO_UDP;
-    udp_socket server(server_configuration);
-    if (server.get_error() != ER_SUCCESS)
+    udp_socket server;
+    if (server.initialize(server_configuration) != ER_SUCCESS)
         return (0);
 
     SocketConfig client_configuration;
     client_configuration._port = 54329;
     client_configuration._type = SocketType::CLIENT;
     client_configuration._protocol = IPPROTO_UDP;
-    udp_socket client(client_configuration);
-    if (client.get_error() != ER_SUCCESS)
+    udp_socket client;
+    if (client.initialize(client_configuration) != ER_SUCCESS)
         return (0);
 
     struct sockaddr_storage dest;

--- a/Test/Test/test_world_events.cpp
+++ b/Test/Test/test_world_events.cpp
@@ -2,24 +2,25 @@
 #include "../../Game/game_event.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include "../../Template/vector.hpp"
+#include "../../Template/shared_ptr.hpp"
 
 FT_TEST(test_world_process_events, "ft_world event expiration")
 {
-    ft_world world;
-    ft_event event;
-    event.set_id(1);
-    event.set_duration(3);
-    world.schedule_event(event);
+    ft_sharedptr<ft_world> world(new ft_world());
+    ft_sharedptr<ft_event> event(new ft_event());
+    event->set_id(1);
+    event->set_duration(3);
+    world->schedule_event(event);
 
-    world.update_events(1);
-    ft_vector<ft_event> events;
-    world.get_event_scheduler().dump_events(events);
-    if (events.size() != 1 || events[0].get_duration() != 2)
+    world->update_events(world, 1);
+    ft_vector<ft_sharedptr<ft_event> > events;
+    world->get_event_scheduler()->dump_events(events);
+    if (events.size() != 1 || events[0]->get_duration() != 2)
         return (0);
 
-    world.update_events(2);
+    world->update_events(world, 2);
     events.clear();
-    world.get_event_scheduler().dump_events(events);
+    world->get_event_scheduler()->dump_events(events);
     if (events.size() != 0)
         return (0);
 


### PR DESCRIPTION
## Summary
- clarify that test suite is incomplete and may fail to build
- update README to show `get_equipped_item` returns `ft_sharedptr<ft_item>`
- adjust equipment, game, networking, and world tests for shared pointer API

## Testing
- `make -j8`
- `make tests -j8`


------
https://chatgpt.com/codex/tasks/task_e_68c7ffb95be08331be763cd8f3f4f05c