### PR TITLE
Add modular arithmetic helpers to ft_big_number

### DIFF
--- a/CPP_class/class_big_number.hpp
+++ b/CPP_class/class_big_number.hpp
@@ -9,6 +9,7 @@ class ft_big_number
         char*           _digits;
         ft_size_t       _size;
         ft_size_t       _capacity;
+        bool            _is_negative;
         mutable int     _error_code;
 
         void    reserve(ft_size_t new_capacity) noexcept;
@@ -16,6 +17,8 @@ class ft_big_number
         void    set_error(int error_code) noexcept;
         bool    is_zero_value() const noexcept;
         int     compare_magnitude(const ft_big_number& other) const noexcept;
+        ft_big_number    add_magnitude(const ft_big_number& other) const noexcept;
+        ft_big_number    subtract_magnitude(const ft_big_number& other) const noexcept;
 
     public:
         ft_big_number() noexcept;
@@ -29,6 +32,7 @@ class ft_big_number
         ft_big_number operator-(const ft_big_number& other) const noexcept;
         ft_big_number operator*(const ft_big_number& other) const noexcept;
         ft_big_number operator/(const ft_big_number& other) const noexcept;
+        ft_big_number operator%(const ft_big_number& other) const noexcept;
         bool          operator==(const ft_big_number& other) const noexcept;
         bool          operator!=(const ft_big_number& other) const noexcept;
         bool          operator<(const ft_big_number& other) const noexcept;
@@ -37,6 +41,7 @@ class ft_big_number
         bool          operator>=(const ft_big_number& other) const noexcept;
 
         void        assign(const char* number) noexcept;
+        void        assign_base(const char* digits, int base) noexcept;
         void        append_digit(char digit) noexcept;
         void        append(const char* digits) noexcept;
         void        append_unsigned(unsigned long value) noexcept;
@@ -47,6 +52,10 @@ class ft_big_number
         const char* c_str() const noexcept;
         ft_size_t   size() const noexcept;
         bool        empty() const noexcept;
+        bool        is_negative() const noexcept;
+        bool        is_positive() const noexcept;
+        ft_string   to_string_base(int base) noexcept;
+        ft_big_number mod_pow(const ft_big_number& exponent, const ft_big_number& modulus) const noexcept;
         int         get_error() const noexcept;
         const char* get_error_str() const noexcept;
 };

--- a/CPP_class/cpp_class_big_number.cpp
+++ b/CPP_class/cpp_class_big_number.cpp
@@ -5,8 +5,67 @@
 #include "../Errno/errno.hpp"
 #include <limits>
 
+struct ft_big_number_digit_entry
+{
+    char    symbol;
+    int     value;
+};
+
+static const ft_big_number_digit_entry g_big_number_digit_to_value_table[] =
+{
+    {'0', 0},
+    {'1', 1},
+    {'2', 2},
+    {'3', 3},
+    {'4', 4},
+    {'5', 5},
+    {'6', 6},
+    {'7', 7},
+    {'8', 8},
+    {'9', 9},
+    {'A', 10},
+    {'B', 11},
+    {'C', 12},
+    {'D', 13},
+    {'E', 14},
+    {'F', 15},
+    {'a', 10},
+    {'b', 11},
+    {'c', 12},
+    {'d', 13},
+    {'e', 14},
+    {'f', 15},
+    {'\0', -1}
+};
+
+static const char g_big_number_value_to_digit_table[] = "0123456789ABCDEF";
+
+static int ft_big_number_digit_value(char digit) noexcept
+{
+    ft_size_t index = 0;
+
+    while (g_big_number_digit_to_value_table[index].symbol != '\0')
+    {
+        if (g_big_number_digit_to_value_table[index].symbol == digit)
+            return (g_big_number_digit_to_value_table[index].value);
+        index++;
+    }
+    return (-1);
+}
+
+static char ft_big_number_digit_symbol(int value) noexcept
+{
+    if (value < 0 || value > 15)
+        return ('\0');
+    return (g_big_number_value_to_digit_table[value]);
+}
+
 ft_big_number::ft_big_number() noexcept
-    : _digits(ft_nullptr), _size(0), _capacity(0), _error_code(0)
+    : _digits(ft_nullptr)
+    , _size(0)
+    , _capacity(0)
+    , _is_negative(false)
+    , _error_code(0)
 {
     return ;
 }
@@ -15,6 +74,7 @@ ft_big_number::ft_big_number(const ft_big_number& other) noexcept
     : _digits(ft_nullptr)
     , _size(other._size)
     , _capacity(other._capacity)
+    , _is_negative(other._is_negative)
     , _error_code(other._error_code)
 {
     if (other._digits)
@@ -36,11 +96,13 @@ ft_big_number::ft_big_number(ft_big_number&& other) noexcept
     : _digits(other._digits)
     , _size(other._size)
     , _capacity(other._capacity)
+    , _is_negative(other._is_negative)
     , _error_code(other._error_code)
 {
     other._digits = ft_nullptr;
     other._size = 0;
     other._capacity = 0;
+    other._is_negative = false;
     other._error_code = 0;
     return ;
 }
@@ -70,6 +132,7 @@ ft_big_number& ft_big_number::operator=(const ft_big_number& other) noexcept
     this->_digits = new_digits;
     this->_size = other._size;
     this->_capacity = other._capacity;
+    this->_is_negative = other._is_negative;
     this->_error_code = other._error_code;
     return (*this);
 }
@@ -82,10 +145,12 @@ ft_big_number& ft_big_number::operator=(ft_big_number&& other) noexcept
         this->_digits = other._digits;
         this->_size = other._size;
         this->_capacity = other._capacity;
+        this->_is_negative = other._is_negative;
         this->_error_code = other._error_code;
         other._digits = ft_nullptr;
         other._size = 0;
         other._capacity = 0;
+        other._is_negative = false;
         other._error_code = 0;
     }
     return (*this);
@@ -138,6 +203,122 @@ int ft_big_number::compare_magnitude(const ft_big_number& other) const noexcept
         digit_index++;
     }
     return (0);
+}
+
+ft_big_number ft_big_number::add_magnitude(const ft_big_number& other) const noexcept
+{
+    ft_big_number result;
+    if (this->is_zero_value())
+    {
+        result = other;
+        result._is_negative = false;
+        return (result);
+    }
+    if (other.is_zero_value())
+    {
+        result = *this;
+        result._is_negative = false;
+        return (result);
+    }
+    ft_size_t left_length = this->_size;
+    ft_size_t right_length = other._size;
+    ft_size_t max_length = left_length;
+    if (max_length < right_length)
+        max_length = right_length;
+    max_length++;
+    result.reserve(max_length + 1);
+    if (result._error_code != 0)
+        return (result);
+    result._size = max_length;
+    result._digits[max_length] = '\0';
+    ft_size_t left_index = left_length;
+    ft_size_t right_index = right_length;
+    ft_size_t write_index = max_length;
+    int carry_value = 0;
+    while (left_index > 0 || right_index > 0 || carry_value > 0)
+    {
+        int digit_sum = carry_value;
+        if (left_index > 0)
+        {
+            left_index--;
+            digit_sum += this->_digits[left_index] - '0';
+        }
+        if (right_index > 0)
+        {
+            right_index--;
+            digit_sum += other._digits[right_index] - '0';
+        }
+        write_index--;
+        result._digits[write_index] = static_cast<char>('0' + (digit_sum % 10));
+        carry_value = digit_sum / 10;
+    }
+    ft_size_t used_digits = max_length - write_index;
+    if (used_digits == 0)
+    {
+        result._digits[0] = '0';
+        result._digits[1] = '\0';
+        result._size = 1;
+    }
+    else
+    {
+        ft_memmove(result._digits, result._digits + write_index, used_digits);
+        result._digits[used_digits] = '\0';
+        result._size = used_digits;
+    }
+    result.shrink_capacity();
+    result._is_negative = false;
+    return (result);
+}
+
+ft_big_number ft_big_number::subtract_magnitude(const ft_big_number& other) const noexcept
+{
+    ft_big_number result;
+    int comparison = this->compare_magnitude(other);
+    if (comparison < 0)
+    {
+        result.set_error(BIG_NUMBER_NEGATIVE_RESULT);
+        return (result);
+    }
+    if (comparison == 0)
+        return (result);
+    if (other.is_zero_value())
+    {
+        result = *this;
+        result._is_negative = false;
+        return (result);
+    }
+    result.reserve(this->_size + 1);
+    if (result._error_code != 0)
+        return (result);
+    result._size = this->_size;
+    result._digits[this->_size] = '\0';
+    ft_size_t left_index = this->_size;
+    ft_size_t right_index = other._size;
+    int borrow_value = 0;
+    while (left_index > 0)
+    {
+        left_index--;
+        int left_digit_value = this->_digits[left_index] - '0';
+        if (borrow_value > 0)
+            left_digit_value--;
+        if (right_index > 0)
+        {
+            right_index--;
+            int right_digit_value = other._digits[right_index] - '0';
+            left_digit_value -= right_digit_value;
+        }
+        if (left_digit_value < 0)
+        {
+            left_digit_value += 10;
+            borrow_value = 1;
+        }
+        else
+            borrow_value = 0;
+        result._digits[left_index] = static_cast<char>('0' + left_digit_value);
+    }
+    result.trim_leading_zeros();
+    result._is_negative = false;
+    return (result);
 }
 
 void ft_big_number::reserve(ft_size_t new_capacity) noexcept
@@ -203,18 +384,32 @@ void ft_big_number::assign(const char* number) noexcept
         return ;
     }
     this->_error_code = 0;
-    ft_size_t length = 0;
-    while (number[length] != '\0')
+    bool parsed_negative = false;
+    ft_size_t start_index = 0;
+    if (number[start_index] == '-')
     {
-        if (number[length] < '0' || number[length] > '9')
+        parsed_negative = true;
+        start_index++;
+    }
+    ft_size_t length = 0;
+    ft_size_t index = start_index;
+    while (number[index] != '\0')
+    {
+        if (number[index] < '0' || number[index] > '9')
         {
             this->set_error(BIG_NUMBER_INVALID_DIGIT);
             return ;
         }
         length++;
+        index++;
     }
     if (length == 0)
     {
+        if (parsed_negative)
+        {
+            this->set_error(BIG_NUMBER_INVALID_DIGIT);
+            return ;
+        }
         this->clear();
         return ;
     }
@@ -224,12 +419,118 @@ void ft_big_number::assign(const char* number) noexcept
         if (this->_error_code)
             return ;
     }
-    ft_memcpy(this->_digits, number, length);
+    ft_memcpy(this->_digits, number + start_index, length);
     this->_digits[length] = '\0';
     this->_size = length;
+    this->_is_negative = parsed_negative;
     this->trim_leading_zeros();
+    if (this->is_zero_value())
+        this->_is_negative = false;
     if (!this->_error_code)
         this->shrink_capacity();
+    return ;
+}
+
+void ft_big_number::assign_base(const char* digits, int base) noexcept
+{
+    if (!digits)
+    {
+        this->clear();
+        return ;
+    }
+    this->_error_code = 0;
+    int local_error = 0;
+    bool parsed_negative = false;
+    ft_size_t index = 0;
+
+    if (base < 2 || base > 16)
+        local_error = BIG_NUMBER_INVALID_DIGIT;
+    else
+    {
+        if (digits[index] == '-')
+        {
+            parsed_negative = true;
+            index++;
+        }
+        if (digits[index] == '\0')
+            local_error = BIG_NUMBER_INVALID_DIGIT;
+        else
+        {
+            ft_big_number base_number;
+
+            base_number.append_unsigned(static_cast<unsigned long>(base));
+            if (base_number.get_error() != 0)
+                local_error = base_number.get_error();
+            else
+            {
+                ft_big_number result;
+
+                while (digits[index] != '\0')
+                {
+                    int digit_value = ft_big_number_digit_value(digits[index]);
+
+                    if (digit_value < 0 || digit_value >= base)
+                    {
+                        local_error = BIG_NUMBER_INVALID_DIGIT;
+                        break;
+                    }
+                    ft_big_number product = result * base_number;
+                    if (product.get_error() != 0)
+                    {
+                        local_error = product.get_error();
+                        break;
+                    }
+                    result = product;
+                    if (result.get_error() != 0)
+                    {
+                        local_error = result.get_error();
+                        break;
+                    }
+                    ft_big_number addend;
+
+                    addend.append_unsigned(static_cast<unsigned long>(digit_value));
+                    if (addend.get_error() != 0)
+                    {
+                        local_error = addend.get_error();
+                        break;
+                    }
+                    ft_big_number sum = result + addend;
+                    if (sum.get_error() != 0)
+                    {
+                        local_error = sum.get_error();
+                        break;
+                    }
+                    result = sum;
+                    if (result.get_error() != 0)
+                    {
+                        local_error = result.get_error();
+                        break;
+                    }
+                    index++;
+                }
+                if (local_error == 0)
+                {
+                    if (parsed_negative && result.is_zero_value())
+                        parsed_negative = false;
+                    *this = result;
+                    if (this->_error_code != 0)
+                        local_error = this->_error_code;
+                    else
+                    {
+                        this->_is_negative = parsed_negative;
+                        if (this->is_zero_value())
+                            this->_is_negative = false;
+                        this->shrink_capacity();
+                    }
+                }
+            }
+        }
+    }
+    if (local_error != 0)
+    {
+        this->_error_code = local_error;
+        ft_errno = local_error;
+    }
     return ;
 }
 
@@ -351,6 +652,7 @@ void ft_big_number::clear() noexcept
     this->_size = 0;
     if (this->_digits)
         this->_digits[0] = '\0';
+    this->_is_negative = false;
     this->_error_code = 0;
     this->shrink_capacity();
     return ;
@@ -367,63 +669,36 @@ ft_big_number ft_big_number::operator+(const ft_big_number& other) const noexcep
             error_result.set_error(other._error_code);
         return (error_result);
     }
-    if (this->is_zero_value())
-    {
-        ft_big_number copy(other);
-        return (copy);
-    }
-    if (other.is_zero_value())
-    {
-        ft_big_number copy(*this);
-        return (copy);
-    }
     ft_big_number result;
-    ft_size_t left_length = this->_size;
-    ft_size_t right_length = other._size;
-    ft_size_t max_length = left_length;
-    if (max_length < right_length)
-        max_length = right_length;
-    max_length++;
-    result.reserve(max_length + 1);
-    if (result._error_code != 0)
+    if (this->_is_negative == other._is_negative)
+    {
+        result = this->add_magnitude(other);
+        if (result._error_code != 0)
+            return (result);
+        result._is_negative = this->_is_negative;
+        if (result.is_zero_value())
+            result._is_negative = false;
         return (result);
-    result._size = max_length;
-    result._digits[max_length] = '\0';
-    ft_size_t left_index = left_length;
-    ft_size_t right_index = right_length;
-    ft_size_t write_index = max_length;
-    int carry_value = 0;
-    while (left_index > 0 || right_index > 0 || carry_value > 0)
-    {
-        int digit_sum = carry_value;
-        if (left_index > 0)
-        {
-            left_index--;
-            digit_sum += this->_digits[left_index] - '0';
-        }
-        if (right_index > 0)
-        {
-            right_index--;
-            digit_sum += other._digits[right_index] - '0';
-        }
-        write_index--;
-        result._digits[write_index] = static_cast<char>('0' + (digit_sum % 10));
-        carry_value = digit_sum / 10;
     }
-    ft_size_t used_digits = max_length - write_index;
-    if (used_digits == 0)
+    int comparison = this->compare_magnitude(other);
+    if (comparison == 0)
+        return (result);
+    if (comparison > 0)
     {
-        result._digits[0] = '0';
-        result._digits[1] = '\0';
-        result._size = 1;
+        result = this->subtract_magnitude(other);
+        if (result._error_code != 0)
+            return (result);
+        result._is_negative = this->_is_negative;
     }
     else
     {
-        ft_memmove(result._digits, result._digits + write_index, used_digits);
-        result._digits[used_digits] = '\0';
-        result._size = used_digits;
+        result = other.subtract_magnitude(*this);
+        if (result._error_code != 0)
+            return (result);
+        result._is_negative = other._is_negative;
     }
-    result.shrink_capacity();
+    if (result.is_zero_value())
+        result._is_negative = false;
     return (result);
 }
 
@@ -438,50 +713,18 @@ ft_big_number ft_big_number::operator-(const ft_big_number& other) const noexcep
             error_result.set_error(other._error_code);
         return (error_result);
     }
-    ft_big_number result;
-    int comparison = this->compare_magnitude(other);
-    if (comparison < 0)
+    ft_big_number neg_other(other);
+    if (neg_other._error_code != 0)
     {
-        result.set_error(BIG_NUMBER_NEGATIVE_RESULT);
-        return (result);
+        ft_big_number error_result;
+        error_result.set_error(neg_other._error_code);
+        return (error_result);
     }
-    if (comparison == 0)
-        return (result);
-    if (other.is_zero_value())
-    {
-        ft_big_number copy(*this);
-        return (copy);
-    }
-    result.reserve(this->_size + 1);
-    if (result._error_code != 0)
-        return (result);
-    result._size = this->_size;
-    result._digits[this->_size] = '\0';
-    ft_size_t left_index = this->_size;
-    ft_size_t right_index = other._size;
-    int borrow_value = 0;
-    while (left_index > 0)
-    {
-        left_index--;
-        int left_digit_value = this->_digits[left_index] - '0';
-        if (borrow_value > 0)
-            left_digit_value--;
-        if (right_index > 0)
-        {
-            right_index--;
-            int right_digit_value = other._digits[right_index] - '0';
-            left_digit_value -= right_digit_value;
-        }
-        if (left_digit_value < 0)
-        {
-            left_digit_value += 10;
-            borrow_value = 1;
-        }
-        else
-            borrow_value = 0;
-        result._digits[left_index] = static_cast<char>('0' + left_digit_value);
-    }
-    result.trim_leading_zeros();
+    if (neg_other.is_zero_value())
+        neg_other._is_negative = false;
+    else
+        neg_other._is_negative = !other._is_negative;
+    ft_big_number result = this->operator+(neg_other);
     return (result);
 }
 
@@ -545,6 +788,12 @@ ft_big_number ft_big_number::operator*(const ft_big_number& other) const noexcep
         left_offset++;
     }
     result.trim_leading_zeros();
+    if (result._error_code != 0)
+        return (result);
+    if (this->_is_negative != other._is_negative)
+        result._is_negative = true;
+    if (result.is_zero_value())
+        result._is_negative = false;
     return (result);
 }
 
@@ -573,6 +822,12 @@ ft_big_number ft_big_number::operator/(const ft_big_number& other) const noexcep
     if (magnitude_comparison == 0)
     {
         result.append_digit('1');
+        if (result._error_code != 0)
+            return (result);
+        if (this->_is_negative != other._is_negative)
+            result._is_negative = true;
+        if (result.is_zero_value())
+            result._is_negative = false;
         return (result);
     }
     ft_big_number remainder;
@@ -595,7 +850,7 @@ ft_big_number ft_big_number::operator/(const ft_big_number& other) const noexcep
         int comparison = remainder.compare_magnitude(other);
         while (comparison >= 0)
         {
-            remainder = remainder - other;
+            remainder = remainder.subtract_magnitude(other);
             if (remainder._error_code != 0)
             {
                 result.set_error(remainder._error_code);
@@ -611,6 +866,88 @@ ft_big_number ft_big_number::operator/(const ft_big_number& other) const noexcep
         digit_index++;
     }
     result.trim_leading_zeros();
+    if (result._error_code != 0)
+        return (result);
+    if (this->_is_negative != other._is_negative)
+        result._is_negative = true;
+    if (result.is_zero_value())
+        result._is_negative = false;
+    return (result);
+}
+
+ft_big_number ft_big_number::operator%(const ft_big_number& other) const noexcept
+{
+    if (this->_error_code != 0 || other._error_code != 0)
+    {
+        ft_big_number error_result;
+        if (this->_error_code != 0)
+            error_result.set_error(this->_error_code);
+        else
+            error_result.set_error(other._error_code);
+        return (error_result);
+    }
+    ft_big_number result;
+    if (other.is_zero_value())
+    {
+        result.set_error(BIG_NUMBER_DIVIDE_BY_ZERO);
+        return (result);
+    }
+    if (this->is_zero_value())
+        return (result);
+    ft_big_number dividend(*this);
+    if (dividend._error_code != 0)
+    {
+        result.set_error(dividend._error_code);
+        return (result);
+    }
+    dividend._is_negative = false;
+    dividend.trim_leading_zeros();
+    ft_big_number divisor(other);
+    if (divisor._error_code != 0)
+    {
+        result.set_error(divisor._error_code);
+        return (result);
+    }
+    divisor._is_negative = false;
+    divisor.trim_leading_zeros();
+    int magnitude_comparison = dividend.compare_magnitude(divisor);
+    if (magnitude_comparison < 0)
+        result = dividend;
+    else if (magnitude_comparison > 0)
+    {
+        ft_big_number current_remainder;
+        ft_size_t digit_index = 0;
+        while (digit_index < dividend._size)
+        {
+            current_remainder.append_digit(dividend._digits[digit_index]);
+            if (current_remainder._error_code != 0)
+            {
+                result.set_error(current_remainder._error_code);
+                return (result);
+            }
+            current_remainder.trim_leading_zeros();
+            int compare_value = current_remainder.compare_magnitude(divisor);
+            while (compare_value >= 0)
+            {
+                current_remainder = current_remainder.subtract_magnitude(divisor);
+                if (current_remainder._error_code != 0)
+                {
+                    result.set_error(current_remainder._error_code);
+                    return (result);
+                }
+                compare_value = current_remainder.compare_magnitude(divisor);
+            }
+            digit_index++;
+        }
+        result = current_remainder;
+    }
+    result.trim_leading_zeros();
+    if (this->_is_negative && !result.is_zero_value())
+        result._is_negative = true;
+    else
+        result._is_negative = false;
+    if (result.is_zero_value())
+        result._is_negative = false;
     return (result);
 }
 
@@ -625,7 +962,19 @@ bool ft_big_number::operator<(const ft_big_number& other) const noexcept
 {
     if (this->_error_code != 0 || other._error_code != 0)
         return (false);
+    if (this->operator==(other))
+        return (false);
+    if (this->_is_negative && !other._is_negative)
+        return (true);
+    if (!this->_is_negative && other._is_negative)
+        return (false);
     int magnitude_comparison = this->compare_magnitude(other);
+    if (this->_is_negative && other._is_negative)
+    {
+        if (magnitude_comparison > 0)
+            return (true);
+        return (false);
+    }
     if (magnitude_comparison < 0)
         return (true);
     return (false);
@@ -640,10 +989,7 @@ bool ft_big_number::operator<=(const ft_big_number& other) const noexcept
 
 bool ft_big_number::operator>(const ft_big_number& other) const noexcept
 {
-    if (this->_error_code != 0 || other._error_code != 0)
-        return (false);
-    int magnitude_comparison = this->compare_magnitude(other);
-    if (magnitude_comparison > 0)
+    if (other.operator<(*this))
         return (true);
     return (false);
 }
@@ -661,6 +1007,8 @@ bool ft_big_number::operator==(const ft_big_number& other) const noexcept
         return (false);
     if (this->is_zero_value() && other.is_zero_value())
         return (true);
+    if (this->_is_negative != other._is_negative)
+        return (false);
     if (this->_size != other._size)
         return (false);
     if (this->_size == 0)
@@ -692,6 +1040,267 @@ ft_size_t ft_big_number::size() const noexcept
 bool ft_big_number::empty() const noexcept
 {
     return (this->_size == 0);
+}
+
+bool ft_big_number::is_negative() const noexcept
+{
+    if (this->is_zero_value())
+        return (false);
+    return (this->_is_negative);
+}
+
+bool ft_big_number::is_positive() const noexcept
+{
+    if (this->is_zero_value())
+        return (false);
+    return (!this->_is_negative);
+}
+
+ft_string ft_big_number::to_string_base(int base) noexcept
+{
+    if (base < 2 || base > 16)
+    {
+        this->set_error(BIG_NUMBER_INVALID_DIGIT);
+        return (ft_string(BIG_NUMBER_INVALID_DIGIT));
+    }
+    if (this->_error_code != 0)
+        return (ft_string(this->_error_code));
+    if (this->is_zero_value())
+    {
+        ft_string zero_result;
+
+        zero_result.append('0');
+        if (zero_result.get_error() != 0)
+        {
+            this->set_error(BIG_NUMBER_ALLOC_FAIL);
+            return (ft_string(BIG_NUMBER_ALLOC_FAIL));
+        }
+        return (zero_result);
+    }
+    ft_big_number magnitude(*this);
+
+    magnitude._is_negative = false;
+    ft_big_number base_value;
+
+    base_value.append_unsigned(static_cast<unsigned long>(base));
+    if (base_value.get_error() != 0)
+    {
+        this->set_error(base_value.get_error());
+        return (ft_string(base_value.get_error()));
+    }
+    ft_string digits;
+
+    while (!magnitude.is_zero_value())
+    {
+        ft_big_number quotient = magnitude / base_value;
+
+        if (quotient.get_error() != 0)
+        {
+            this->set_error(quotient.get_error());
+            return (ft_string(quotient.get_error()));
+        }
+        ft_big_number product = quotient * base_value;
+
+        if (product.get_error() != 0)
+        {
+            this->set_error(product.get_error());
+            return (ft_string(product.get_error()));
+        }
+        ft_big_number remainder_number = magnitude - product;
+
+        if (remainder_number.get_error() != 0)
+        {
+            this->set_error(remainder_number.get_error());
+            return (ft_string(remainder_number.get_error()));
+        }
+        const char* remainder_digits = remainder_number.c_str();
+        ft_size_t remainder_index = 0;
+        int remainder_value = 0;
+
+        while (remainder_digits[remainder_index] != '\0')
+        {
+            remainder_value = remainder_value * 10 + (remainder_digits[remainder_index] - '0');
+            remainder_index++;
+        }
+        char digit_symbol = ft_big_number_digit_symbol(remainder_value);
+
+        if (digit_symbol == '\0')
+        {
+            this->set_error(BIG_NUMBER_INVALID_DIGIT);
+            return (ft_string(BIG_NUMBER_INVALID_DIGIT));
+        }
+        digits.append(digit_symbol);
+        if (digits.get_error() != 0)
+        {
+            this->set_error(BIG_NUMBER_ALLOC_FAIL);
+            return (ft_string(BIG_NUMBER_ALLOC_FAIL));
+        }
+        magnitude = quotient;
+        if (magnitude.get_error() != 0)
+        {
+            this->set_error(magnitude.get_error());
+            return (ft_string(magnitude.get_error()));
+        }
+        magnitude._is_negative = false;
+    }
+    ft_string result;
+
+    if (this->_is_negative)
+    {
+        result.append('-');
+        if (result.get_error() != 0)
+        {
+            this->set_error(BIG_NUMBER_ALLOC_FAIL);
+            return (ft_string(BIG_NUMBER_ALLOC_FAIL));
+        }
+    }
+    const char* digits_buffer = digits.c_str();
+    ft_size_t digits_length = digits.size();
+
+    while (digits_length > 0)
+    {
+        digits_length--;
+        result.append(digits_buffer[digits_length]);
+        if (result.get_error() != 0)
+        {
+            this->set_error(BIG_NUMBER_ALLOC_FAIL);
+            return (ft_string(BIG_NUMBER_ALLOC_FAIL));
+        }
+    }
+    return (result);
+}
+
+ft_big_number ft_big_number::mod_pow(const ft_big_number& exponent, const ft_big_number& modulus) const noexcept
+{
+    if (this->_error_code != 0 || exponent._error_code != 0 || modulus._error_code != 0)
+    {
+        ft_big_number error_result;
+        if (this->_error_code != 0)
+            error_result.set_error(this->_error_code);
+        else if (exponent._error_code != 0)
+            error_result.set_error(exponent._error_code);
+        else
+            error_result.set_error(modulus._error_code);
+        return (error_result);
+    }
+    if (modulus.is_zero_value())
+    {
+        ft_big_number error_result;
+        error_result.set_error(BIG_NUMBER_DIVIDE_BY_ZERO);
+        return (error_result);
+    }
+    if (modulus.is_negative())
+    {
+        ft_big_number error_result;
+        error_result.set_error(BIG_NUMBER_INVALID_DIGIT);
+        return (error_result);
+    }
+    if (exponent.is_negative())
+    {
+        ft_big_number error_result;
+        error_result.set_error(BIG_NUMBER_INVALID_DIGIT);
+        return (error_result);
+    }
+    ft_big_number modulus_value(modulus);
+    if (modulus_value._error_code != 0)
+    {
+        ft_big_number error_result;
+        error_result.set_error(modulus_value._error_code);
+        return (error_result);
+    }
+    modulus_value._is_negative = false;
+    modulus_value.trim_leading_zeros();
+    ft_big_number base_remainder = this->operator%(modulus_value);
+    if (base_remainder._error_code != 0)
+    {
+        ft_big_number error_result;
+        error_result.set_error(base_remainder._error_code);
+        return (error_result);
+    }
+    while (base_remainder.is_negative())
+    {
+        ft_big_number adjusted_base = base_remainder + modulus_value;
+        if (adjusted_base._error_code != 0)
+        {
+            ft_big_number error_result;
+            error_result.set_error(adjusted_base._error_code);
+            return (error_result);
+        }
+        base_remainder = adjusted_base;
+    }
+    base_remainder.trim_leading_zeros();
+    ft_big_number exponent_value(exponent);
+    if (exponent_value._error_code != 0)
+    {
+        ft_big_number error_result;
+        error_result.set_error(exponent_value._error_code);
+        return (error_result);
+    }
+    exponent_value._is_negative = false;
+    exponent_value.trim_leading_zeros();
+    ft_big_number one;
+    one.append_digit('1');
+    if (one._error_code != 0)
+    {
+        ft_big_number error_result;
+        error_result.set_error(one._error_code);
+        return (error_result);
+    }
+    if (exponent_value.is_zero_value())
+    {
+        ft_big_number identity_result = one % modulus_value;
+        if (identity_result._error_code != 0)
+        {
+            ft_big_number error_result;
+            error_result.set_error(identity_result._error_code);
+            return (error_result);
+        }
+        identity_result._is_negative = false;
+        if (identity_result.is_zero_value())
+            identity_result._is_negative = false;
+        identity_result.trim_leading_zeros();
+        return (identity_result);
+    }
+    ft_big_number accumulator(one);
+    if (accumulator._error_code != 0)
+    {
+        ft_big_number error_result;
+        error_result.set_error(accumulator._error_code);
+        return (error_result);
+    }
+    while (!exponent_value.is_zero_value())
+    {
+        ft_big_number product_value = accumulator * base_remainder;
+        if (product_value._error_code != 0)
+        {
+            ft_big_number error_result;
+            error_result.set_error(product_value._error_code);
+            return (error_result);
+        }
+        ft_big_number reduced_value = product_value % modulus_value;
+        if (reduced_value._error_code != 0)
+        {
+            ft_big_number error_result;
+            error_result.set_error(reduced_value._error_code);
+            return (error_result);
+        }
+        accumulator = reduced_value;
+        ft_big_number next_exponent = exponent_value - one;
+        if (next_exponent._error_code != 0)
+        {
+            ft_big_number error_result;
+            error_result.set_error(next_exponent._error_code);
+            return (error_result);
+        }
+        exponent_value = next_exponent;
+        exponent_value._is_negative = false;
+        exponent_value.trim_leading_zeros();
+    }
+    accumulator._is_negative = false;
+    if (accumulator.is_zero_value())
+        accumulator._is_negative = false;
+    accumulator.trim_leading_zeros();
+    return (accumulator);
 }
 
 int ft_big_number::get_error() const noexcept

--- a/README.md
+++ b/README.md
@@ -537,10 +537,18 @@ operator const char*() const noexcept;
 ```
 
 #### `ft_big_number`
-Provides a decimal big-integer type that validates input digits, expands its
-internal buffer as digits are appended, releases excess memory when the number
-shrinks, and offers arithmetic helpers and comparisons that surface error
-states for unsupported operations.
+Provides a decimal big-integer type that validates input digits (including an
+optional leading minus sign), expands its internal buffer as digits are
+appended, releases excess memory when the number shrinks, and offers arithmetic
+helpers and comparisons that surface error states for unsupported operations.
+The class tracks the sign separately so arithmetic can produce negative
+results. Use `is_negative()` or `is_positive()` to inspect the sign while
+`c_str()` returns the magnitude digits. `assign_base()` and
+`to_string_base()` convert to and from bases up to hexadecimal so callers can
+work with binary, octal, decimal, or hexadecimal representations without
+changing the internal decimal storage. `operator%()` and `mod_pow()` provide
+modular arithmetic primitives so the class can participate in cryptographic
+workflows such as key exchange and signature verification.
 ```
 ft_big_number() noexcept;
 ft_big_number(const ft_big_number& other) noexcept;
@@ -551,6 +559,7 @@ ft_big_number operator+(const ft_big_number& other) const noexcept;
 ft_big_number operator-(const ft_big_number& other) const noexcept;
 ft_big_number operator*(const ft_big_number& other) const noexcept;
 ft_big_number operator/(const ft_big_number& other) const noexcept;
+ft_big_number operator%(const ft_big_number& other) const noexcept;
 bool          operator==(const ft_big_number& other) const noexcept;
 bool          operator!=(const ft_big_number& other) const noexcept;
 bool          operator<(const ft_big_number& other) const noexcept;
@@ -558,6 +567,7 @@ bool          operator<=(const ft_big_number& other) const noexcept;
 bool          operator>(const ft_big_number& other) const noexcept;
 bool          operator>=(const ft_big_number& other) const noexcept;
 void        assign(const char* number) noexcept;
+void        assign_base(const char* digits, int base) noexcept;
 void        append_digit(char digit) noexcept;
 void        append(const char* digits) noexcept;
 void        append_unsigned(unsigned long value) noexcept;
@@ -567,6 +577,10 @@ void        clear() noexcept;
 const char *c_str() const noexcept;
 ft_size_t   size() const noexcept;
 bool        empty() const noexcept;
+bool        is_negative() const noexcept;
+bool        is_positive() const noexcept;
+ft_string   to_string_base(int base) noexcept;
+ft_big_number mod_pow(const ft_big_number& exponent, const ft_big_number& modulus) const noexcept;
 int         get_error() const noexcept;
 const char *get_error_str() const noexcept;
 ```

--- a/Test/Test/test_big_number.cpp
+++ b/Test/Test/test_big_number.cpp
@@ -10,6 +10,8 @@ FT_TEST(test_big_number_default_state, "ft_big_number default state is zero")
     FT_ASSERT(number.empty());
     FT_ASSERT_EQ(static_cast<ft_size_t>(0), number.size());
     FT_ASSERT_EQ(0, std::strcmp(number.c_str(), "0"));
+    FT_ASSERT(!number.is_negative());
+    FT_ASSERT(!number.is_positive());
     FT_ASSERT_EQ(0, number.get_error());
     return (1);
 }
@@ -22,6 +24,72 @@ FT_TEST(test_big_number_assign_trim, "ft_big_number assign trims leading zeros")
     FT_ASSERT_EQ(0, number.get_error());
     FT_ASSERT_EQ(static_cast<ft_size_t>(7), number.size());
     FT_ASSERT_EQ(0, std::strcmp(number.c_str(), "1234500"));
+    FT_ASSERT(!number.is_negative());
+    FT_ASSERT(number.is_positive());
+    return (1);
+}
+
+FT_TEST(test_big_number_assign_negative, "ft_big_number assign parses negative numbers")
+{
+    ft_big_number number;
+
+    number.assign("-001234");
+    FT_ASSERT_EQ(0, number.get_error());
+    FT_ASSERT_EQ(static_cast<ft_size_t>(4), number.size());
+    FT_ASSERT_EQ(0, std::strcmp(number.c_str(), "1234"));
+    FT_ASSERT(number.is_negative());
+    FT_ASSERT(!number.is_positive());
+
+    number.assign("-0");
+    FT_ASSERT_EQ(0, number.get_error());
+    FT_ASSERT_EQ(static_cast<ft_size_t>(1), number.size());
+    FT_ASSERT_EQ(0, std::strcmp(number.c_str(), "0"));
+    FT_ASSERT(!number.is_negative());
+    FT_ASSERT(!number.is_positive());
+    return (1);
+}
+
+FT_TEST(test_big_number_assign_base_binary, "ft_big_number assign_base decodes binary strings")
+{
+    ft_big_number number;
+
+    number.assign_base("101010", 2);
+    FT_ASSERT_EQ(0, number.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(number.c_str(), "42"));
+    FT_ASSERT(!number.is_negative());
+    FT_ASSERT(number.is_positive());
+
+    number.assign_base("-1111111", 2);
+    FT_ASSERT_EQ(0, number.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(number.c_str(), "127"));
+    FT_ASSERT(number.is_negative());
+    FT_ASSERT(!number.is_positive());
+    return (1);
+}
+
+FT_TEST(test_big_number_assign_base_octal_hex, "ft_big_number assign_base handles octal and hexadecimal")
+{
+    ft_big_number octal_number;
+    ft_big_number hex_number;
+    ft_big_number invalid_number;
+
+    octal_number.assign_base("755", 8);
+    FT_ASSERT_EQ(0, octal_number.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(octal_number.c_str(), "493"));
+    FT_ASSERT(!octal_number.is_negative());
+    FT_ASSERT(octal_number.is_positive());
+
+    hex_number.assign_base("1a3f", 16);
+    FT_ASSERT_EQ(0, hex_number.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(hex_number.c_str(), "6719"));
+    FT_ASSERT(!hex_number.is_negative());
+    FT_ASSERT(hex_number.is_positive());
+
+    ft_errno = 0;
+    invalid_number.assign_base("19", 8);
+    FT_ASSERT_EQ(BIG_NUMBER_INVALID_DIGIT, invalid_number.get_error());
+    FT_ASSERT_EQ(BIG_NUMBER_INVALID_DIGIT, ft_errno);
+    ft_errno = 0;
     return (1);
 }
 
@@ -37,6 +105,8 @@ FT_TEST(test_big_number_append_helpers, "ft_big_number append_digit and append_u
     FT_ASSERT_EQ(0, number.get_error());
     FT_ASSERT_EQ(static_cast<ft_size_t>(7), number.size());
     FT_ASSERT_EQ(0, std::strcmp(number.c_str(), "4212345"));
+    FT_ASSERT(!number.is_negative());
+    FT_ASSERT(number.is_positive());
     return (1);
 }
 
@@ -66,6 +136,38 @@ FT_TEST(test_big_number_append_invalid_digit, "ft_big_number append_digit reject
     return (1);
 }
 
+FT_TEST(test_big_number_to_string_base_conversions, "ft_big_number to_string_base converts to binary, octal, and hexadecimal")
+{
+    ft_big_number decimal_value;
+    ft_big_number negative_value;
+
+    decimal_value.assign("255");
+    negative_value.assign("-240");
+
+    ft_string hex_output = decimal_value.to_string_base(16);
+    FT_ASSERT_EQ(0, decimal_value.get_error());
+    FT_ASSERT_EQ(0, hex_output.get_error());
+    FT_ASSERT(hex_output == "FF");
+
+    ft_string octal_output = decimal_value.to_string_base(8);
+    FT_ASSERT_EQ(0, decimal_value.get_error());
+    FT_ASSERT_EQ(0, octal_output.get_error());
+    FT_ASSERT(octal_output == "377");
+
+    ft_string binary_output = negative_value.to_string_base(2);
+    FT_ASSERT_EQ(0, negative_value.get_error());
+    FT_ASSERT_EQ(0, binary_output.get_error());
+    FT_ASSERT(binary_output == "-11110000");
+
+    ft_errno = 0;
+    ft_string invalid_output = decimal_value.to_string_base(1);
+    FT_ASSERT_EQ(BIG_NUMBER_INVALID_DIGIT, decimal_value.get_error());
+    FT_ASSERT_EQ(BIG_NUMBER_INVALID_DIGIT, ft_errno);
+    FT_ASSERT_EQ(BIG_NUMBER_INVALID_DIGIT, invalid_output.get_error());
+    ft_errno = 0;
+    return (1);
+}
+
 FT_TEST(test_big_number_addition_large_values, "ft_big_number addition handles large operands")
 {
     ft_big_number left_number;
@@ -78,6 +180,46 @@ FT_TEST(test_big_number_addition_large_values, "ft_big_number addition handles l
     ft_big_number sum_number = left_number + right_number;
     FT_ASSERT_EQ(0, sum_number.get_error());
     FT_ASSERT_EQ(0, std::strcmp(sum_number.c_str(), "111111111011111111100"));
+    FT_ASSERT(!sum_number.is_negative());
+    FT_ASSERT(sum_number.is_positive());
+    return (1);
+}
+
+FT_TEST(test_big_number_signed_addition, "ft_big_number addition handles negative operands")
+{
+    ft_big_number negative_five_hundred;
+    ft_big_number negative_two_hundred;
+    ft_big_number positive_two_hundred;
+    ft_big_number positive_five_hundred;
+
+    negative_five_hundred.assign("-500");
+    negative_two_hundred.assign("-200");
+    positive_two_hundred.assign("200");
+    positive_five_hundred.assign("500");
+
+    ft_big_number sum_neg_pos = negative_five_hundred + positive_two_hundred;
+    FT_ASSERT_EQ(0, sum_neg_pos.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(sum_neg_pos.c_str(), "300"));
+    FT_ASSERT(sum_neg_pos.is_negative());
+    FT_ASSERT(!sum_neg_pos.is_positive());
+
+    ft_big_number sum_pos_neg = positive_five_hundred + negative_two_hundred;
+    FT_ASSERT_EQ(0, sum_pos_neg.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(sum_pos_neg.c_str(), "300"));
+    FT_ASSERT(!sum_pos_neg.is_negative());
+    FT_ASSERT(sum_pos_neg.is_positive());
+
+    ft_big_number sum_neg_neg = negative_five_hundred + negative_two_hundred;
+    FT_ASSERT_EQ(0, sum_neg_neg.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(sum_neg_neg.c_str(), "700"));
+    FT_ASSERT(sum_neg_neg.is_negative());
+    FT_ASSERT(!sum_neg_neg.is_positive());
+
+    ft_big_number sum_cancel = positive_two_hundred + negative_two_hundred;
+    FT_ASSERT_EQ(0, sum_cancel.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(sum_cancel.c_str(), "0"));
+    FT_ASSERT(!sum_cancel.is_negative());
+    FT_ASSERT(!sum_cancel.is_positive());
     return (1);
 }
 
@@ -91,21 +233,63 @@ FT_TEST(test_big_number_subtraction_basic, "ft_big_number subtraction removes di
     ft_big_number difference_number = left_number - right_number;
     FT_ASSERT_EQ(0, difference_number.get_error());
     FT_ASSERT_EQ(0, std::strcmp(difference_number.c_str(), "999"));
+    FT_ASSERT(!difference_number.is_negative());
+    FT_ASSERT(difference_number.is_positive());
     return (1);
 }
 
-FT_TEST(test_big_number_subtraction_negative_error, "ft_big_number subtraction reports negative results")
+FT_TEST(test_big_number_signed_subtraction, "ft_big_number subtraction handles negative operands")
+{
+    ft_big_number positive_five;
+    ft_big_number positive_three;
+    ft_big_number negative_five;
+    ft_big_number negative_three;
+    ft_big_number negative_ten;
+
+    positive_five.assign("5");
+    positive_three.assign("3");
+    negative_five.assign("-5");
+    negative_three.assign("-3");
+    negative_ten.assign("-10");
+
+    ft_big_number diff_one = positive_five - negative_three;
+    FT_ASSERT_EQ(0, diff_one.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(diff_one.c_str(), "8"));
+    FT_ASSERT(!diff_one.is_negative());
+    FT_ASSERT(diff_one.is_positive());
+
+    ft_big_number diff_two = negative_five - positive_three;
+    FT_ASSERT_EQ(0, diff_two.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(diff_two.c_str(), "8"));
+    FT_ASSERT(diff_two.is_negative());
+    FT_ASSERT(!diff_two.is_positive());
+
+    ft_big_number diff_three = negative_ten - negative_three;
+    FT_ASSERT_EQ(0, diff_three.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(diff_three.c_str(), "7"));
+    FT_ASSERT(diff_three.is_negative());
+    FT_ASSERT(!diff_three.is_positive());
+
+    ft_big_number diff_four = negative_three - negative_ten;
+    FT_ASSERT_EQ(0, diff_four.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(diff_four.c_str(), "7"));
+    FT_ASSERT(!diff_four.is_negative());
+    FT_ASSERT(diff_four.is_positive());
+    return (1);
+}
+
+FT_TEST(test_big_number_subtraction_negative_result, "ft_big_number subtraction returns negative results")
 {
     ft_big_number small_number;
     ft_big_number large_number;
 
-    ft_errno = 0;
     small_number.assign("5");
     large_number.assign("10");
     ft_big_number result_number = small_number - large_number;
-    FT_ASSERT_EQ(BIG_NUMBER_NEGATIVE_RESULT, result_number.get_error());
-    FT_ASSERT_EQ(BIG_NUMBER_NEGATIVE_RESULT, ft_errno);
-    ft_errno = 0;
+    FT_ASSERT_EQ(0, result_number.get_error());
+    FT_ASSERT(result_number.is_negative());
+    FT_ASSERT(!result_number.is_positive());
+    FT_ASSERT_EQ(0, std::strcmp(result_number.c_str(), "5"));
     return (1);
 }
 
@@ -122,6 +306,36 @@ FT_TEST(test_big_number_multiplication_large_values, "ft_big_number multiplicati
     return (1);
 }
 
+FT_TEST(test_big_number_signed_multiplication, "ft_big_number multiplication applies sign")
+{
+    ft_big_number positive_twelve;
+    ft_big_number negative_three;
+    ft_big_number negative_four;
+
+    positive_twelve.assign("12");
+    negative_three.assign("-3");
+    negative_four.assign("-4");
+
+    ft_big_number product_one = positive_twelve * negative_three;
+    FT_ASSERT_EQ(0, product_one.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(product_one.c_str(), "36"));
+    FT_ASSERT(product_one.is_negative());
+    FT_ASSERT(!product_one.is_positive());
+
+    ft_big_number product_two = negative_three * negative_four;
+    FT_ASSERT_EQ(0, product_two.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(product_two.c_str(), "12"));
+    FT_ASSERT(!product_two.is_negative());
+    FT_ASSERT(product_two.is_positive());
+
+    ft_big_number product_three = negative_four * positive_twelve;
+    FT_ASSERT_EQ(0, product_three.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(product_three.c_str(), "48"));
+    FT_ASSERT(product_three.is_negative());
+    FT_ASSERT(!product_three.is_positive());
+    return (1);
+}
+
 FT_TEST(test_big_number_division_even, "ft_big_number division returns quotient")
 {
     ft_big_number numerator_number;
@@ -135,6 +349,38 @@ FT_TEST(test_big_number_division_even, "ft_big_number division returns quotient"
     return (1);
 }
 
+FT_TEST(test_big_number_signed_division, "ft_big_number division applies sign")
+{
+    ft_big_number numerator_positive;
+    ft_big_number numerator_negative;
+    ft_big_number denominator_positive;
+    ft_big_number denominator_negative;
+
+    numerator_positive.assign("100");
+    numerator_negative.assign("-100");
+    denominator_positive.assign("5");
+    denominator_negative.assign("-5");
+
+    ft_big_number quotient_one = numerator_negative / denominator_positive;
+    FT_ASSERT_EQ(0, quotient_one.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(quotient_one.c_str(), "20"));
+    FT_ASSERT(quotient_one.is_negative());
+    FT_ASSERT(!quotient_one.is_positive());
+
+    ft_big_number quotient_two = numerator_positive / denominator_negative;
+    FT_ASSERT_EQ(0, quotient_two.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(quotient_two.c_str(), "20"));
+    FT_ASSERT(quotient_two.is_negative());
+    FT_ASSERT(!quotient_two.is_positive());
+
+    ft_big_number quotient_three = numerator_negative / denominator_negative;
+    FT_ASSERT_EQ(0, quotient_three.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(quotient_three.c_str(), "20"));
+    FT_ASSERT(!quotient_three.is_negative());
+    FT_ASSERT(quotient_three.is_positive());
+    return (1);
+}
+
 FT_TEST(test_big_number_division_by_zero_error, "ft_big_number division reports divide by zero")
 {
     ft_big_number numerator_number;
@@ -145,6 +391,109 @@ FT_TEST(test_big_number_division_by_zero_error, "ft_big_number division reports 
     ft_big_number result_number = numerator_number / zero_number;
     FT_ASSERT_EQ(BIG_NUMBER_DIVIDE_BY_ZERO, result_number.get_error());
     FT_ASSERT_EQ(BIG_NUMBER_DIVIDE_BY_ZERO, ft_errno);
+    ft_errno = 0;
+    return (1);
+}
+
+FT_TEST(test_big_number_modulus_basic, "ft_big_number modulus returns signed remainders")
+{
+    ft_big_number positive_dividend;
+    ft_big_number divisor;
+
+    positive_dividend.assign("100");
+    divisor.assign("7");
+
+    ft_big_number positive_remainder = positive_dividend % divisor;
+    FT_ASSERT_EQ(0, positive_remainder.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(positive_remainder.c_str(), "2"));
+    FT_ASSERT(!positive_remainder.is_negative());
+    FT_ASSERT(positive_remainder.is_positive());
+
+    ft_big_number negative_dividend;
+
+    negative_dividend.assign("-100");
+    ft_big_number negative_remainder = negative_dividend % divisor;
+    FT_ASSERT_EQ(0, negative_remainder.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(negative_remainder.c_str(), "2"));
+    FT_ASSERT(negative_remainder.is_negative());
+    FT_ASSERT(!negative_remainder.is_positive());
+
+    ft_big_number small_dividend;
+    ft_big_number large_divisor;
+
+    small_dividend.assign("3");
+    large_divisor.assign("10");
+    ft_big_number small_remainder = small_dividend % large_divisor;
+    FT_ASSERT_EQ(0, small_remainder.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(small_remainder.c_str(), "3"));
+    FT_ASSERT(!small_remainder.is_negative());
+    FT_ASSERT(small_remainder.is_positive());
+
+    ft_big_number zero_divisor;
+
+    ft_errno = 0;
+    ft_big_number error_remainder = positive_dividend % zero_divisor;
+    FT_ASSERT_EQ(BIG_NUMBER_DIVIDE_BY_ZERO, error_remainder.get_error());
+    FT_ASSERT_EQ(BIG_NUMBER_DIVIDE_BY_ZERO, ft_errno);
+    ft_errno = 0;
+    return (1);
+}
+
+FT_TEST(test_big_number_modular_exponentiation, "ft_big_number mod_pow performs repeated modular multiplication")
+{
+    ft_big_number base_number;
+    ft_big_number exponent_number;
+    ft_big_number modulus_number;
+
+    base_number.assign("7");
+    exponent_number.assign("4");
+    modulus_number.assign("13");
+    ft_big_number power_result = base_number.mod_pow(exponent_number, modulus_number);
+    FT_ASSERT_EQ(0, power_result.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(power_result.c_str(), "9"));
+    FT_ASSERT(!power_result.is_negative());
+    FT_ASSERT(power_result.is_positive());
+
+    ft_big_number zero_exponent;
+
+    zero_exponent.assign("0");
+    ft_big_number identity_result = base_number.mod_pow(zero_exponent, modulus_number);
+    FT_ASSERT_EQ(0, identity_result.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(identity_result.c_str(), "1"));
+    FT_ASSERT(!identity_result.is_negative());
+    FT_ASSERT(identity_result.is_positive());
+
+    ft_big_number negative_base;
+    ft_big_number cube_exponent;
+    ft_big_number modulus_five;
+
+    negative_base.assign("-2");
+    cube_exponent.assign("3");
+    modulus_five.assign("5");
+    ft_big_number wrapped_result = negative_base.mod_pow(cube_exponent, modulus_five);
+    FT_ASSERT_EQ(0, wrapped_result.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(wrapped_result.c_str(), "2"));
+    FT_ASSERT(!wrapped_result.is_negative());
+    FT_ASSERT(wrapped_result.is_positive());
+
+    ft_big_number zero_modulus;
+    ft_big_number exponent_one;
+
+    zero_modulus.assign("0");
+    exponent_one.assign("1");
+    ft_errno = 0;
+    ft_big_number modulus_error = base_number.mod_pow(exponent_one, zero_modulus);
+    FT_ASSERT_EQ(BIG_NUMBER_DIVIDE_BY_ZERO, modulus_error.get_error());
+    FT_ASSERT_EQ(BIG_NUMBER_DIVIDE_BY_ZERO, ft_errno);
+    ft_errno = 0;
+
+    ft_big_number negative_exponent;
+
+    negative_exponent.assign("-1");
+    ft_errno = 0;
+    ft_big_number exponent_error = base_number.mod_pow(negative_exponent, modulus_number);
+    FT_ASSERT_EQ(BIG_NUMBER_INVALID_DIGIT, exponent_error.get_error());
+    FT_ASSERT_EQ(BIG_NUMBER_INVALID_DIGIT, ft_errno);
     ft_errno = 0;
     return (1);
 }
@@ -168,5 +517,36 @@ FT_TEST(test_big_number_comparisons, "ft_big_number comparison operators compare
     FT_ASSERT(third_number > first_number);
     FT_ASSERT(zero_number <= first_number);
     FT_ASSERT(first_number >= zero_number);
+    return (1);
+}
+
+FT_TEST(test_big_number_signed_comparisons, "ft_big_number comparisons handle signs")
+{
+    ft_big_number negative_large;
+    ft_big_number negative_small;
+    ft_big_number positive_small;
+    ft_big_number positive_large;
+    ft_big_number negative_small_copy;
+
+    negative_large.assign("-200");
+    negative_small.assign("-50");
+    positive_small.assign("50");
+    positive_large.assign("200");
+    negative_small_copy.assign("-50");
+
+    FT_ASSERT(negative_large.is_negative());
+    FT_ASSERT(!negative_large.is_positive());
+    FT_ASSERT(positive_large.is_positive());
+    FT_ASSERT(!positive_large.is_negative());
+
+    FT_ASSERT(negative_large < negative_small);
+    FT_ASSERT(!(negative_large > negative_small));
+    FT_ASSERT(negative_small < positive_small);
+    FT_ASSERT(!(positive_small < negative_large));
+    FT_ASSERT(positive_large > negative_small);
+    FT_ASSERT(positive_small >= negative_small);
+    FT_ASSERT(negative_small <= positive_small);
+    FT_ASSERT(negative_small == negative_small_copy);
+    FT_ASSERT(negative_small != positive_small);
     return (1);
 }


### PR DESCRIPTION
## Summary
- add `%` and `mod_pow` support to `ft_big_number` so signed values can compute modular arithmetic with existing error propagation helpers
- cover binary, octal, hexadecimal, modulus, and modular exponentiation scenarios in the big number unit tests
- document the new APIs and their cryptographic applications in the README

## Testing
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68c907504f648331a8f957e259f27fc2