### PR TITLE
Add big-number math wrappers and tests

### DIFF
--- a/Math/Makefile
+++ b/Math/Makefile
@@ -9,6 +9,7 @@ SRCS := math_abs.cpp \
         math_swap.cpp \
         math_clamp.cpp \
         math_gcd.cpp \
+        math_big_number.cpp \
         math_lcm.cpp \
         math_max.cpp \
         math_min.cpp \

--- a/Math/math.hpp
+++ b/Math/math.hpp
@@ -1,6 +1,8 @@
 #ifndef MATH_HPP
 # define MATH_HPP
 
+# include "../CPP_class/class_big_number.hpp"
+
 int         math_abs(int number);
 long        math_abs(long number);
 long long   math_abs(long long number);
@@ -13,9 +15,11 @@ int         math_clamp(int value, int minimum, int maximum);
 int         math_gcd(int first_number, int second_number);
 long        math_gcd(long first_number, long second_number);
 long long   math_gcd(long long first_number, long long second_number);
+ft_big_number    math_big_gcd(const ft_big_number &first_number, const ft_big_number &second_number);
 int         math_lcm(int first_number, int second_number);
 long        math_lcm(long first_number, long second_number);
 long long   math_lcm(long long first_number, long long second_number);
+ft_big_number    math_big_lcm(const ft_big_number &first_number, const ft_big_number &second_number);
 int         math_max(int first_number, int second_number);
 long        math_max(long first_number, long second_number);
 long long   math_max(long long first_number, long long second_number);

--- a/Math/math_big_number.cpp
+++ b/Math/math_big_number.cpp
@@ -1,0 +1,96 @@
+#include "math.hpp"
+
+static ft_big_number math_big_absolute_value(const ft_big_number &number)
+{
+    if (number.get_error() != 0)
+    {
+        ft_big_number error_copy(number);
+
+        return (error_copy);
+    }
+    if (!number.is_negative())
+    {
+        ft_big_number positive_number(number);
+
+        positive_number.trim_leading_zeros();
+        return (positive_number);
+    }
+    ft_big_number zero_number;
+    ft_big_number positive_number = zero_number - number;
+
+    if (positive_number.get_error() != 0)
+        return (positive_number);
+    positive_number.trim_leading_zeros();
+    return (positive_number);
+}
+
+static ft_big_number math_big_gcd_normalized(ft_big_number first_value, ft_big_number second_value)
+{
+    if (first_value.get_error() != 0)
+        return (first_value);
+    if (second_value.get_error() != 0)
+        return (second_value);
+    ft_big_number zero_number;
+
+    while (!(second_value == zero_number))
+    {
+        ft_big_number remainder_number = first_value % second_value;
+
+        if (remainder_number.get_error() != 0)
+            return (remainder_number);
+        first_value = second_value;
+        if (first_value.get_error() != 0)
+            return (first_value);
+        second_value = remainder_number;
+        if (second_value.get_error() != 0)
+            return (second_value);
+    }
+    first_value.trim_leading_zeros();
+    return (first_value);
+}
+
+ft_big_number math_big_gcd(const ft_big_number &first_number, const ft_big_number &second_number)
+{
+    ft_big_number first_value = math_big_absolute_value(first_number);
+
+    if (first_value.get_error() != 0)
+        return (first_value);
+    ft_big_number second_value = math_big_absolute_value(second_number);
+
+    if (second_value.get_error() != 0)
+        return (second_value);
+    ft_big_number gcd_value = math_big_gcd_normalized(first_value, second_value);
+
+    return (gcd_value);
+}
+
+ft_big_number math_big_lcm(const ft_big_number &first_number, const ft_big_number &second_number)
+{
+    ft_big_number first_value = math_big_absolute_value(first_number);
+
+    if (first_value.get_error() != 0)
+        return (first_value);
+    ft_big_number second_value = math_big_absolute_value(second_number);
+
+    if (second_value.get_error() != 0)
+        return (second_value);
+    ft_big_number zero_number;
+
+    if (first_value == zero_number || second_value == zero_number)
+    {
+        ft_big_number zero_result;
+
+        return (zero_result);
+    }
+    ft_big_number gcd_value = math_big_gcd_normalized(first_value, second_value);
+
+    if (gcd_value.get_error() != 0)
+        return (gcd_value);
+    ft_big_number product_value = first_value * second_value;
+
+    if (product_value.get_error() != 0)
+        return (product_value);
+    ft_big_number lcm_value = product_value / gcd_value;
+
+    return (lcm_value);
+}

--- a/README.md
+++ b/README.md
@@ -148,9 +148,11 @@ int         math_clamp(int value, int minimum, int maximum);
 int         math_gcd(int first_number, int second_number);
 long        math_gcd(long first_number, long second_number);
 long long   math_gcd(long long first_number, long long second_number);
+ft_big_number    math_big_gcd(const ft_big_number& first_number, const ft_big_number& second_number);
 int         math_lcm(int first_number, int second_number);
 long        math_lcm(long first_number, long second_number);
 long long   math_lcm(long long first_number, long long second_number);
+ft_big_number    math_big_lcm(const ft_big_number& first_number, const ft_big_number& second_number);
 int         math_max(int first_number, int second_number);
 long        math_max(long first_number, long second_number);
 long long   math_max(long long first_number, long long second_number);
@@ -186,6 +188,11 @@ double      ft_mode(const double *values, int array_size);
 double      ft_variance(const double *values, int array_size);
 double      ft_stddev(const double *values, int array_size);
 ```
+
+`math_big_gcd` and `math_big_lcm` bridge the `Math` helpers with the
+`ft_big_number` class so applications can compute number theory operations on
+operands that exceed native integer ranges while retaining the existing big
+integer error propagation.
 
 Example usage:
 

--- a/Test/Test/test_math_big_number.cpp
+++ b/Test/Test/test_math_big_number.cpp
@@ -1,0 +1,67 @@
+#include "../../Math/math.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cstring>
+
+FT_TEST(test_math_big_gcd_large_operands, "math_big_gcd computes gcd for large operands")
+{
+    ft_big_number first_number;
+    ft_big_number second_number;
+
+    first_number.assign("123456789012345678901234567890");
+    FT_ASSERT_EQ(0, first_number.get_error());
+    second_number.assign("987654321098765432109876543210");
+    FT_ASSERT_EQ(0, second_number.get_error());
+
+    ft_big_number gcd_value = math_big_gcd(first_number, second_number);
+
+    FT_ASSERT_EQ(0, gcd_value.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(gcd_value.c_str(), "9000000000900000000090"));
+
+    ft_big_number negative_first_number;
+    ft_big_number negative_second_number;
+
+    negative_first_number.assign("-123456789012345678901234567890");
+    FT_ASSERT_EQ(0, negative_first_number.get_error());
+    negative_second_number.assign("-987654321098765432109876543210");
+    FT_ASSERT_EQ(0, negative_second_number.get_error());
+
+    ft_big_number negative_gcd_value = math_big_gcd(negative_first_number, negative_second_number);
+
+    FT_ASSERT_EQ(0, negative_gcd_value.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(negative_gcd_value.c_str(), "9000000000900000000090"));
+    return (1);
+}
+
+FT_TEST(test_math_big_lcm_large_operands, "math_big_lcm computes lcm for large operands")
+{
+    ft_big_number first_number;
+    ft_big_number second_number;
+
+    first_number.assign("123456789012345678901234567890");
+    FT_ASSERT_EQ(0, first_number.get_error());
+    second_number.assign("987654321098765432109876543210");
+    FT_ASSERT_EQ(0, second_number.get_error());
+
+    ft_big_number lcm_value = math_big_lcm(first_number, second_number);
+
+    FT_ASSERT_EQ(0, lcm_value.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(lcm_value.c_str(), "13548070124980948012498094801236261410"));
+
+    ft_big_number negative_second_number;
+
+    negative_second_number.assign("-987654321098765432109876543210");
+    FT_ASSERT_EQ(0, negative_second_number.get_error());
+
+    ft_big_number mixed_lcm_value = math_big_lcm(first_number, negative_second_number);
+
+    FT_ASSERT_EQ(0, mixed_lcm_value.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(mixed_lcm_value.c_str(), "13548070124980948012498094801236261410"));
+
+    ft_big_number zero_number;
+
+    ft_big_number zero_lcm_value = math_big_lcm(first_number, zero_number);
+
+    FT_ASSERT_EQ(0, zero_lcm_value.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(zero_lcm_value.c_str(), "0"));
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add math_big_gcd and math_big_lcm wrappers that leverage ft_big_number arithmetic
- expose the new big-number helpers in math.hpp and document them in the README
- cover the big-number gcd and lcm helpers with large-operand tests

## Testing
- make tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68c92e8f0de08331bd42e68ac1a512a6