### PR TITLE
Add helpers for big number hex serialization

### DIFF
--- a/CPP_class/Makefile
+++ b/CPP_class/Makefile
@@ -11,7 +11,8 @@ SRCS :=  cpp_class_string_constructors.cpp \
          cpp_class_fd_istream.cpp \
          cpp_class_istringstream.cpp \
          cpp_class_ofstream.cpp \
-         cpp_class_big_number.cpp
+         cpp_class_big_number.cpp \
+         cpp_class_big_number_serialization.cpp
 
 HEADERS := class_string_class.hpp \
           class_nullptr.hpp \

--- a/CPP_class/class_big_number.hpp
+++ b/CPP_class/class_big_number.hpp
@@ -60,4 +60,7 @@ class ft_big_number
         const char* get_error_str() const noexcept;
 };
 
+ft_string   big_number_to_hex_string(const ft_big_number& number) noexcept;
+ft_big_number   big_number_from_hex_string(const char* hex_digits) noexcept;
+
 #endif

--- a/CPP_class/cpp_class_big_number_serialization.cpp
+++ b/CPP_class/cpp_class_big_number_serialization.cpp
@@ -1,0 +1,46 @@
+#include "class_big_number.hpp"
+
+ft_string big_number_to_hex_string(const ft_big_number& number) noexcept
+{
+    ft_big_number number_copy(number);
+    ft_string hex_string = number_copy.to_string_base(16);
+    return (hex_string);
+}
+
+ft_big_number big_number_from_hex_string(const char* hex_digits) noexcept
+{
+    ft_big_number result;
+
+    if (!hex_digits)
+    {
+        result.assign_base("", 16);
+        return (result);
+    }
+    const char* digits = hex_digits;
+    bool has_negative_sign = false;
+
+    if (digits[0] == '-')
+    {
+        has_negative_sign = true;
+        digits++;
+    }
+    else if (digits[0] == '+')
+        digits++;
+    if (digits[0] == '0')
+    {
+        if (digits[1] == 'x' || digits[1] == 'X')
+            digits += 2;
+    }
+    result.assign_base(digits, 16);
+    if (result.get_error() != 0)
+        return (result);
+    if (!has_negative_sign)
+        return (result);
+    ft_big_number zero_reference;
+
+    zero_reference.assign("0");
+    if (zero_reference.get_error() != 0)
+        return (zero_reference);
+    ft_big_number signed_result = zero_reference - result;
+    return (signed_result);
+}

--- a/README.md
+++ b/README.md
@@ -592,6 +592,27 @@ int         get_error() const noexcept;
 const char *get_error_str() const noexcept;
 ```
 
+The standalone helpers below expose common serialization flows so callers can
+emit uppercase hexadecimal digits or parse them (optionally prefixed with
+`0x`/`0X` and an optional leading sign) without manually juggling intermediate
+base conversions:
+
+```
+ft_string   big_number_to_hex_string(const ft_big_number& number) noexcept;
+ft_big_number   big_number_from_hex_string(const char* hex_digits) noexcept;
+```
+
+Example usage:
+
+```
+ft_big_number value;
+value.assign("3735928559");
+ft_string hex_value = big_number_to_hex_string(value); // "DEADBEEF"
+
+ft_big_number parsed = big_number_from_hex_string("-0x1234");
+// parsed.is_negative() == true and parsed.c_str() == "4660"
+```
+
 #### `ft_nullptr`
 ```
 namespace ft {

--- a/Test/Test/test_big_number.cpp
+++ b/Test/Test/test_big_number.cpp
@@ -168,6 +168,58 @@ FT_TEST(test_big_number_to_string_base_conversions, "ft_big_number to_string_bas
     return (1);
 }
 
+FT_TEST(test_big_number_hex_serialization_round_trip, "ft_big_number hex serialization round trip")
+{
+    ft_big_number decimal_value;
+
+    decimal_value.assign("3735928559");
+    FT_ASSERT_EQ(0, decimal_value.get_error());
+
+    ft_string hex_string = big_number_to_hex_string(decimal_value);
+    FT_ASSERT_EQ(0, hex_string.get_error());
+    FT_ASSERT(hex_string == "DEADBEEF");
+
+    ft_big_number parsed_value = big_number_from_hex_string(hex_string.c_str());
+
+    FT_ASSERT_EQ(0, parsed_value.get_error());
+    FT_ASSERT_EQ(0, std::strcmp(parsed_value.c_str(), decimal_value.c_str()));
+    FT_ASSERT(!parsed_value.is_negative());
+    FT_ASSERT(parsed_value.is_positive());
+    return (1);
+}
+
+FT_TEST(test_big_number_hex_serialization_prefix_support, "ft_big_number hex serialization handles prefixes and signs")
+{
+    ft_big_number negative_decimal;
+
+    negative_decimal.assign("-4660");
+    FT_ASSERT_EQ(0, negative_decimal.get_error());
+
+    ft_string negative_hex = big_number_to_hex_string(negative_decimal);
+    FT_ASSERT_EQ(0, negative_hex.get_error());
+    FT_ASSERT(negative_hex == "-1234");
+
+    ft_big_number round_trip_negative = big_number_from_hex_string(negative_hex.c_str());
+
+    FT_ASSERT_EQ(0, round_trip_negative.get_error());
+    FT_ASSERT(round_trip_negative.is_negative());
+    FT_ASSERT_EQ(0, std::strcmp(round_trip_negative.c_str(), "4660"));
+
+    ft_big_number prefixed_negative = big_number_from_hex_string("-0x1234");
+
+    FT_ASSERT_EQ(0, prefixed_negative.get_error());
+    FT_ASSERT(prefixed_negative.is_negative());
+    FT_ASSERT_EQ(0, std::strcmp(prefixed_negative.c_str(), "4660"));
+
+    ft_big_number prefixed_positive = big_number_from_hex_string("0XCAFEBABE");
+
+    FT_ASSERT_EQ(0, prefixed_positive.get_error());
+    FT_ASSERT(!prefixed_positive.is_negative());
+    FT_ASSERT(prefixed_positive.is_positive());
+    FT_ASSERT_EQ(0, std::strcmp(prefixed_positive.c_str(), "3405691582"));
+    return (1);
+}
+
 FT_TEST(test_big_number_addition_large_values, "ft_big_number addition handles large operands")
 {
     ft_big_number left_number;


### PR DESCRIPTION
## Summary
- add helpers that convert `ft_big_number` values to uppercase hexadecimal strings and parse hexadecimal input back into big numbers, including optional sign and `0x` prefixes
- declare the serialization helpers in the big number header and document their usage in the README
- add tests that round-trip decimal and hexadecimal representations and verify prefixed inputs

## Testing
- make tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68c9327944c0833184ff4864048b8519