### PR TITLE
Add compatibility timegm wrapper and timezone-safe ISO parsing

### DIFF
--- a/Compatebility/Compatebility_system.cpp
+++ b/Compatebility/Compatebility_system.cpp
@@ -2,6 +2,7 @@
 #include "../Libft/libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include <cstdlib>
+#include <ctime>
 
 #if defined(_WIN32) || defined(_WIN64)
 # include <windows.h>
@@ -104,5 +105,16 @@ unsigned long long cmp_get_total_memory(void)
         return (0);
     return (static_cast<unsigned long long>(pages) *
             static_cast<unsigned long long>(page_size));
+#endif
+}
+
+std::time_t cmp_timegm(std::tm *time_pointer)
+{
+    if (time_pointer == ft_nullptr)
+        return (static_cast<std::time_t>(-1));
+#if defined(_WIN32) || defined(_WIN64)
+    return (_mkgmtime(time_pointer));
+#else
+    return (::timegm(time_pointer));
 #endif
 }

--- a/Compatebility/compatebility_internal.hpp
+++ b/Compatebility/compatebility_internal.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <pthread.h>
 #include <sys/types.h>
+#include <ctime>
 
 #if defined(_WIN32) || defined(_WIN64)
 # include <BaseTsd.h>
@@ -75,6 +76,7 @@ int cmp_putenv(char *string);
 char *cmp_get_home_directory(void);
 unsigned int cmp_get_cpu_count(void);
 unsigned long long cmp_get_total_memory(void);
+std::time_t cmp_timegm(std::tm *time_pointer);
 
 ssize_t cmp_su_write(int file_descriptor, const char *buffer, size_t length);
 

--- a/README.md
+++ b/README.md
@@ -1493,6 +1493,10 @@ std::tm time_data;
 time_parse_custom("1970/01/01", "%Y/%m/%d", &time_data, NULL);
 ```
 
+`time_parse_iso8601` relies on the `cmp_timegm` compatibility helper, which wraps
+`timegm` on POSIX platforms and `_mkgmtime` on Windows so `'Z'` timestamps are
+translated using UTC even when the current timezone has a non-zero offset.
+
 `timer.hpp` defines a small timer class:
 
 ```

--- a/Test/Test/test_time.cpp
+++ b/Test/Test/test_time.cpp
@@ -1,6 +1,10 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
 #include "../../System_utils/test_runner.hpp"
+#include "../../CPP_class/class_string_class.hpp"
+#include "../../Time/time.hpp"
+#include <ctime>
+#include <cstring>
 
 FT_TEST(test_time_ms_basic, "ft_time_ms increasing")
 {
@@ -29,4 +33,92 @@ FT_TEST(test_time_format_errors, "ft_time_format edge cases")
     FT_ASSERT_EQ(ft_nullptr, ft_time_format(ft_nullptr, sizeof(buffer)));
     FT_ASSERT_EQ(ft_nullptr, ft_time_format(buffer, 0));
     return (1);
+}
+
+FT_TEST(test_time_parse_iso8601_timezone_independent, "time_parse_iso8601 handles UTC Z regardless of TZ")
+{
+    char *original_timezone;
+    ft_string timezone_backup;
+    std::tm local_epoch_input;
+    std::time_t local_epoch_result;
+    std::tm parsed_time;
+    t_time parsed_epoch;
+    int success;
+    bool parse_result;
+
+    success = 0;
+    original_timezone = ft_getenv("TZ");
+    if (original_timezone != ft_nullptr)
+        timezone_backup = original_timezone;
+    if (ft_setenv("TZ", "GMT+3", 1) != 0)
+    {
+        ft_test_fail("ft_setenv(\"TZ\", \"GMT+3\", 1) == 0", __FILE__, __LINE__);
+        goto cleanup;
+    }
+#if defined(_WIN32) || defined(_WIN64)
+    _tzset();
+#else
+    tzset();
+#endif
+    std::memset(&local_epoch_input, 0, sizeof(local_epoch_input));
+    local_epoch_input.tm_year = 70;
+    local_epoch_input.tm_mday = 1;
+    local_epoch_input.tm_isdst = 0;
+    local_epoch_result = std::mktime(&local_epoch_input);
+    if (local_epoch_result == static_cast<std::time_t>(-1))
+    {
+        ft_test_fail("local_epoch_result != (time_t)-1", __FILE__, __LINE__);
+        goto cleanup;
+    }
+    if (local_epoch_result == 0)
+    {
+        if (ft_setenv("TZ", "GMT-3", 1) != 0)
+        {
+            ft_test_fail("ft_setenv(\"TZ\", \"GMT-3\", 1) == 0", __FILE__, __LINE__);
+            goto cleanup;
+        }
+#if defined(_WIN32) || defined(_WIN64)
+        _tzset();
+#else
+        tzset();
+#endif
+        std::memset(&local_epoch_input, 0, sizeof(local_epoch_input));
+        local_epoch_input.tm_year = 70;
+        local_epoch_input.tm_mday = 1;
+        local_epoch_input.tm_isdst = 0;
+        local_epoch_result = std::mktime(&local_epoch_input);
+        if (local_epoch_result == static_cast<std::time_t>(-1))
+        {
+            ft_test_fail("local_epoch_result != (time_t)-1", __FILE__, __LINE__);
+            goto cleanup;
+        }
+    }
+    if (local_epoch_result == 0)
+    {
+        ft_test_fail("local_epoch_result != 0", __FILE__, __LINE__);
+        goto cleanup;
+    }
+    parse_result = time_parse_iso8601("1970-01-01T00:00:00Z", &parsed_time, &parsed_epoch);
+    if (!parse_result)
+    {
+        ft_test_fail("parse_result", __FILE__, __LINE__);
+        goto cleanup;
+    }
+    if (parsed_epoch != 0)
+    {
+        ft_test_fail("parsed_epoch == 0", __FILE__, __LINE__);
+        goto cleanup;
+    }
+    success = 1;
+cleanup:
+    if (original_timezone != ft_nullptr)
+        ft_setenv("TZ", timezone_backup.c_str(), 1);
+    else
+        ft_unsetenv("TZ");
+#if defined(_WIN32) || defined(_WIN64)
+    _tzset();
+#else
+    tzset();
+#endif
+    return (success);
 }

--- a/Time/time_parse.cpp
+++ b/Time/time_parse.cpp
@@ -1,4 +1,5 @@
 #include "time.hpp"
+#include "../Compatebility/compatebility_internal.hpp"
 #include <ctime>
 #include <cstdio>
 #include <cstring>
@@ -35,7 +36,7 @@ bool    time_parse_iso8601(const char *string_input, std::tm *time_output, t_tim
         *time_output = parsed_time;
     if (timestamp_output)
     {
-        epoch_time = std::mktime(&parsed_time);
+        epoch_time = cmp_timegm(&parsed_time);
         if (epoch_time == static_cast<std::time_t>(-1))
             return (false);
         *timestamp_output = static_cast<t_time>(epoch_time);


### PR DESCRIPTION
## Summary
- add a cmp_timegm helper that wraps timegm on POSIX and _mkgmtime on Windows
- use the compatibility helper in time_parse_iso8601 so Z timestamps always yield UTC epochs
- document the change and add a regression test that exercises ISO parsing under a non-UTC timezone

## Testing
- make tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68c9af4214ac83318644c6ab29eaa8cd