### PR TITLE
Fix math include guard collisions

### DIFF
--- a/Math/math.hpp
+++ b/Math/math.hpp
@@ -1,5 +1,5 @@
-#ifndef MATH_HPP
-# define MATH_HPP
+#ifndef MATH_MATH_HPP
+# define MATH_MATH_HPP
 
 # include "../CPP_class/class_big_number.hpp"
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ FT_ULONG_MAX
 
 ### Math
 
-Located in `Math/`. Headers: `math.hpp` and `roll.hpp`. Provides basic math utilities:
+Located in `Math/`. Headers: `math.hpp` and `roll.hpp`. Provides basic math utilities.
+`math.hpp` now uses the `MATH_MATH_HPP` include guard to avoid colliding with the template helper in `Template/math.hpp`, which switched to `FT_TEMPLATE_MATH_HPP`.
 
 ```
 int         math_abs(int number);

--- a/Template/math.hpp
+++ b/Template/math.hpp
@@ -1,5 +1,5 @@
-#ifndef MATH_HPP
-#define MATH_HPP
+#ifndef FT_TEMPLATE_MATH_HPP
+#define FT_TEMPLATE_MATH_HPP
 
 #include <cstddef>
 #include <type_traits>


### PR DESCRIPTION
## Summary
- use distinct include guard macros for Math/math.hpp and Template/math.hpp
- document the guard updates in the Math section of the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce735a67a0833189be1dce97481c17