### PR TITLE
Harden template iterators and API TLS error handling

### DIFF
--- a/API/api_promise.cpp
+++ b/API/api_promise.cpp
@@ -9,7 +9,13 @@ bool api_promise::request(const char *ip, uint16_t port,
     json_group *resp = api_request_json(ip, port, method, path, payload,
                                         headers, status, timeout);
     if (!resp)
+    {
+        int request_error = ft_errno;
+        if (request_error == ER_SUCCESS)
+            request_error = SOCKET_CONNECT_FAILED;
+        this->set_error(request_error);
         return (false);
+    }
     set_value(resp);
     return (true);
 }
@@ -23,7 +29,13 @@ bool api_string_promise::request(const char *ip, uint16_t port,
     char *resp = api_request_string(ip, port, method, path, payload,
                                     headers, status, timeout);
     if (!resp)
+    {
+        int request_error = ft_errno;
+        if (request_error == ER_SUCCESS)
+            request_error = SOCKET_CONNECT_FAILED;
+        this->set_error(request_error);
         return (false);
+    }
     set_value(resp);
     return (true);
 }
@@ -37,7 +49,13 @@ bool api_tls_promise::request(const char *host, uint16_t port,
     json_group *resp = api_request_json_tls(host, port, method, path, payload,
                                             headers, status, timeout);
     if (!resp)
+    {
+        int request_error = ft_errno;
+        if (request_error == ER_SUCCESS)
+            request_error = SOCKET_CONNECT_FAILED;
+        this->set_error(request_error);
         return (false);
+    }
     set_value(resp);
     return (true);
 }
@@ -51,7 +69,13 @@ bool api_tls_string_promise::request(const char *host, uint16_t port,
     char *resp = api_request_string_tls(host, port, method, path, payload,
                                         headers, status, timeout);
     if (!resp)
+    {
+        int request_error = ft_errno;
+        if (request_error == ER_SUCCESS)
+            request_error = SOCKET_CONNECT_FAILED;
+        this->set_error(request_error);
         return (false);
+    }
     set_value(resp);
     return (true);
 }

--- a/API/tls_client.hpp
+++ b/API/tls_client.hpp
@@ -4,6 +4,7 @@
 #include "../JSon/json.hpp"
 #include "../CPP_class/class_string_class.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include <openssl/ssl.h>
 #include <cstdint>
 
@@ -17,6 +18,9 @@ class api_tls_client
         int _sock;
         ft_string _host;
         int _timeout;
+        mutable int _error_code;
+
+        void set_error(int error_code) const noexcept;
 
     public:
         api_tls_client(const char *host, uint16_t port, int timeout = 60000);
@@ -35,6 +39,9 @@ class api_tls_client
                            const char *headers = ft_nullptr,
                            api_callback callback = ft_nullptr,
                            void *user_data = ft_nullptr);
+
+        int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Errno/errno.hpp
+++ b/Errno/errno.hpp
@@ -103,6 +103,8 @@ enum PTErrorCode
     FUTURE_INVALID,
     FUTURE_ALLOC_FAIL,
     FUTURE_BROKEN,
+    POOL_EMPTY,
+    POOL_INVALID_OBJECT,
 };
 
 const char* ft_strerror(int error_code);

--- a/Errno/errno_strerror.cpp
+++ b/Errno/errno_strerror.cpp
@@ -194,6 +194,10 @@ const char* ft_strerror(int error_code)
         return ("Future memory allocation failed");
     else if (error_code == FUTURE_BROKEN)
         return ("Associated promise was destroyed");
+    else if (error_code == POOL_EMPTY)
+        return ("Object pool has no available entries");
+    else if (error_code == POOL_INVALID_OBJECT)
+        return ("Object pool handle is invalid");
     else if (error_code > ERRNO_OFFSET)
     {
         int standard_errno = error_code - ERRNO_OFFSET;

--- a/Game/game_achievement.cpp
+++ b/Game/game_achievement.cpp
@@ -4,7 +4,11 @@ ft_achievement::ft_achievement() noexcept
     : _id(0), _goals(), _error(ER_SUCCESS)
 {
     if (this->_goals.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_goals.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -12,7 +16,11 @@ ft_achievement::ft_achievement(const ft_achievement &other) noexcept
     : _id(other._id), _goals(other._goals), _error(other._error)
 {
     if (this->_goals.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_goals.get_error());
+        return ;
+    }
+    this->set_error(other._error);
     return ;
 }
 
@@ -20,11 +28,15 @@ ft_achievement &ft_achievement::operator=(const ft_achievement &other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_goals = other._goals;
-        this->_error = other._error;
         if (this->_goals.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_goals.get_error());
+            return (*this);
+        }
+        this->set_error(other_error);
     }
     return (*this);
 }
@@ -33,7 +45,11 @@ ft_achievement::ft_achievement(ft_achievement &&other) noexcept
     : _id(other._id), _goals(ft_move(other._goals)), _error(other._error)
 {
     if (this->_goals.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_goals.get_error());
+        return ;
+    }
+    this->set_error(this->_error);
     other._id = 0;
     other._error = ER_SUCCESS;
     other._goals.clear();
@@ -44,11 +60,15 @@ ft_achievement &ft_achievement::operator=(ft_achievement &&other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_goals = ft_move(other._goals);
-        this->_error = other._error;
         if (this->_goals.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_goals.get_error());
+            return (*this);
+        }
+        this->set_error(other_error);
         other._id = 0;
         other._error = ER_SUCCESS;
         other._goals.clear();
@@ -58,97 +78,166 @@ ft_achievement &ft_achievement::operator=(ft_achievement &&other) noexcept
 
 int ft_achievement::get_id() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_id);
 }
 
 void ft_achievement::set_id(int id) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_id = id;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_map<int, ft_goal> &ft_achievement::get_goals() noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_goals);
 }
 
 const ft_map<int, ft_goal> &ft_achievement::get_goals() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_goals);
 }
 
 void ft_achievement::set_goals(const ft_map<int, ft_goal> &goals) noexcept
 {
     this->_goals = goals;
+    if (this->_goals.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_goals.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_achievement::get_goal(int id) const noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return (0);
+    }
     const Pair<int, ft_goal> *entry = this->_goals.find(id);
     if (!entry)
+    {
+        this->set_error(MAP_KEY_NOT_FOUND);
         return (0);
+    }
+    this->set_error(ER_SUCCESS);
     return (entry->value.goal);
 }
 
 void ft_achievement::set_goal(int id, int goal) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     Pair<int, ft_goal> *entry = this->_goals.find(id);
     if (!entry)
     {
         ft_goal new_goal{goal, 0};
         this->_goals.insert(id, new_goal);
         if (this->_goals.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_goals.get_error());
+            return ;
+        }
     }
     else
         entry->value.goal = goal;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_achievement::get_progress(int id) const noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return (0);
+    }
     const Pair<int, ft_goal> *entry = this->_goals.find(id);
     if (!entry)
+    {
+        this->set_error(MAP_KEY_NOT_FOUND);
         return (0);
+    }
+    this->set_error(ER_SUCCESS);
     return (entry->value.progress);
 }
 
 void ft_achievement::set_progress(int id, int progress) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     Pair<int, ft_goal> *entry = this->_goals.find(id);
     if (!entry)
     {
         ft_goal new_goal{0, progress};
         this->_goals.insert(id, new_goal);
         if (this->_goals.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_goals.get_error());
+            return ;
+        }
     }
     else
         entry->value.progress = progress;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_achievement::add_progress(int id, int value) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     Pair<int, ft_goal> *entry = this->_goals.find(id);
     if (!entry)
     {
         ft_goal new_goal{0, value};
         this->_goals.insert(id, new_goal);
         if (this->_goals.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_goals.get_error());
+            return ;
+        }
     }
     else
         entry->value.progress += value;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 bool ft_achievement::is_goal_complete(int id) const noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return (false);
+    }
     const Pair<int, ft_goal> *entry = this->_goals.find(id);
     if (!entry)
+    {
+        this->set_error(MAP_KEY_NOT_FOUND);
         return (false);
+    }
+    this->set_error(ER_SUCCESS);
     return (entry->value.progress >= entry->value.goal);
 }
 
@@ -159,9 +248,13 @@ bool ft_achievement::is_complete() const noexcept
     while (goal_ptr != goal_end)
     {
         if (goal_ptr->value.progress < goal_ptr->value.goal)
+        {
+            this->set_error(ER_SUCCESS);
             return (false);
+        }
         ++goal_ptr;
     }
+    this->set_error(ER_SUCCESS);
     return (true);
 }
 

--- a/Game/game_buff.cpp
+++ b/Game/game_buff.cpp
@@ -1,14 +1,17 @@
 #include "game_buff.hpp"
+#include "../Errno/errno.hpp"
 
 ft_buff::ft_buff() noexcept
-    : _id(0), _duration(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0)
+    : _id(0), _duration(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0), _error(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_buff::ft_buff(const ft_buff &other) noexcept
-    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4)
+    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _error(other._error)
 {
+    this->set_error(this->_error);
     return ;
 }
 
@@ -16,18 +19,20 @@ ft_buff &ft_buff::operator=(const ft_buff &other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_duration = other._duration;
         this->_modifier1 = other._modifier1;
         this->_modifier2 = other._modifier2;
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
+        this->set_error(other_error);
     }
     return (*this);
 }
 
 ft_buff::ft_buff(ft_buff &&other) noexcept
-    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4)
+    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _error(other._error)
 {
     other._id = 0;
     other._duration = 0;
@@ -35,6 +40,8 @@ ft_buff::ft_buff(ft_buff &&other) noexcept
     other._modifier2 = 0;
     other._modifier3 = 0;
     other._modifier4 = 0;
+    other.set_error(ER_SUCCESS);
+    this->set_error(this->_error);
     return ;
 }
 
@@ -42,18 +49,21 @@ ft_buff &ft_buff::operator=(ft_buff &&other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_duration = other._duration;
         this->_modifier1 = other._modifier1;
         this->_modifier2 = other._modifier2;
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
+        this->set_error(other_error);
         other._id = 0;
         other._duration = 0;
         other._modifier1 = 0;
         other._modifier2 = 0;
         other._modifier3 = 0;
         other._modifier4 = 0;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -65,7 +75,13 @@ int ft_buff::get_id() const noexcept
 
 void ft_buff::set_id(int id) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_id = id;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -76,19 +92,37 @@ int ft_buff::get_duration() const noexcept
 
 void ft_buff::set_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration = duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::add_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration += duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::sub_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration -= duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -100,18 +134,21 @@ int ft_buff::get_modifier1() const noexcept
 void ft_buff::set_modifier1(int mod) noexcept
 {
     this->_modifier1 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::add_modifier1(int mod) noexcept
 {
     this->_modifier1 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::sub_modifier1(int mod) noexcept
 {
     this->_modifier1 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -123,18 +160,21 @@ int ft_buff::get_modifier2() const noexcept
 void ft_buff::set_modifier2(int mod) noexcept
 {
     this->_modifier2 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::add_modifier2(int mod) noexcept
 {
     this->_modifier2 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::sub_modifier2(int mod) noexcept
 {
     this->_modifier2 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -146,18 +186,21 @@ int ft_buff::get_modifier3() const noexcept
 void ft_buff::set_modifier3(int mod) noexcept
 {
     this->_modifier3 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::add_modifier3(int mod) noexcept
 {
     this->_modifier3 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::sub_modifier3(int mod) noexcept
 {
     this->_modifier3 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -169,17 +212,37 @@ int ft_buff::get_modifier4() const noexcept
 void ft_buff::set_modifier4(int mod) noexcept
 {
     this->_modifier4 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::add_modifier4(int mod) noexcept
 {
     this->_modifier4 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_buff::sub_modifier4(int mod) noexcept
 {
     this->_modifier4 -= mod;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+int ft_buff::get_error() const noexcept
+{
+    return (this->_error);
+}
+
+const char *ft_buff::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+
+void ft_buff::set_error(int err) const noexcept
+{
+    ft_errno = err;
+    this->_error = err;
     return ;
 }

--- a/Game/game_buff.hpp
+++ b/Game/game_buff.hpp
@@ -10,6 +10,9 @@ class ft_buff
         int _modifier2;
         int _modifier3;
         int _modifier4;
+        mutable int _error;
+
+        void set_error(int err) const noexcept;
 
     public:
         ft_buff() noexcept;
@@ -46,6 +49,9 @@ class ft_buff
         void set_modifier4(int mod) noexcept;
         void add_modifier4(int mod) noexcept;
         void sub_modifier4(int mod) noexcept;
+
+        int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Game/game_character_constructor.cpp
+++ b/Game/game_character_constructor.cpp
@@ -14,19 +14,41 @@ ft_character::ft_character() noexcept
       _error(ER_SUCCESS)
 {
     if (this->_buffs.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_buffs.get_error());
-    else if (this->_skills.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_skills.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_skills.get_error());
-    else if (this->_debuffs.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_debuffs.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_debuffs.get_error());
-    else if (this->_upgrades.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_upgrades.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_upgrades.get_error());
-    else if (this->_quests.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_quests.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_quests.get_error());
-    else if (this->_achievements.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_achievements.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_achievements.get_error());
-    else if (this->_reputation.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_reputation.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_reputation.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -46,6 +68,7 @@ ft_character &ft_character::operator=(const ft_character &other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_hit_points = other._hit_points;
         this->_physical_armor = other._physical_armor;
         this->_magic_armor = other._magic_armor;
@@ -83,21 +106,42 @@ ft_character &ft_character::operator=(const ft_character &other) noexcept
         this->_reputation = other._reputation;
         this->_inventory = other._inventory;
         this->_equipment = other._equipment;
-        this->_error = other._error;
         if (this->_buffs.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_buffs.get_error());
-        else if (this->_skills.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_skills.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_skills.get_error());
-        else if (this->_debuffs.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_debuffs.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_debuffs.get_error());
-        else if (this->_upgrades.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_upgrades.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_upgrades.get_error());
-        else if (this->_quests.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_quests.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_quests.get_error());
-        else if (this->_achievements.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_achievements.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_achievements.get_error());
-        else if (this->_reputation.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_reputation.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_reputation.get_error());
+            return (*this);
+        }
+        this->set_error(other_error);
     }
     return (*this);
 }
@@ -150,21 +194,42 @@ ft_character &ft_character::operator=(ft_character &&other) noexcept
         this->_reputation = ft_move(other._reputation);
         this->_inventory = ft_move(other._inventory);
         this->_equipment = ft_move(other._equipment);
-        this->_error = other._error;
         if (this->_buffs.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_buffs.get_error());
-        else if (this->_skills.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_skills.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_skills.get_error());
-        else if (this->_debuffs.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_debuffs.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_debuffs.get_error());
-        else if (this->_upgrades.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_upgrades.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_upgrades.get_error());
-        else if (this->_quests.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_quests.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_quests.get_error());
-        else if (this->_achievements.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_achievements.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_achievements.get_error());
-        else if (this->_reputation.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_reputation.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_reputation.get_error());
+            return (*this);
+        }
+        this->set_error(other._error);
         other._hit_points = 0;
         other._physical_armor = 0;
         other._magic_armor = 0;
@@ -209,7 +274,7 @@ ft_character &ft_character::operator=(ft_character &&other) noexcept
         other._reputation = ft_reputation();
         other._inventory = ft_inventory();
         other._equipment = ft_equipment();
-        other._error = ER_SUCCESS;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }

--- a/Game/game_debuff.cpp
+++ b/Game/game_debuff.cpp
@@ -1,14 +1,17 @@
 #include "game_debuff.hpp"
+#include "../Errno/errno.hpp"
 
 ft_debuff::ft_debuff() noexcept
-    : _id(0), _duration(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0)
+    : _id(0), _duration(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0), _error(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_debuff::ft_debuff(const ft_debuff &other) noexcept
-    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4)
+    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _error(other._error)
 {
+    this->set_error(this->_error);
     return ;
 }
 
@@ -16,18 +19,20 @@ ft_debuff &ft_debuff::operator=(const ft_debuff &other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_duration = other._duration;
         this->_modifier1 = other._modifier1;
         this->_modifier2 = other._modifier2;
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
+        this->set_error(other_error);
     }
     return (*this);
 }
 
 ft_debuff::ft_debuff(ft_debuff &&other) noexcept
-    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4)
+    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _error(other._error)
 {
     other._id = 0;
     other._duration = 0;
@@ -35,6 +40,8 @@ ft_debuff::ft_debuff(ft_debuff &&other) noexcept
     other._modifier2 = 0;
     other._modifier3 = 0;
     other._modifier4 = 0;
+    other.set_error(ER_SUCCESS);
+    this->set_error(this->_error);
     return ;
 }
 
@@ -42,18 +49,21 @@ ft_debuff &ft_debuff::operator=(ft_debuff &&other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_duration = other._duration;
         this->_modifier1 = other._modifier1;
         this->_modifier2 = other._modifier2;
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
+        this->set_error(other_error);
         other._id = 0;
         other._duration = 0;
         other._modifier1 = 0;
         other._modifier2 = 0;
         other._modifier3 = 0;
         other._modifier4 = 0;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -65,7 +75,13 @@ int ft_debuff::get_id() const noexcept
 
 void ft_debuff::set_id(int id) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_id = id;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -76,19 +92,37 @@ int ft_debuff::get_duration() const noexcept
 
 void ft_debuff::set_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration = duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::add_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration += duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::sub_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration -= duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -100,18 +134,21 @@ int ft_debuff::get_modifier1() const noexcept
 void ft_debuff::set_modifier1(int mod) noexcept
 {
     this->_modifier1 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::add_modifier1(int mod) noexcept
 {
     this->_modifier1 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::sub_modifier1(int mod) noexcept
 {
     this->_modifier1 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -123,18 +160,21 @@ int ft_debuff::get_modifier2() const noexcept
 void ft_debuff::set_modifier2(int mod) noexcept
 {
     this->_modifier2 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::add_modifier2(int mod) noexcept
 {
     this->_modifier2 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::sub_modifier2(int mod) noexcept
 {
     this->_modifier2 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -146,18 +186,21 @@ int ft_debuff::get_modifier3() const noexcept
 void ft_debuff::set_modifier3(int mod) noexcept
 {
     this->_modifier3 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::add_modifier3(int mod) noexcept
 {
     this->_modifier3 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::sub_modifier3(int mod) noexcept
 {
     this->_modifier3 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -169,17 +212,37 @@ int ft_debuff::get_modifier4() const noexcept
 void ft_debuff::set_modifier4(int mod) noexcept
 {
     this->_modifier4 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::add_modifier4(int mod) noexcept
 {
     this->_modifier4 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_debuff::sub_modifier4(int mod) noexcept
 {
     this->_modifier4 -= mod;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+int ft_debuff::get_error() const noexcept
+{
+    return (this->_error);
+}
+
+const char *ft_debuff::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+
+void ft_debuff::set_error(int err) const noexcept
+{
+    ft_errno = err;
+    this->_error = err;
     return ;
 }

--- a/Game/game_debuff.hpp
+++ b/Game/game_debuff.hpp
@@ -10,6 +10,9 @@ class ft_debuff
         int _modifier2;
         int _modifier3;
         int _modifier4;
+        mutable int _error;
+
+        void set_error(int err) const noexcept;
 
     public:
         ft_debuff() noexcept;
@@ -46,6 +49,9 @@ class ft_debuff
         void set_modifier4(int mod) noexcept;
         void add_modifier4(int mod) noexcept;
         void sub_modifier4(int mod) noexcept;
+
+        int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Game/game_event.cpp
+++ b/Game/game_event.cpp
@@ -1,8 +1,14 @@
 #include "game_event.hpp"
 
 ft_event::ft_event() noexcept
-    : _id(0), _duration(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0), _callback()
+    : _id(0), _duration(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0), _callback(), _error(ER_SUCCESS)
 {
+    if (this->_callback.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_callback.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -12,8 +18,14 @@ ft_event::~ft_event() noexcept
 }
 
 ft_event::ft_event(const ft_event &other) noexcept
-    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _callback(other._callback)
+    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _callback(other._callback), _error(other._error)
 {
+    if (this->_callback.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_callback.get_error());
+        return ;
+    }
+    this->set_error(this->_error);
     return ;
 }
 
@@ -21,6 +33,7 @@ ft_event &ft_event::operator=(const ft_event &other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_duration = other._duration;
         this->_modifier1 = other._modifier1;
@@ -28,12 +41,18 @@ ft_event &ft_event::operator=(const ft_event &other) noexcept
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
         this->_callback = other._callback;
+        if (this->_callback.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_callback.get_error());
+            return (*this);
+        }
+        this->set_error(other_error);
     }
     return (*this);
 }
 
 ft_event::ft_event(ft_event &&other) noexcept
-    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _callback(ft_move(other._callback))
+    : _id(other._id), _duration(other._duration), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _callback(ft_move(other._callback)), _error(other._error)
 {
     other._id = 0;
     other._duration = 0;
@@ -41,6 +60,13 @@ ft_event::ft_event(ft_event &&other) noexcept
     other._modifier2 = 0;
     other._modifier3 = 0;
     other._modifier4 = 0;
+    other.set_error(ER_SUCCESS);
+    if (this->_callback.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_callback.get_error());
+        return ;
+    }
+    this->set_error(this->_error);
     return ;
 }
 
@@ -48,6 +74,7 @@ ft_event &ft_event::operator=(ft_event &&other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_duration = other._duration;
         this->_modifier1 = other._modifier1;
@@ -55,12 +82,26 @@ ft_event &ft_event::operator=(ft_event &&other) noexcept
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
         this->_callback = ft_move(other._callback);
+        if (this->_callback.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_callback.get_error());
+            other._id = 0;
+            other._duration = 0;
+            other._modifier1 = 0;
+            other._modifier2 = 0;
+            other._modifier3 = 0;
+            other._modifier4 = 0;
+            other.set_error(ER_SUCCESS);
+            return (*this);
+        }
+        this->set_error(other_error);
         other._id = 0;
         other._duration = 0;
         other._modifier1 = 0;
         other._modifier2 = 0;
         other._modifier3 = 0;
         other._modifier4 = 0;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -72,7 +113,13 @@ int ft_event::get_id() const noexcept
 
 void ft_event::set_id(int id) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_id = id;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -83,19 +130,37 @@ int ft_event::get_duration() const noexcept
 
 void ft_event::set_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration = duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::add_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration += duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::sub_duration(int duration) noexcept
 {
+    if (duration < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_duration -= duration;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -107,18 +172,21 @@ int ft_event::get_modifier1() const noexcept
 void ft_event::set_modifier1(int mod) noexcept
 {
     this->_modifier1 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::add_modifier1(int mod) noexcept
 {
     this->_modifier1 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::sub_modifier1(int mod) noexcept
 {
     this->_modifier1 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -130,18 +198,21 @@ int ft_event::get_modifier2() const noexcept
 void ft_event::set_modifier2(int mod) noexcept
 {
     this->_modifier2 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::add_modifier2(int mod) noexcept
 {
     this->_modifier2 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::sub_modifier2(int mod) noexcept
 {
     this->_modifier2 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -153,18 +224,21 @@ int ft_event::get_modifier3() const noexcept
 void ft_event::set_modifier3(int mod) noexcept
 {
     this->_modifier3 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::add_modifier3(int mod) noexcept
 {
     this->_modifier3 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::sub_modifier3(int mod) noexcept
 {
     this->_modifier3 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -176,28 +250,63 @@ int ft_event::get_modifier4() const noexcept
 void ft_event::set_modifier4(int mod) noexcept
 {
     this->_modifier4 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::add_modifier4(int mod) noexcept
 {
     this->_modifier4 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_event::sub_modifier4(int mod) noexcept
 {
     this->_modifier4 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 const ft_function<void(ft_world&, ft_event&)> &ft_event::get_callback() const noexcept
 {
+    if (this->_callback.get_error() != ER_SUCCESS)
+        this->set_error(this->_callback.get_error());
+    else
+        this->set_error(ER_SUCCESS);
     return (this->_callback);
 }
 
 void ft_event::set_callback(ft_function<void(ft_world&, ft_event&)> &&callback) noexcept
 {
+    if (callback.get_error() != ER_SUCCESS)
+    {
+        this->set_error(callback.get_error());
+        return ;
+    }
     this->_callback = ft_move(callback);
+    if (this->_callback.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_callback.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+int ft_event::get_error() const noexcept
+{
+    return (this->_error);
+}
+
+const char *ft_event::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+
+void ft_event::set_error(int err) const noexcept
+{
+    ft_errno = err;
+    this->_error = err;
     return ;
 }

--- a/Game/game_event.hpp
+++ b/Game/game_event.hpp
@@ -2,6 +2,7 @@
 # define GAME_EVENT_HPP
 
 #include "../Template/function.hpp"
+#include "../Errno/errno.hpp"
 
 class ft_world;
 
@@ -15,6 +16,9 @@ class ft_event
         int _modifier3;
         int _modifier4;
         ft_function<void(ft_world&, ft_event&)> _callback;
+        mutable int _error;
+
+        void set_error(int err) const noexcept;
 
     public:
         ft_event() noexcept;
@@ -54,6 +58,9 @@ class ft_event
 
         const ft_function<void(ft_world&, ft_event&)> &get_callback() const noexcept;
         void set_callback(ft_function<void(ft_world&, ft_event&)> &&callback) noexcept;
+
+        int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Game/game_experience_table.cpp
+++ b/Game/game_experience_table.cpp
@@ -16,6 +16,7 @@ ft_experience_table::ft_experience_table(int count) noexcept
         }
         this->_count = count;
     }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -25,7 +26,7 @@ ft_experience_table::~ft_experience_table()
         cma_free(this->_levels);
     this->_levels = ft_nullptr;
     this->_count = 0;
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -38,6 +39,7 @@ ft_experience_table::ft_experience_table(const ft_experience_table &other) noexc
         if (!this->_levels)
         {
             this->set_error(CMA_BAD_ALLOC);
+            this->_count = 0;
             return ;
         }
         int index = 0;
@@ -47,6 +49,7 @@ ft_experience_table::ft_experience_table(const ft_experience_table &other) noexc
             ++index;
         }
     }
+    this->set_error(other._error);
     return ;
 }
 
@@ -58,13 +61,13 @@ ft_experience_table &ft_experience_table::operator=(const ft_experience_table &o
             cma_free(this->_levels);
         this->_levels = ft_nullptr;
         this->_count = other._count;
-        this->_error = other._error;
         if (this->_count > 0)
         {
             this->_levels = static_cast<int*>(cma_calloc(this->_count, sizeof(int)));
             if (!this->_levels)
             {
                 this->set_error(CMA_BAD_ALLOC);
+                this->_count = 0;
                 return (*this);
             }
             int index = 0;
@@ -74,6 +77,7 @@ ft_experience_table &ft_experience_table::operator=(const ft_experience_table &o
                 ++index;
             }
         }
+        this->set_error(other._error);
     }
     return (*this);
 }
@@ -83,7 +87,8 @@ ft_experience_table::ft_experience_table(ft_experience_table &&other) noexcept
 {
     other._levels = ft_nullptr;
     other._count = 0;
-    other._error = ER_SUCCESS;
+    this->set_error(this->_error);
+    other.set_error(ER_SUCCESS);
     return ;
 }
 
@@ -95,10 +100,10 @@ ft_experience_table &ft_experience_table::operator=(ft_experience_table &&other)
             cma_free(this->_levels);
         this->_levels = other._levels;
         this->_count = other._count;
-        this->_error = other._error;
+        this->set_error(other._error);
         other._levels = ft_nullptr;
         other._count = 0;
-        other._error = ER_SUCCESS;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -126,12 +131,13 @@ bool ft_experience_table::is_valid(int count, const int *array) const noexcept
 
 int ft_experience_table::get_count() const noexcept
 {
+    const_cast<ft_experience_table*>(this)->set_error(ER_SUCCESS);
     return (this->_count);
 }
 
 int ft_experience_table::resize(int new_count) noexcept
 {
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     if (new_count <= 0)
     {
         if (this->_levels)
@@ -159,23 +165,29 @@ int ft_experience_table::resize(int new_count) noexcept
     }
     this->_levels = new_levels;
     this->_count = new_count;
-    int check_count;
-    if (old_count < new_count)
-        check_count = old_count;
-    else
+    int check_count = old_count;
+    if (old_count > new_count)
         check_count = new_count;
     if (!this->is_valid(check_count, this->_levels))
+    {
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
-    return (this->_error);
+        return (this->_error);
+    }
+    this->set_error(ER_SUCCESS);
+    return (ER_SUCCESS);
 }
 
 int ft_experience_table::get_level(int experience) const noexcept
 {
     if (!this->_levels || this->_count == 0)
+    {
+        const_cast<ft_experience_table*>(this)->set_error(ER_SUCCESS);
         return (0);
+    }
     int level = 0;
     while (level < this->_count && experience >= this->_levels[level])
         ++level;
+    const_cast<ft_experience_table*>(this)->set_error(ER_SUCCESS);
     return (level);
 }
 
@@ -186,6 +198,7 @@ int ft_experience_table::get_value(int index) const noexcept
         const_cast<ft_experience_table*>(this)->set_error(VECTOR_OUT_OF_BOUNDS);
         return (0);
     }
+    const_cast<ft_experience_table*>(this)->set_error(ER_SUCCESS);
     return (this->_levels[index]);
 }
 
@@ -198,13 +211,17 @@ void ft_experience_table::set_value(int index, int value) noexcept
     }
     this->_levels[index] = value;
     if (!this->is_valid(this->_count, this->_levels))
+    {
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_experience_table::set_levels(const int *levels, int count) noexcept
 {
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     if (count <= 0 || !levels)
         return (this->resize(0));
     if (this->resize(count) != ER_SUCCESS)
@@ -216,14 +233,18 @@ int ft_experience_table::set_levels(const int *levels, int count) noexcept
         ++level_index;
     }
     if (!this->is_valid(this->_count, this->_levels))
+    {
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
-    return (this->_error);
+        return (this->_error);
+    }
+    this->set_error(ER_SUCCESS);
+    return (ER_SUCCESS);
 }
 
 int ft_experience_table::generate_levels_total(int count, int base,
                                                double multiplier) noexcept
 {
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     if (count <= 0)
         return (this->resize(0));
     if (this->resize(count) != ER_SUCCESS)
@@ -237,14 +258,18 @@ int ft_experience_table::generate_levels_total(int count, int base,
         ++level_index;
     }
     if (!this->is_valid(this->_count, this->_levels))
+    {
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
-    return (this->_error);
+        return (this->_error);
+    }
+    this->set_error(ER_SUCCESS);
+    return (ER_SUCCESS);
 }
 
 int ft_experience_table::generate_levels_scaled(int count, int base,
                                                 double multiplier) noexcept
 {
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     if (count <= 0)
         return (this->resize(0));
     if (this->resize(count) != ER_SUCCESS)
@@ -261,14 +286,21 @@ int ft_experience_table::generate_levels_scaled(int count, int base,
         ++index;
     }
     if (!this->is_valid(this->_count, this->_levels))
+    {
         this->set_error(CHARACTER_LEVEL_TABLE_INVALID);
-    return (this->_error);
+        return (this->_error);
+    }
+    this->set_error(ER_SUCCESS);
+    return (ER_SUCCESS);
 }
 
 int ft_experience_table::check_for_error() const noexcept
 {
     if (!this->_levels)
+    {
+        const_cast<ft_experience_table*>(this)->set_error(ER_SUCCESS);
         return (0);
+    }
     int index = 1;
     while (index < this->_count)
     {
@@ -280,6 +312,7 @@ int ft_experience_table::check_for_error() const noexcept
         }
         ++index;
     }
+    const_cast<ft_experience_table*>(this)->set_error(ER_SUCCESS);
     return (0);
 }
 

--- a/Game/game_inventory.cpp
+++ b/Game/game_inventory.cpp
@@ -6,7 +6,11 @@ ft_inventory::ft_inventory(size_t capacity, int weight_limit) noexcept
       _next_slot(0), _error(ER_SUCCESS)
 {
     if (this->_items.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_items.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -16,7 +20,11 @@ ft_inventory::ft_inventory(const ft_inventory &other) noexcept
       _next_slot(other._next_slot), _error(other._error)
 {
     if (this->_items.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_items.get_error());
+        return ;
+    }
+    this->set_error(other._error);
     return ;
 }
 
@@ -30,9 +38,12 @@ ft_inventory &ft_inventory::operator=(const ft_inventory &other) noexcept
         this->_weight_limit = other._weight_limit;
         this->_current_weight = other._current_weight;
         this->_next_slot = other._next_slot;
-        this->_error = other._error;
         if (this->_items.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_items.get_error());
+            return (*this);
+        }
+        this->set_error(other._error);
     }
     return (*this);
 }
@@ -43,13 +54,17 @@ ft_inventory::ft_inventory(ft_inventory &&other) noexcept
       _next_slot(other._next_slot), _error(other._error)
 {
     if (this->_items.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_items.get_error());
+        return ;
+    }
+    this->set_error(this->_error);
     other._capacity = 0;
     other._used_slots = 0;
     other._weight_limit = 0;
     other._current_weight = 0;
     other._next_slot = 0;
-    other._error = ER_SUCCESS;
+    other.set_error(ER_SUCCESS);
     other._items.clear();
     return ;
 }
@@ -64,15 +79,18 @@ ft_inventory &ft_inventory::operator=(ft_inventory &&other) noexcept
         this->_weight_limit = other._weight_limit;
         this->_current_weight = other._current_weight;
         this->_next_slot = other._next_slot;
-        this->_error = other._error;
         if (this->_items.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_items.get_error());
+            return (*this);
+        }
+        this->set_error(other._error);
         other._capacity = 0;
         other._used_slots = 0;
         other._weight_limit = 0;
         other._current_weight = 0;
         other._next_slot = 0;
-        other._error = ER_SUCCESS;
+        other.set_error(ER_SUCCESS);
         other._items.clear();
     }
     return (*this);
@@ -80,38 +98,45 @@ ft_inventory &ft_inventory::operator=(ft_inventory &&other) noexcept
 
 ft_map<int, ft_sharedptr<ft_item> > &ft_inventory::get_items() noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_items);
 }
 
 const ft_map<int, ft_sharedptr<ft_item> > &ft_inventory::get_items() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_items);
 }
 
 size_t ft_inventory::get_capacity() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_capacity);
 }
 
 void ft_inventory::resize(size_t capacity) noexcept
 {
     this->_capacity = capacity;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 size_t ft_inventory::get_used() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_used_slots);
 }
 
 void ft_inventory::set_used_slots(size_t used) noexcept
 {
     this->_used_slots = used;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 bool ft_inventory::is_full() const noexcept
 {
+    this->set_error(ER_SUCCESS);
 #if USE_INVENTORY_SLOTS
     if (this->_capacity != 0 && this->_used_slots >= this->_capacity)
         return (true);
@@ -125,23 +150,27 @@ bool ft_inventory::is_full() const noexcept
 
 int ft_inventory::get_weight_limit() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_weight_limit);
 }
 
 void ft_inventory::set_weight_limit(int limit) noexcept
 {
     this->_weight_limit = limit;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_inventory::get_current_weight() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_current_weight);
 }
 
 void ft_inventory::set_current_weight(int weight) noexcept
 {
     this->_current_weight = weight;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -159,7 +188,7 @@ void ft_inventory::set_error(int err) const noexcept
 
 int ft_inventory::add_item(const ft_sharedptr<ft_item> &item) noexcept
 {
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     if (!item)
     {
         this->set_error(GAME_GENERAL_ERROR);
@@ -260,6 +289,7 @@ int ft_inventory::add_item(const ft_sharedptr<ft_item> &item) noexcept
 #endif
         remaining -= to_add;
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }
 
@@ -282,11 +312,18 @@ void ft_inventory::remove_item(int slot) noexcept
         }
     }
     this->_items.remove(slot);
+    if (this->_items.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_items.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_inventory::count_item(int item_id) const noexcept
 {
+    this->set_error(ER_SUCCESS);
     const Pair<int, ft_sharedptr<ft_item> > *item_ptr = this->_items.end() - this->_items.size();
     const Pair<int, ft_sharedptr<ft_item> > *item_end = this->_items.end();
     int total = 0;
@@ -309,6 +346,7 @@ int ft_inventory::count_item(int item_id) const noexcept
         }
         ++item_ptr;
     }
+    this->set_error(ER_SUCCESS);
     return (total);
 }
 
@@ -319,6 +357,7 @@ bool ft_inventory::has_item(int item_id) const noexcept
 
 int ft_inventory::count_rarity(int rarity) const noexcept
 {
+    this->set_error(ER_SUCCESS);
     const Pair<int, ft_sharedptr<ft_item> > *item_ptr = this->_items.end() - this->_items.size();
     const Pair<int, ft_sharedptr<ft_item> > *item_end = this->_items.end();
     int total = 0;
@@ -341,6 +380,7 @@ int ft_inventory::count_rarity(int rarity) const noexcept
         }
         ++item_ptr;
     }
+    this->set_error(ER_SUCCESS);
     return (total);
 }
 

--- a/Game/game_map3d.cpp
+++ b/Game/game_map3d.cpp
@@ -8,6 +8,8 @@ ft_map3d::ft_map3d(size_t width, size_t height, size_t depth, int value)
     : _data(ft_nullptr), _width(0), _height(0), _depth(0), _error(ER_SUCCESS)
 {
     this->allocate(width, height, depth, value);
+    if (this->_error == ER_SUCCESS)
+        this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -21,6 +23,8 @@ ft_map3d::ft_map3d(const ft_map3d &other)
     : _data(ft_nullptr), _width(0), _height(0), _depth(0), _error(ER_SUCCESS)
 {
     this->allocate(other._width, other._height, other._depth, 0);
+    if (this->_error != ER_SUCCESS)
+        return ;
     if (this->_data)
     {
         size_t z = 0;
@@ -40,7 +44,7 @@ ft_map3d::ft_map3d(const ft_map3d &other)
             ++z;
         }
     }
-    this->_error = other._error;
+    this->set_error(other._error);
     return ;
 }
 
@@ -50,6 +54,8 @@ ft_map3d &ft_map3d::operator=(const ft_map3d &other)
     {
         this->deallocate();
         this->allocate(other._width, other._height, other._depth, 0);
+        if (this->_error != ER_SUCCESS)
+            return (*this);
         if (this->_data)
         {
             size_t z = 0;
@@ -69,7 +75,7 @@ ft_map3d &ft_map3d::operator=(const ft_map3d &other)
                 ++z;
             }
         }
-        this->_error = other._error;
+        this->set_error(other._error);
     }
     return (*this);
 }
@@ -81,7 +87,8 @@ ft_map3d::ft_map3d(ft_map3d &&other) noexcept
     other._width = 0;
     other._height = 0;
     other._depth = 0;
-    other._error = ER_SUCCESS;
+    this->set_error(this->_error);
+    other.set_error(ER_SUCCESS);
     return ;
 }
 
@@ -94,12 +101,12 @@ ft_map3d &ft_map3d::operator=(ft_map3d &&other) noexcept
         this->_width = other._width;
         this->_height = other._height;
         this->_depth = other._depth;
-        this->_error = other._error;
+        this->set_error(other._error);
         other._data = ft_nullptr;
         other._width = 0;
         other._height = 0;
         other._depth = 0;
-        other._error = ER_SUCCESS;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -108,6 +115,8 @@ void ft_map3d::resize(size_t width, size_t height, size_t depth, int value)
 {
     this->deallocate();
     this->allocate(width, height, depth, value);
+    if (this->_error == ER_SUCCESS)
+        this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -140,6 +149,7 @@ int ft_map3d::get(size_t x, size_t y, size_t z) const
         const_cast<ft_map3d*>(this)->set_error(MAP3D_OUT_OF_BOUNDS);
         return (0);
     }
+    const_cast<ft_map3d*>(this)->set_error(ER_SUCCESS);
     return (this->_data[z][y][x]);
 }
 
@@ -151,13 +161,18 @@ void ft_map3d::set(size_t x, size_t y, size_t z, int value)
         return ;
     }
     this->_data[z][y][x] = value;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_map3d::is_obstacle(size_t x, size_t y, size_t z) const
 {
-    if (this->get(x, y, z) != 0)
+    int value = this->get(x, y, z);
+    if (this->_error != ER_SUCCESS)
+        return (0);
+    if (value != 0)
         return (1);
+    this->set_error(ER_SUCCESS);
     return (0);
 }
 
@@ -174,27 +189,31 @@ void ft_map3d::toggle_obstacle(size_t x, size_t y, size_t z, ft_pathfinding *lis
         this->_data[z][y][x] = 0;
     if (listener)
         listener->update_obstacle(x, y, z, this->_data[z][y][x]);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 size_t ft_map3d::get_width() const
 {
+    const_cast<ft_map3d*>(this)->set_error(ER_SUCCESS);
     return (this->_width);
 }
 
 size_t ft_map3d::get_height() const
 {
+    const_cast<ft_map3d*>(this)->set_error(ER_SUCCESS);
     return (this->_height);
 }
 
 size_t ft_map3d::get_depth() const
 {
+    const_cast<ft_map3d*>(this)->set_error(ER_SUCCESS);
     return (this->_depth);
 }
 
 void ft_map3d::allocate(size_t width, size_t height, size_t depth, int value)
 {
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     this->_width = width;
     this->_height = height;
     this->_depth = depth;
@@ -251,13 +270,21 @@ void ft_map3d::allocate(size_t width, size_t height, size_t depth, int value)
         }
         ++z;
     }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_map3d::deallocate()
 {
     if (!this->_data)
+    {
+        this->_width = 0;
+        this->_height = 0;
+        this->_depth = 0;
+        if (this->_error == ER_SUCCESS)
+            this->set_error(ER_SUCCESS);
         return ;
+    }
     size_t z = 0;
     while (z < this->_depth)
     {
@@ -275,6 +302,7 @@ void ft_map3d::deallocate()
     this->_width = 0;
     this->_height = 0;
     this->_depth = 0;
-    this->_error = ER_SUCCESS;
+    if (this->_error == ER_SUCCESS)
+        this->set_error(ER_SUCCESS);
     return ;
 }

--- a/Game/game_quest.cpp
+++ b/Game/game_quest.cpp
@@ -1,15 +1,42 @@
 #include "game_quest.hpp"
 
 ft_quest::ft_quest() noexcept
-    : _id(0), _phases(0), _current_phase(0), _description(), _objective(), _reward_experience(0), _reward_items()
+    : _id(0), _phases(0), _current_phase(0), _description(), _objective(), _reward_experience(0), _reward_items(), _error(ER_SUCCESS)
 {
+    if (this->_description.get_error() != ER_SUCCESS)
+        this->set_error(this->_description.get_error());
+    if (this->_error == ER_SUCCESS && this->_objective.get_error() != ER_SUCCESS)
+        this->set_error(this->_objective.get_error());
+    if (this->_error == ER_SUCCESS && this->_reward_items.get_error() != ER_SUCCESS)
+        this->set_error(this->_reward_items.get_error());
+    if (this->_error == ER_SUCCESS)
+        this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_quest::ft_quest(const ft_quest &other) noexcept
-    : _id(other._id), _phases(other._phases), _current_phase(other._current_phase), _description(other._description), _objective(other._objective), _reward_experience(other._reward_experience), _reward_items()
+    : _id(other._id), _phases(other._phases), _current_phase(other._current_phase), _description(other._description), _objective(other._objective), _reward_experience(other._reward_experience), _reward_items(), _error(ER_SUCCESS)
 {
+    if (this->_description.get_error() != ER_SUCCESS)
+        this->set_error(this->_description.get_error());
+    if (this->_error == ER_SUCCESS && other._description.get_error() != ER_SUCCESS)
+        this->set_error(other._description.get_error());
+    if (this->_error == ER_SUCCESS && this->_objective.get_error() != ER_SUCCESS)
+        this->set_error(this->_objective.get_error());
+    if (this->_error == ER_SUCCESS && other._objective.get_error() != ER_SUCCESS)
+        this->set_error(other._objective.get_error());
+    if (this->_error == ER_SUCCESS && this->_reward_items.get_error() != ER_SUCCESS)
+        this->set_error(this->_reward_items.get_error());
+    if (this->_error != ER_SUCCESS)
+        return ;
     this->set_reward_items(other._reward_items);
+    if (this->_error == ER_SUCCESS && other._error != ER_SUCCESS)
+    {
+        this->set_error(other._error);
+        return ;
+    }
+    if (this->_error == ER_SUCCESS)
+        this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -17,24 +44,64 @@ ft_quest &ft_quest::operator=(const ft_quest &other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_phases = other._phases;
         this->_current_phase = other._current_phase;
         this->_description = other._description;
+        if (this->_description.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_description.get_error());
+            return (*this);
+        }
+        if (other._description.get_error() != ER_SUCCESS)
+        {
+            this->set_error(other._description.get_error());
+            return (*this);
+        }
         this->_objective = other._objective;
+        if (this->_objective.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_objective.get_error());
+            return (*this);
+        }
+        if (other._objective.get_error() != ER_SUCCESS)
+        {
+            this->set_error(other._objective.get_error());
+            return (*this);
+        }
         this->_reward_experience = other._reward_experience;
         this->set_reward_items(other._reward_items);
+        if (this->_error != ER_SUCCESS)
+            return (*this);
+        if (other_error != ER_SUCCESS)
+        {
+            this->set_error(other_error);
+            return (*this);
+        }
+        this->set_error(ER_SUCCESS);
     }
     return (*this);
 }
 
 ft_quest::ft_quest(ft_quest &&other) noexcept
-    : _id(other._id), _phases(other._phases), _current_phase(other._current_phase), _description(ft_move(other._description)), _objective(ft_move(other._objective)), _reward_experience(other._reward_experience), _reward_items(ft_move(other._reward_items))
+    : _id(other._id), _phases(other._phases), _current_phase(other._current_phase), _description(ft_move(other._description)), _objective(ft_move(other._objective)), _reward_experience(other._reward_experience), _reward_items(ft_move(other._reward_items)), _error(other._error)
 {
+    if (this->_description.get_error() != ER_SUCCESS)
+        this->set_error(this->_description.get_error());
+    if (this->_error == ER_SUCCESS && this->_objective.get_error() != ER_SUCCESS)
+        this->set_error(this->_objective.get_error());
+    if (this->_error == ER_SUCCESS && this->_reward_items.get_error() != ER_SUCCESS)
+        this->set_error(this->_reward_items.get_error());
     other._id = 0;
     other._phases = 0;
     other._current_phase = 0;
     other._reward_experience = 0;
+    other.set_error(ER_SUCCESS);
+    if (this->_error == ER_SUCCESS)
+        this->set_error(ER_SUCCESS);
+    else
+        this->set_error(this->_error);
     return ;
 }
 
@@ -42,17 +109,35 @@ ft_quest &ft_quest::operator=(ft_quest &&other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_phases = other._phases;
         this->_current_phase = other._current_phase;
         this->_description = ft_move(other._description);
+        if (this->_description.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_description.get_error());
+            return (*this);
+        }
         this->_objective = ft_move(other._objective);
+        if (this->_objective.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_objective.get_error());
+            return (*this);
+        }
         this->_reward_experience = other._reward_experience;
         this->_reward_items = ft_move(other._reward_items);
+        if (this->_reward_items.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_reward_items.get_error());
+            return (*this);
+        }
+        this->set_error(other_error);
         other._id = 0;
         other._phases = 0;
         other._current_phase = 0;
         other._reward_experience = 0;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -64,7 +149,13 @@ int ft_quest::get_id() const noexcept
 
 void ft_quest::set_id(int id) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_id = id;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -75,7 +166,15 @@ int ft_quest::get_phases() const noexcept
 
 void ft_quest::set_phases(int phases) noexcept
 {
+    if (phases < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_phases = phases;
+    if (this->_current_phase > this->_phases)
+        this->_current_phase = this->_phases;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -86,7 +185,13 @@ int ft_quest::get_current_phase() const noexcept
 
 void ft_quest::set_current_phase(int phase) noexcept
 {
+    if (phase < 0 || phase > this->_phases)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_current_phase = phase;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -97,7 +202,18 @@ const ft_string &ft_quest::get_description() const noexcept
 
 void ft_quest::set_description(const ft_string &description) noexcept
 {
+    if (description.get_error() != ER_SUCCESS)
+    {
+        this->set_error(description.get_error());
+        return ;
+    }
     this->_description = description;
+    if (this->_description.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_description.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -108,7 +224,18 @@ const ft_string &ft_quest::get_objective() const noexcept
 
 void ft_quest::set_objective(const ft_string &objective) noexcept
 {
+    if (objective.get_error() != ER_SUCCESS)
+    {
+        this->set_error(objective.get_error());
+        return ;
+    }
     this->_objective = objective;
+    if (this->_objective.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_objective.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -119,30 +246,81 @@ int ft_quest::get_reward_experience() const noexcept
 
 void ft_quest::set_reward_experience(int experience) noexcept
 {
+    if (experience < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_reward_experience = experience;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_vector<ft_sharedptr<ft_item> > &ft_quest::get_reward_items() noexcept
 {
+    if (this->_reward_items.get_error() != ER_SUCCESS)
+        this->set_error(this->_reward_items.get_error());
+    else
+        this->set_error(ER_SUCCESS);
     return (this->_reward_items);
 }
 
 const ft_vector<ft_sharedptr<ft_item> > &ft_quest::get_reward_items() const noexcept
 {
+    if (this->_reward_items.get_error() != ER_SUCCESS)
+        this->set_error(this->_reward_items.get_error());
+    else
+        this->set_error(ER_SUCCESS);
     return (this->_reward_items);
 }
 
 void ft_quest::set_reward_items(const ft_vector<ft_sharedptr<ft_item> > &items) noexcept
 {
+    if (items.get_error() != ER_SUCCESS)
+    {
+        this->set_error(items.get_error());
+        return ;
+    }
     this->_reward_items.clear();
+    if (this->_reward_items.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_reward_items.get_error());
+        return ;
+    }
     size_t index = 0;
     size_t count = items.size();
     while (index < count)
     {
-        this->_reward_items.push_back(items[index]);
+        const ft_sharedptr<ft_item> &item_ptr = items[index];
+        if (items.get_error() != ER_SUCCESS)
+        {
+            this->set_error(items.get_error());
+            return ;
+        }
+        if (!item_ptr)
+        {
+            this->set_error(SHARED_PTR_NULL_PTR);
+            return ;
+        }
+        if (item_ptr.get_error() != ER_SUCCESS)
+        {
+            this->set_error(item_ptr.get_error());
+            return ;
+        }
+        if (item_ptr->get_error() != ER_SUCCESS)
+        {
+            this->set_error(item_ptr->get_error());
+            return ;
+        }
+        this->_reward_items.push_back(item_ptr);
+        if (this->_reward_items.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_reward_items.get_error());
+            return ;
+        }
         index++;
     }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -153,7 +331,34 @@ bool ft_quest::is_complete() const noexcept
 
 void ft_quest::advance_phase() noexcept
 {
-    if (this->_current_phase < this->_phases)
-        ++this->_current_phase;
+    if (this->_phases <= 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
+    if (this->_current_phase >= this->_phases)
+    {
+        this->set_error(GAME_GENERAL_ERROR);
+        return ;
+    }
+    ++this->_current_phase;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+int ft_quest::get_error() const noexcept
+{
+    return (this->_error);
+}
+
+const char *ft_quest::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+
+void ft_quest::set_error(int err) const noexcept
+{
+    ft_errno = err;
+    this->_error = err;
     return ;
 }

--- a/Game/game_quest.hpp
+++ b/Game/game_quest.hpp
@@ -5,6 +5,7 @@
 #include "../Template/vector.hpp"
 #include "game_item.hpp"
 #include "../Template/shared_ptr.hpp"
+#include "../Errno/errno.hpp"
 
 class ft_quest
 {
@@ -16,6 +17,9 @@ class ft_quest
         ft_string _objective;
         int _reward_experience;
         ft_vector<ft_sharedptr<ft_item> > _reward_items;
+        mutable int _error;
+
+        void set_error(int err) const noexcept;
 
     public:
         ft_quest() noexcept;
@@ -49,6 +53,9 @@ class ft_quest
 
         bool is_complete() const noexcept;
         void advance_phase() noexcept;
+
+        int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Game/game_reputation.cpp
+++ b/Game/game_reputation.cpp
@@ -5,9 +5,16 @@ ft_reputation::ft_reputation() noexcept
       _current_rep(0), _error(ER_SUCCESS)
 {
     if (this->_milestones.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_milestones.get_error());
-    else if (this->_reps.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_reps.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_reps.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -16,9 +23,16 @@ ft_reputation::ft_reputation(const ft_map<int, int> &milestones, int total) noex
       _current_rep(0), _error(ER_SUCCESS)
 {
     if (this->_milestones.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_milestones.get_error());
-    else if (this->_reps.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_reps.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_reps.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -27,9 +41,16 @@ ft_reputation::ft_reputation(const ft_reputation &other) noexcept
       _current_rep(other._current_rep), _error(other._error)
 {
     if (this->_milestones.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_milestones.get_error());
-    else if (this->_reps.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_reps.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_reps.get_error());
+        return ;
+    }
+    this->set_error(other._error);
     return ;
 }
 
@@ -41,11 +62,17 @@ ft_reputation &ft_reputation::operator=(const ft_reputation &other) noexcept
         this->_reps = other._reps;
         this->_total_rep = other._total_rep;
         this->_current_rep = other._current_rep;
-        this->_error = other._error;
         if (this->_milestones.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_milestones.get_error());
-        else if (this->_reps.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_reps.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_reps.get_error());
+            return (*this);
+        }
+        this->set_error(other._error);
     }
     return (*this);
 }
@@ -55,9 +82,16 @@ ft_reputation::ft_reputation(ft_reputation &&other) noexcept
       _current_rep(other._current_rep), _error(other._error)
 {
     if (this->_milestones.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_milestones.get_error());
-    else if (this->_reps.get_error() != ER_SUCCESS)
+        return ;
+    }
+    if (this->_reps.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_reps.get_error());
+        return ;
+    }
+    this->set_error(this->_error);
     other._total_rep = 0;
     other._current_rep = 0;
     other._error = ER_SUCCESS;
@@ -74,11 +108,17 @@ ft_reputation &ft_reputation::operator=(ft_reputation &&other) noexcept
         this->_reps = ft_move(other._reps);
         this->_total_rep = other._total_rep;
         this->_current_rep = other._current_rep;
-        this->_error = other._error;
         if (this->_milestones.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_milestones.get_error());
-        else if (this->_reps.get_error() != ER_SUCCESS)
+            return (*this);
+        }
+        if (this->_reps.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_reps.get_error());
+            return (*this);
+        }
+        this->set_error(other._error);
         other._total_rep = 0;
         other._current_rep = 0;
         other._error = ER_SUCCESS;
@@ -90,35 +130,41 @@ ft_reputation &ft_reputation::operator=(ft_reputation &&other) noexcept
 
 int ft_reputation::get_total_rep() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_total_rep);
 }
 
 void ft_reputation::set_total_rep(int rep) noexcept
 {
     this->_total_rep = rep;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_reputation::add_total_rep(int rep) noexcept
 {
     this->_total_rep += rep;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_reputation::sub_total_rep(int rep) noexcept
 {
     this->_total_rep -= rep;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_reputation::get_current_rep() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_current_rep);
 }
 
 void ft_reputation::set_current_rep(int rep) noexcept
 {
     this->_current_rep = rep;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -126,6 +172,7 @@ void ft_reputation::add_current_rep(int rep) noexcept
 {
     this->_current_rep += rep;
     this->_total_rep += rep;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -133,74 +180,135 @@ void ft_reputation::sub_current_rep(int rep) noexcept
 {
     this->_current_rep -= rep;
     this->_total_rep -= rep;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_map<int, int> &ft_reputation::get_milestones() noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_milestones);
 }
 
 const ft_map<int, int> &ft_reputation::get_milestones() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_milestones);
 }
 
 void ft_reputation::set_milestones(const ft_map<int, int> &milestones) noexcept
 {
     this->_milestones = milestones;
+    if (this->_milestones.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_milestones.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_reputation::get_milestone(int id) const noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return (0);
+    }
     const Pair<int, int> *entry = this->_milestones.find(id);
     if (!entry)
+    {
+        this->set_error(MAP_KEY_NOT_FOUND);
         return (0);
+    }
+    this->set_error(ER_SUCCESS);
     return (entry->value);
 }
 
 void ft_reputation::set_milestone(int id, int value) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     Pair<int, int> *entry = this->_milestones.find(id);
     if (!entry)
+    {
         this->_milestones.insert(id, value);
+        if (this->_milestones.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_milestones.get_error());
+            return ;
+        }
+    }
     else
         entry->value = value;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_map<int, int> &ft_reputation::get_reps() noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_reps);
 }
 
 const ft_map<int, int> &ft_reputation::get_reps() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_reps);
 }
 
 void ft_reputation::set_reps(const ft_map<int, int> &reps) noexcept
 {
     this->_reps = reps;
+    if (this->_reps.get_error() != ER_SUCCESS)
+    {
+        this->set_error(this->_reps.get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_reputation::get_rep(int id) const noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return (0);
+    }
     const Pair<int, int> *entry = this->_reps.find(id);
     if (!entry)
+    {
+        this->set_error(MAP_KEY_NOT_FOUND);
         return (0);
+    }
+    this->set_error(ER_SUCCESS);
     return (entry->value);
 }
 
 void ft_reputation::set_rep(int id, int value) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     Pair<int, int> *entry = this->_reps.find(id);
     if (!entry)
+    {
         this->_reps.insert(id, value);
+        if (this->_reps.get_error() != ER_SUCCESS)
+        {
+            this->set_error(this->_reps.get_error());
+            return ;
+        }
+    }
     else
         entry->value = value;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 

--- a/Game/game_skill.cpp
+++ b/Game/game_skill.cpp
@@ -4,6 +4,7 @@
 ft_skill::ft_skill() noexcept
     : _id(0), _level(0), _cooldown(0), _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0), _error(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -15,6 +16,7 @@ ft_skill::~ft_skill() noexcept
 ft_skill::ft_skill(const ft_skill &other) noexcept
     : _id(other._id), _level(other._level), _cooldown(other._cooldown), _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _error(other._error)
 {
+    this->set_error(other._error);
     return ;
 }
 
@@ -29,7 +31,7 @@ ft_skill &ft_skill::operator=(const ft_skill &other) noexcept
         this->_modifier2 = other._modifier2;
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
-        this->_error = other._error;
+        this->set_error(other._error);
     }
     return (*this);
 }
@@ -44,7 +46,8 @@ ft_skill::ft_skill(ft_skill &&other) noexcept
     other._modifier2 = 0;
     other._modifier3 = 0;
     other._modifier4 = 0;
-    other._error = ER_SUCCESS;
+    this->set_error(this->_error);
+    other.set_error(ER_SUCCESS);
     return ;
 }
 
@@ -59,7 +62,7 @@ ft_skill &ft_skill::operator=(ft_skill &&other) noexcept
         this->_modifier2 = other._modifier2;
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
-        this->_error = other._error;
+        this->set_error(other._error);
         other._id = 0;
         other._level = 0;
         other._cooldown = 0;
@@ -67,7 +70,7 @@ ft_skill &ft_skill::operator=(ft_skill &&other) noexcept
         other._modifier2 = 0;
         other._modifier3 = 0;
         other._modifier4 = 0;
-        other._error = ER_SUCCESS;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -81,138 +84,227 @@ void ft_skill::set_error(int err) const noexcept
 
 int ft_skill::get_id() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_id);
 }
 
 void ft_skill::set_id(int id) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_id = id;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_skill::get_level() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_level);
 }
 
 void ft_skill::set_level(int level) noexcept
 {
+    if (level < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_level = level;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_skill::get_cooldown() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_cooldown);
 }
 
 void ft_skill::set_cooldown(int cooldown) noexcept
 {
+    if (cooldown < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_cooldown = cooldown;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::add_cooldown(int cooldown) noexcept
 {
+    if (cooldown < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_cooldown += cooldown;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::sub_cooldown(int cooldown) noexcept
 {
+    if (cooldown < 0 || this->_cooldown < cooldown)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_cooldown -= cooldown;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_skill::get_modifier1() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_modifier1);
 }
 
 void ft_skill::set_modifier1(int mod) noexcept
 {
     this->_modifier1 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::add_modifier1(int mod) noexcept
 {
+    if (mod < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_modifier1 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::sub_modifier1(int mod) noexcept
 {
+    if (mod < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_modifier1 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_skill::get_modifier2() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_modifier2);
 }
 
 void ft_skill::set_modifier2(int mod) noexcept
 {
     this->_modifier2 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::add_modifier2(int mod) noexcept
 {
+    if (mod < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_modifier2 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::sub_modifier2(int mod) noexcept
 {
+    if (mod < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_modifier2 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_skill::get_modifier3() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_modifier3);
 }
 
 void ft_skill::set_modifier3(int mod) noexcept
 {
     this->_modifier3 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::add_modifier3(int mod) noexcept
 {
+    if (mod < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_modifier3 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::sub_modifier3(int mod) noexcept
 {
+    if (mod < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_modifier3 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int ft_skill::get_modifier4() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_modifier4);
 }
 
 void ft_skill::set_modifier4(int mod) noexcept
 {
     this->_modifier4 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::add_modifier4(int mod) noexcept
 {
+    if (mod < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_modifier4 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_skill::sub_modifier4(int mod) noexcept
 {
+    if (mod < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_modifier4 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 

--- a/Game/game_upgrade.cpp
+++ b/Game/game_upgrade.cpp
@@ -2,15 +2,17 @@
 
 ft_upgrade::ft_upgrade() noexcept
     : _id(0), _current_level(0), _max_level(0),
-      _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0)
+      _modifier1(0), _modifier2(0), _modifier3(0), _modifier4(0), _error(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_upgrade::ft_upgrade(const ft_upgrade &other) noexcept
     : _id(other._id), _current_level(other._current_level), _max_level(other._max_level),
-      _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4)
+      _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _error(other._error)
 {
+    this->set_error(this->_error);
     return ;
 }
 
@@ -18,6 +20,7 @@ ft_upgrade &ft_upgrade::operator=(const ft_upgrade &other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_current_level = other._current_level;
         this->_max_level = other._max_level;
@@ -25,13 +28,14 @@ ft_upgrade &ft_upgrade::operator=(const ft_upgrade &other) noexcept
         this->_modifier2 = other._modifier2;
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
+        this->set_error(other_error);
     }
     return (*this);
 }
 
 ft_upgrade::ft_upgrade(ft_upgrade &&other) noexcept
     : _id(other._id), _current_level(other._current_level), _max_level(other._max_level),
-      _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4)
+      _modifier1(other._modifier1), _modifier2(other._modifier2), _modifier3(other._modifier3), _modifier4(other._modifier4), _error(other._error)
 {
     other._id = 0;
     other._current_level = 0;
@@ -40,6 +44,8 @@ ft_upgrade::ft_upgrade(ft_upgrade &&other) noexcept
     other._modifier2 = 0;
     other._modifier3 = 0;
     other._modifier4 = 0;
+    other.set_error(ER_SUCCESS);
+    this->set_error(this->_error);
     return ;
 }
 
@@ -47,6 +53,7 @@ ft_upgrade &ft_upgrade::operator=(ft_upgrade &&other) noexcept
 {
     if (this != &other)
     {
+        int other_error = other._error;
         this->_id = other._id;
         this->_current_level = other._current_level;
         this->_max_level = other._max_level;
@@ -54,6 +61,7 @@ ft_upgrade &ft_upgrade::operator=(ft_upgrade &&other) noexcept
         this->_modifier2 = other._modifier2;
         this->_modifier3 = other._modifier3;
         this->_modifier4 = other._modifier4;
+        this->set_error(other_error);
         other._id = 0;
         other._current_level = 0;
         other._max_level = 0;
@@ -61,6 +69,7 @@ ft_upgrade &ft_upgrade::operator=(ft_upgrade &&other) noexcept
         other._modifier2 = 0;
         other._modifier3 = 0;
         other._modifier4 = 0;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -72,7 +81,13 @@ int ft_upgrade::get_id() const noexcept
 
 void ft_upgrade::set_id(int id) noexcept
 {
+    if (id < 0)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_id = id;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -83,7 +98,13 @@ uint16_t ft_upgrade::get_current_level() const noexcept
 
 void ft_upgrade::set_current_level(uint16_t level) noexcept
 {
+    if (this->_max_level != 0 && level > this->_max_level)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     this->_current_level = level;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -92,6 +113,7 @@ void ft_upgrade::add_level(uint16_t level) noexcept
     this->_current_level += level;
     if (this->_current_level > this->_max_level)
         this->_current_level = this->_max_level;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -101,6 +123,7 @@ void ft_upgrade::sub_level(uint16_t level) noexcept
         this->_current_level = 0;
     else
         this->_current_level -= level;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -112,6 +135,9 @@ uint16_t ft_upgrade::get_max_level() const noexcept
 void ft_upgrade::set_max_level(uint16_t level) noexcept
 {
     this->_max_level = level;
+    if (this->_max_level != 0 && this->_current_level > this->_max_level)
+        this->_current_level = this->_max_level;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -123,18 +149,21 @@ int ft_upgrade::get_modifier1() const noexcept
 void ft_upgrade::set_modifier1(int mod) noexcept
 {
     this->_modifier1 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_upgrade::add_modifier1(int mod) noexcept
 {
     this->_modifier1 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_upgrade::sub_modifier1(int mod) noexcept
 {
     this->_modifier1 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -146,18 +175,21 @@ int ft_upgrade::get_modifier2() const noexcept
 void ft_upgrade::set_modifier2(int mod) noexcept
 {
     this->_modifier2 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_upgrade::add_modifier2(int mod) noexcept
 {
     this->_modifier2 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_upgrade::sub_modifier2(int mod) noexcept
 {
     this->_modifier2 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -169,18 +201,21 @@ int ft_upgrade::get_modifier3() const noexcept
 void ft_upgrade::set_modifier3(int mod) noexcept
 {
     this->_modifier3 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_upgrade::add_modifier3(int mod) noexcept
 {
     this->_modifier3 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_upgrade::sub_modifier3(int mod) noexcept
 {
     this->_modifier3 -= mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -192,18 +227,38 @@ int ft_upgrade::get_modifier4() const noexcept
 void ft_upgrade::set_modifier4(int mod) noexcept
 {
     this->_modifier4 = mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_upgrade::add_modifier4(int mod) noexcept
 {
     this->_modifier4 += mod;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void ft_upgrade::sub_modifier4(int mod) noexcept
 {
     this->_modifier4 -= mod;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+int ft_upgrade::get_error() const noexcept
+{
+    return (this->_error);
+}
+
+const char *ft_upgrade::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error));
+}
+
+void ft_upgrade::set_error(int err) const noexcept
+{
+    ft_errno = err;
+    this->_error = err;
     return ;
 }
 

--- a/Game/game_upgrade.hpp
+++ b/Game/game_upgrade.hpp
@@ -2,6 +2,7 @@
 # define GAME_UPGRADE_HPP
 
 #include <cstdint>
+#include "../Errno/errno.hpp"
 
 class ft_upgrade
 {
@@ -13,6 +14,9 @@ class ft_upgrade
         int      _modifier2;
         int      _modifier3;
         int      _modifier4;
+        mutable int _error;
+
+        void set_error(int err) const noexcept;
 
     public:
         ft_upgrade() noexcept;
@@ -52,6 +56,9 @@ class ft_upgrade
         void set_modifier4(int mod) noexcept;
         void add_modifier4(int mod) noexcept;
         void sub_modifier4(int mod) noexcept;
+
+        int get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 };
 
 #endif

--- a/Game/game_world.cpp
+++ b/Game/game_world.cpp
@@ -38,9 +38,16 @@ ft_world::ft_world() noexcept
     : _event_scheduler(new ft_event_scheduler()), _error(ER_SUCCESS)
 {
     if (this->_event_scheduler.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler.get_error());
+        return ;
+    }
     if (this->_event_scheduler->get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler->get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -48,9 +55,16 @@ ft_world::ft_world(const ft_world &other) noexcept
     : _event_scheduler(other._event_scheduler), _error(other._error)
 {
     if (this->_event_scheduler.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler.get_error());
+        return ;
+    }
     if (this->_event_scheduler->get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler->get_error());
+        return ;
+    }
+    this->set_error(other._error);
     return ;
 }
 
@@ -59,11 +73,17 @@ ft_world &ft_world::operator=(const ft_world &other) noexcept
     if (this != &other)
     {
         this->_event_scheduler = other._event_scheduler;
-        this->_error = other._error;
         if (this->_event_scheduler.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_event_scheduler.get_error());
+            return (*this);
+        }
         if (this->_event_scheduler->get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_event_scheduler->get_error());
+            return (*this);
+        }
+        this->set_error(other._error);
     }
     return (*this);
 }
@@ -72,10 +92,17 @@ ft_world::ft_world(ft_world &&other) noexcept
     : _event_scheduler(ft_move(other._event_scheduler)), _error(other._error)
 {
     if (this->_event_scheduler.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler.get_error());
+        return ;
+    }
     if (this->_event_scheduler->get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler->get_error());
-    other._error = ER_SUCCESS;
+        return ;
+    }
+    this->set_error(this->_error);
+    other.set_error(ER_SUCCESS);
     return ;
 }
 
@@ -84,12 +111,18 @@ ft_world &ft_world::operator=(ft_world &&other) noexcept
     if (this != &other)
     {
         this->_event_scheduler = ft_move(other._event_scheduler);
-        this->_error = other._error;
         if (this->_event_scheduler.get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_event_scheduler.get_error());
+            return (*this);
+        }
         if (this->_event_scheduler->get_error() != ER_SUCCESS)
+        {
             this->set_error(this->_event_scheduler->get_error());
-        other._error = ER_SUCCESS;
+            return (*this);
+        }
+        this->set_error(other._error);
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -113,9 +146,16 @@ void ft_world::schedule_event(const ft_sharedptr<ft_event> &event) noexcept
     }
     this->_event_scheduler->schedule_event(event);
     if (this->_event_scheduler.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler.get_error());
+        return ;
+    }
     if (this->_event_scheduler->get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler->get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -133,19 +173,28 @@ void ft_world::update_events(ft_sharedptr<ft_world> &self, int ticks, const char
     }
     this->_event_scheduler->update_events(self, ticks, log_file_path, log_buffer);
     if (this->_event_scheduler.get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler.get_error());
+        return ;
+    }
     if (this->_event_scheduler->get_error() != ER_SUCCESS)
+    {
         this->set_error(this->_event_scheduler->get_error());
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 ft_sharedptr<ft_event_scheduler> &ft_world::get_event_scheduler() noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_event_scheduler);
 }
 
 const ft_sharedptr<ft_event_scheduler> &ft_world::get_event_scheduler() const noexcept
 {
+    this->set_error(ER_SUCCESS);
     return (this->_event_scheduler);
 }
 

--- a/HTML/document.hpp
+++ b/HTML/document.hpp
@@ -5,6 +5,12 @@
 
 class html_document
 {
+    private:
+        html_node *_root;
+        mutable int _error_code;
+
+        void set_error(int error_code) const noexcept;
+
     public:
         html_document() noexcept;
         ~html_document() noexcept;
@@ -25,10 +31,10 @@ class html_document
         html_node   *find_by_text(const char *text_content) const noexcept;
         html_node   *find_by_selector(const char *selector) const noexcept;
         size_t      count_nodes_by_tag(const char *tag_name) const noexcept;
+        html_node   *get_root() const noexcept;
+        int         get_error() const noexcept;
+        const char  *get_error_str() const noexcept;
         void        clear() noexcept;
-
-    private:
-        html_node *_root;
 };
 
 #endif

--- a/HTML/html_document.cpp
+++ b/HTML/html_document.cpp
@@ -1,9 +1,11 @@
 #include "document.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 html_document::html_document() noexcept
-    : _root(ft_nullptr)
+    : _root(ft_nullptr), _error_code(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -15,95 +17,273 @@ html_document::~html_document() noexcept
 
 html_node *html_document::create_node(const char *tag_name, const char *text_content) noexcept
 {
-    return (html_create_node(tag_name, text_content));
+    html_node *node;
+
+    if (!tag_name)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    ft_errno = ER_SUCCESS;
+    node = html_create_node(tag_name, text_content);
+    if (!node)
+    {
+        if (ft_errno == ER_SUCCESS)
+            this->set_error(FT_EALLOC);
+        else
+            this->set_error(ft_errno);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (node);
 }
 
 html_attr *html_document::create_attr(const char *key, const char *value) noexcept
 {
-    return (html_create_attr(key, value));
+    html_attr *attribute;
+
+    if (!key || !value)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    ft_errno = ER_SUCCESS;
+    attribute = html_create_attr(key, value);
+    if (!attribute)
+    {
+        if (ft_errno == ER_SUCCESS)
+            this->set_error(FT_EALLOC);
+        else
+            this->set_error(ft_errno);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (attribute);
 }
 
 void html_document::add_attr(html_node *target_node, html_attr *new_attribute) noexcept
 {
+    if (!target_node || !new_attribute)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     html_add_attr(target_node, new_attribute);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void html_document::remove_attr(html_node *target_node, const char *key) noexcept
 {
+    if (!target_node || !key)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     html_remove_attr(target_node, key);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void html_document::add_child(html_node *parent_node, html_node *child_node) noexcept
 {
+    if (!parent_node || !child_node)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     html_add_child(parent_node, child_node);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void html_document::append_node(html_node *new_node) noexcept
 {
+    if (!new_node)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     html_append_node(&this->_root, new_node);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int html_document::write_to_file(const char *file_path) const noexcept
 {
-    return (html_write_to_file(file_path, this->_root));
+    int result;
+
+    if (!file_path)
+    {
+        this->set_error(FT_EINVAL);
+        return (-1);
+    }
+    ft_errno = ER_SUCCESS;
+    result = html_write_to_file(file_path, this->_root);
+    if (result != 0)
+    {
+        if (ft_errno == ER_SUCCESS)
+            this->set_error(FILE_INVALID_FD);
+        else
+            this->set_error(ft_errno);
+        return (-1);
+    }
+    this->set_error(ER_SUCCESS);
+    return (0);
 }
 
 char *html_document::write_to_string() const noexcept
 {
-    return (html_write_to_string(this->_root));
+    char *result;
+
+    ft_errno = ER_SUCCESS;
+    result = html_write_to_string(this->_root);
+    if (!result)
+    {
+        if (ft_errno == ER_SUCCESS)
+            this->set_error(FT_EALLOC);
+        else
+            this->set_error(ft_errno);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (result);
 }
 
 void html_document::remove_nodes_by_tag(const char *tag_name) noexcept
 {
+    if (!tag_name)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     html_remove_nodes_by_tag(&this->_root, tag_name);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void html_document::remove_nodes_by_attr(const char *key, const char *value) noexcept
 {
+    if (!key || !value)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     html_remove_nodes_by_attr(&this->_root, key, value);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void html_document::remove_nodes_by_text(const char *text_content) noexcept
 {
+    if (!text_content)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     html_remove_nodes_by_text(&this->_root, text_content);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 html_node *html_document::find_by_tag(const char *tag_name) const noexcept
 {
-    return (html_find_by_tag(this->_root, tag_name));
+    html_node *node;
+
+    if (!tag_name)
+    {
+        const_cast<html_document *>(this)->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    node = html_find_by_tag(this->_root, tag_name);
+    const_cast<html_document *>(this)->set_error(ER_SUCCESS);
+    return (node);
 }
 
 html_node *html_document::find_by_attr(const char *key, const char *value) const noexcept
 {
-    return (html_find_by_attr(this->_root, key, value));
+    html_node *node;
+
+    if (!key || !value)
+    {
+        const_cast<html_document *>(this)->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    node = html_find_by_attr(this->_root, key, value);
+    const_cast<html_document *>(this)->set_error(ER_SUCCESS);
+    return (node);
 }
 
 html_node *html_document::find_by_text(const char *text_content) const noexcept
 {
-    return (html_find_by_text(this->_root, text_content));
+    html_node *node;
+
+    if (!text_content)
+    {
+        const_cast<html_document *>(this)->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    node = html_find_by_text(this->_root, text_content);
+    const_cast<html_document *>(this)->set_error(ER_SUCCESS);
+    return (node);
 }
 
 html_node *html_document::find_by_selector(const char *selector) const noexcept
 {
-    return (html_find_by_selector(this->_root, selector));
+    html_node *node;
+
+    if (!selector)
+    {
+        const_cast<html_document *>(this)->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    node = html_find_by_selector(this->_root, selector);
+    const_cast<html_document *>(this)->set_error(ER_SUCCESS);
+    return (node);
 }
 
 size_t html_document::count_nodes_by_tag(const char *tag_name) const noexcept
 {
-    return (html_count_nodes_by_tag(this->_root, tag_name));
+    size_t count;
+
+    if (!tag_name)
+    {
+        const_cast<html_document *>(this)->set_error(FT_EINVAL);
+        return (0);
+    }
+    count = html_count_nodes_by_tag(this->_root, tag_name);
+    const_cast<html_document *>(this)->set_error(ER_SUCCESS);
+    return (count);
+}
+
+html_node *html_document::get_root() const noexcept
+{
+    const_cast<html_document *>(this)->set_error(ER_SUCCESS);
+    return (this->_root);
+}
+
+int html_document::get_error() const noexcept
+{
+    return (this->_error_code);
+}
+
+const char *html_document::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error_code));
 }
 
 void html_document::clear() noexcept
 {
     html_free_nodes(this->_root);
     this->_root = ft_nullptr;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+void html_document::set_error(int error_code) const noexcept
+{
+    this->_error_code = error_code;
+    ft_errno = error_code;
     return ;
 }
 

--- a/JSon/document.hpp
+++ b/JSon/document.hpp
@@ -5,6 +5,12 @@
 
 class json_document
 {
+    private:
+        json_group *_groups;
+        mutable int _error_code;
+
+        void set_error(int error_code) const noexcept;
+
     public:
         json_document() noexcept;
         ~json_document() noexcept;
@@ -29,9 +35,8 @@ class json_document
         void         update_item(json_group *group, const char *key, const bool value) noexcept;
         void         update_item(json_group *group, const char *key, const ft_big_number &value) noexcept;
         void         clear() noexcept;
-
-    private:
-        json_group *_groups;
+        int          get_error() const noexcept;
+        const char   *get_error_str() const noexcept;
 };
 
 #endif

--- a/JSon/json_document.cpp
+++ b/JSon/json_document.cpp
@@ -1,9 +1,11 @@
 #include "document.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 json_document::json_document() noexcept
-    : _groups(ft_nullptr)
+    : _groups(ft_nullptr), _error_code(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -15,112 +17,358 @@ json_document::~json_document() noexcept
 
 json_group *json_document::create_group(const char *name) noexcept
 {
-    return (json_create_json_group(name));
+    if (!name)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    json_group *group = json_create_json_group(name);
+    if (!group)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (group);
 }
 
 json_item *json_document::create_item(const char *key, const char *value) noexcept
 {
-    return (json_create_item(key, value));
+    if (!key || !value)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    json_item *item = json_create_item(key, value);
+    if (!item)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (item);
 }
 
 json_item *json_document::create_item(const char *key, const ft_big_number &value) noexcept
 {
-    return (json_create_item(key, value));
+    if (!key)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    json_item *item = json_create_item(key, value);
+    if (!item)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (item);
 }
 
 json_item *json_document::create_item(const char *key, const int value) noexcept
 {
-    return (json_create_item(key, value));
+    if (!key)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    json_item *item = json_create_item(key, value);
+    if (!item)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (item);
 }
 
 json_item *json_document::create_item(const char *key, const bool value) noexcept
 {
-    return (json_create_item(key, value));
+    if (!key)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    json_item *item = json_create_item(key, value);
+    if (!item)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (item);
 }
 
 void json_document::add_item(json_group *group, json_item *item) noexcept
 {
+    if (!group || !item)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     json_add_item_to_group(group, item);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void json_document::append_group(json_group *group) noexcept
 {
+    if (!group)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     json_append_group(&this->_groups, group);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 int json_document::write_to_file(const char *file_path) const noexcept
 {
-    return (json_write_to_file(file_path, this->_groups));
+    if (!file_path)
+    {
+        this->set_error(FT_EINVAL);
+        return (-1);
+    }
+    int result = json_write_to_file(file_path, this->_groups);
+    if (result != 0)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = FILE_INVALID_FD;
+        this->set_error(current_error);
+        return (result);
+    }
+    this->set_error(ER_SUCCESS);
+    return (0);
 }
 
 char *json_document::write_to_string() const noexcept
 {
-    return (json_write_to_string(this->_groups));
+    char *result = json_write_to_string(this->_groups);
+    if (!result)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return (ft_nullptr);
+    }
+    this->set_error(ER_SUCCESS);
+    return (result);
 }
 
 int json_document::read_from_file(const char *file_path) noexcept
 {
-    this->clear();
-    this->_groups = json_read_from_file(file_path);
-    if (!this->_groups)
+    if (!file_path)
+    {
+        this->clear();
+        this->set_error(FT_EINVAL);
         return (-1);
+    }
+    this->clear();
+    json_group *groups = json_read_from_file(file_path);
+    if (!groups)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = FT_EINVAL;
+        this->set_error(current_error);
+        return (-1);
+    }
+    this->_groups = groups;
+    this->set_error(ER_SUCCESS);
     return (0);
 }
 
 int json_document::read_from_string(const char *content) noexcept
 {
-    this->clear();
-    this->_groups = json_read_from_string(content);
-    if (!this->_groups)
+    if (!content)
+    {
+        this->clear();
+        this->set_error(FT_EINVAL);
         return (-1);
+    }
+    this->clear();
+    json_group *groups = json_read_from_string(content);
+    if (!groups)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = FT_EINVAL;
+        this->set_error(current_error);
+        return (-1);
+    }
+    this->_groups = groups;
+    this->set_error(ER_SUCCESS);
     return (0);
 }
 
 json_group *json_document::find_group(const char *name) const noexcept
 {
-    return (json_find_group(this->_groups, name));
+    if (!name)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    json_group *group = json_find_group(this->_groups, name);
+    this->set_error(ER_SUCCESS);
+    return (group);
 }
 
 json_item *json_document::find_item(json_group *group, const char *key) const noexcept
 {
-    return (json_find_item(group, key));
+    if (!group || !key)
+    {
+        this->set_error(FT_EINVAL);
+        return (ft_nullptr);
+    }
+    json_item *item = json_find_item(group, key);
+    this->set_error(ER_SUCCESS);
+    return (item);
 }
 
 void json_document::remove_group(const char *name) noexcept
 {
+    if (!name)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     json_remove_group(&this->_groups, name);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void json_document::remove_item(json_group *group, const char *key) noexcept
 {
+    if (!group || !key)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     json_remove_item(group, key);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void json_document::update_item(json_group *group, const char *key, const char *value) noexcept
 {
+    if (!group || !key || !value)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
+    json_item *item = json_find_item(group, key);
+    if (!item)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     json_update_item(group, key, value);
+    if (!item->value)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void json_document::update_item(json_group *group, const char *key, const int value) noexcept
 {
+    if (!group || !key)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
+    json_item *item = json_find_item(group, key);
+    if (!item)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     json_update_item(group, key, value);
+    if (!item->value)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void json_document::update_item(json_group *group, const char *key, const bool value) noexcept
 {
+    if (!group || !key)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
+    json_item *item = json_find_item(group, key);
+    if (!item)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     json_update_item(group, key, value);
+    if (!item->value)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 void json_document::update_item(json_group *group, const char *key, const ft_big_number &value) noexcept
 {
+    if (!group || !key)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
+    json_item *item = json_find_item(group, key);
+    if (!item)
+    {
+        this->set_error(FT_EINVAL);
+        return ;
+    }
     json_update_item(group, key, value);
+    if (!item->value)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = JSON_MALLOC_FAIL;
+        this->set_error(current_error);
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -128,6 +376,24 @@ void json_document::clear() noexcept
 {
     json_free_groups(this->_groups);
     this->_groups = ft_nullptr;
+    this->set_error(ER_SUCCESS);
+    return ;
+}
+
+int json_document::get_error() const noexcept
+{
+    return (this->_error_code);
+}
+
+const char *json_document::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error_code));
+}
+
+void json_document::set_error(int error_code) const noexcept
+{
+    this->_error_code = error_code;
+    ft_errno = error_code;
     return ;
 }
 

--- a/Logger/logger.hpp
+++ b/Logger/logger.hpp
@@ -45,6 +45,9 @@ class ft_logger
     private:
         bool _alloc_logging;
         bool _api_logging;
+        mutable int _error_code;
+
+        void set_error(int error_code) const noexcept;
 
     public:
         ft_logger(const char *path = nullptr, size_t max_size = 0,
@@ -69,6 +72,8 @@ class ft_logger
         int  set_syslog(const char *identifier) noexcept;
         int  set_remote_sink(const char *host, unsigned short port,
                              bool use_tcp) noexcept;
+        int  get_error() const noexcept;
+        const char *get_error_str() const noexcept;
 
         void debug(const char *fmt, ...) noexcept;
         void info(const char *fmt, ...) noexcept;

--- a/Logger/logger_log_add_sink.cpp
+++ b/Logger/logger_log_add_sink.cpp
@@ -5,13 +5,20 @@
 int ft_log_add_sink(t_log_sink sink, void *user_data)
 {
     if (!sink)
+    {
+        ft_errno = FT_EINVAL;
         return (-1);
+    }
     s_log_sink entry;
     entry.function = sink;
     entry.user_data = user_data;
     g_sinks.push_back(entry);
     if (g_sinks.get_error() != ER_SUCCESS)
+    {
+        ft_errno = g_sinks.get_error();
         return (-1);
+    }
+    ft_errno = ER_SUCCESS;
     return (0);
 }
 

--- a/Logger/logger_log_close.cpp
+++ b/Logger/logger_log_close.cpp
@@ -39,6 +39,10 @@ void ft_log_close()
     }
     g_sinks.clear();
     if (g_sinks.get_error() != ER_SUCCESS)
+    {
+        ft_errno = g_sinks.get_error();
         return ;
+    }
+    ft_errno = ER_SUCCESS;
     return ;
 }

--- a/Logger/logger_log_remove_sink.cpp
+++ b/Logger/logger_log_remove_sink.cpp
@@ -3,18 +3,28 @@
 void ft_log_remove_sink(t_log_sink sink, void *user_data)
 {
     size_t index;
+    bool   removed;
 
     index = 0;
+    removed = false;
     while (index < g_sinks.size())
     {
         if (g_sinks[index].function == sink && g_sinks[index].user_data == user_data)
         {
             g_sinks.erase(g_sinks.begin() + index);
             if (g_sinks.get_error() != ER_SUCCESS)
+            {
+                ft_errno = g_sinks.get_error();
                 return ;
-            return ;
+            }
+            removed = true;
+            break;
         }
         index++;
     }
+    if (!removed)
+        ft_errno = FT_EINVAL;
+    else
+        ft_errno = ER_SUCCESS;
     return ;
 }

--- a/Logger/logger_log_set_file.cpp
+++ b/Logger/logger_log_set_file.cpp
@@ -1,6 +1,7 @@
 #include "logger_internal.hpp"
 #include <fcntl.h>
 #include <unistd.h>
+#include <new>
 #include "../Libft/libft.hpp"
 
 void ft_file_sink(const char *message, void *user_data)
@@ -24,25 +25,45 @@ int ft_log_set_file(const char *path, size_t max_size)
     int          file_descriptor;
 
     if (!path)
+    {
+        ft_errno = FT_EINVAL;
         return (-1);
+    }
     file_descriptor = open(path, O_CREAT | O_WRONLY | O_APPEND, 0644);
     if (file_descriptor == -1)
+    {
+        ft_errno = FILE_INVALID_FD;
         return (-1);
-    sink = new s_file_sink;
+    }
+    sink = new(std::nothrow) s_file_sink;
     if (!sink)
     {
         close(file_descriptor);
+        ft_errno = FT_EALLOC;
         return (-1);
     }
     sink->fd = file_descriptor;
     sink->path = path;
     sink->max_size = max_size;
-    if (sink->path.get_error() != ER_SUCCESS ||
-        ft_log_add_sink(ft_file_sink, sink) != 0)
+    if (sink->path.get_error() != ER_SUCCESS)
     {
+        ft_errno = sink->path.get_error();
         close(file_descriptor);
         delete sink;
         return (-1);
     }
+    if (ft_log_add_sink(ft_file_sink, sink) != 0)
+    {
+        int error_code;
+
+        error_code = ft_errno;
+        if (error_code == ER_SUCCESS)
+            error_code = FT_EINVAL;
+        close(file_descriptor);
+        delete sink;
+        ft_errno = error_code;
+        return (-1);
+    }
+    ft_errno = ER_SUCCESS;
     return (0);
 }

--- a/Logger/logger_network.cpp
+++ b/Logger/logger_network.cpp
@@ -3,6 +3,7 @@
 #include "../Compatebility/compatebility_internal.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../Libft/libft.hpp"
+#include <new>
 
 int ft_log_set_remote_sink(const char *host, unsigned short port, bool use_tcp)
 {
@@ -12,19 +13,27 @@ int ft_log_set_remote_sink(const char *host, unsigned short port, bool use_tcp)
     int socket_type;
 
     if (!host)
+    {
+        ft_errno = FT_EINVAL;
         return (-1);
+    }
     socket_type = SOCK_DGRAM;
     if (use_tcp)
         socket_type = SOCK_STREAM;
     socket_fd = nw_socket(AF_INET, socket_type, 0);
     if (socket_fd < 0)
+    {
+        if (ft_errno == ER_SUCCESS)
+            ft_errno = SOCKET_CREATION_FAILED;
         return (-1);
+    }
     ft_memset(&address, 0, sizeof(address));
     address.sin_family = AF_INET;
     address.sin_port = htons(port);
     if (nw_inet_pton(AF_INET, host, &address.sin_addr) != 1)
     {
         cmp_close(socket_fd);
+        ft_errno = INVALID_IP_FORMAT;
         return (-1);
     }
     if (use_tcp)
@@ -32,6 +41,8 @@ int ft_log_set_remote_sink(const char *host, unsigned short port, bool use_tcp)
         if (nw_connect(socket_fd, reinterpret_cast<struct sockaddr *>(&address), sizeof(address)) != 0)
         {
             cmp_close(socket_fd);
+            if (ft_errno == ER_SUCCESS)
+                ft_errno = SOCKET_CONNECT_FAILED;
             return (-1);
         }
     }
@@ -39,10 +50,11 @@ int ft_log_set_remote_sink(const char *host, unsigned short port, bool use_tcp)
     {
         nw_connect(socket_fd, reinterpret_cast<struct sockaddr *>(&address), sizeof(address));
     }
-    sink = new s_network_sink;
+    sink = new(std::nothrow) s_network_sink;
     if (!sink)
     {
         cmp_close(socket_fd);
+        ft_errno = FT_EALLOC;
         return (-1);
     }
     sink->socket_fd = socket_fd;
@@ -50,8 +62,11 @@ int ft_log_set_remote_sink(const char *host, unsigned short port, bool use_tcp)
     {
         cmp_close(socket_fd);
         delete sink;
+        if (ft_errno == ER_SUCCESS)
+            ft_errno = FT_EINVAL;
         return (-1);
     }
+    ft_errno = ER_SUCCESS;
     return (0);
 }
 

--- a/Logger/logger_syslog.cpp
+++ b/Logger/logger_syslog.cpp
@@ -5,12 +5,18 @@
 int ft_log_set_syslog(const char *identifier)
 {
     if (cmp_syslog_open(identifier) != 0)
+    {
+        ft_errno = FT_EINVAL;
         return (-1);
+    }
     if (ft_log_add_sink(ft_syslog_sink, ft_nullptr) != 0)
     {
         cmp_syslog_close();
+        if (ft_errno == ER_SUCCESS)
+            ft_errno = FT_EINVAL;
         return (-1);
     }
+    ft_errno = ER_SUCCESS;
     return (0);
 }
 

--- a/Networking/networking.cpp
+++ b/Networking/networking.cpp
@@ -10,7 +10,8 @@
 #endif
 
 SocketConfig::SocketConfig()
-    : _type(SocketType::SERVER),
+    : _error_code(ER_SUCCESS),
+      _type(SocketType::SERVER),
       _ip("127.0.0.1"),
       _port(8080),
       _backlog(10),
@@ -23,17 +24,18 @@ SocketConfig::SocketConfig()
       _multicast_group(""),
       _multicast_interface("")
 {
-    if (!_error && _ip.get_error())
-        _error = _ip.get_error();
-    if (!_error && _multicast_group.get_error())
-        _error = _multicast_group.get_error();
-    if (!_error && _multicast_interface.get_error())
-        _error = _multicast_interface.get_error();
+    this->set_error(ER_SUCCESS);
+    if (this->_error_code == ER_SUCCESS && _ip.get_error())
+        this->set_error(_ip.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_group.get_error())
+        this->set_error(_multicast_group.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_interface.get_error())
+        this->set_error(_multicast_interface.get_error());
     return ;
 }
 
 SocketConfig::SocketConfig(const SocketConfig& other) noexcept
-    : _error(other._error),
+    : _error_code(other._error_code),
       _type(other._type),
       _ip(other._ip),
       _port(other._port),
@@ -47,12 +49,13 @@ SocketConfig::SocketConfig(const SocketConfig& other) noexcept
       _multicast_group(other._multicast_group),
       _multicast_interface(other._multicast_interface)
 {
-    if (!_error && _ip.get_error())
-        _error = _ip.get_error();
-    if (!_error && _multicast_group.get_error())
-        _error = _multicast_group.get_error();
-    if (!_error && _multicast_interface.get_error())
-        _error = _multicast_interface.get_error();
+    this->set_error(other._error_code);
+    if (this->_error_code == ER_SUCCESS && _ip.get_error())
+        this->set_error(_ip.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_group.get_error())
+        this->set_error(_multicast_group.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_interface.get_error())
+        this->set_error(_multicast_interface.get_error());
     return ;
 }
 
@@ -60,7 +63,7 @@ SocketConfig& SocketConfig::operator=(const SocketConfig& other) noexcept
 {
     if (this != &other)
     {
-        _error = other._error;
+        this->set_error(other._error_code);
         _type = other._type;
         _ip = other._ip;
         _port = other._port;
@@ -74,17 +77,17 @@ SocketConfig& SocketConfig::operator=(const SocketConfig& other) noexcept
         _multicast_group = other._multicast_group;
         _multicast_interface = other._multicast_interface;
     }
-    if (!_error && _ip.get_error())
-        _error = _ip.get_error();
-    if (!_error && _multicast_group.get_error())
-        _error = _multicast_group.get_error();
-    if (!_error && _multicast_interface.get_error())
-        _error = _multicast_interface.get_error();
+    if (this->_error_code == ER_SUCCESS && _ip.get_error())
+        this->set_error(_ip.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_group.get_error())
+        this->set_error(_multicast_group.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_interface.get_error())
+        this->set_error(_multicast_interface.get_error());
     return (*this);
 }
 
 SocketConfig::SocketConfig(SocketConfig&& other) noexcept
-    : _error(other._error),
+    : _error_code(other._error_code),
       _type(other._type),
       _ip(other._ip),
       _port(other._port),
@@ -98,7 +101,7 @@ SocketConfig::SocketConfig(SocketConfig&& other) noexcept
       _multicast_group(other._multicast_group),
       _multicast_interface(other._multicast_interface)
 {
-    other._error = 0;
+    other.set_error(ER_SUCCESS);
     other._type = SocketType::CLIENT;
     other._port = 0;
     other._backlog = 0;
@@ -110,12 +113,12 @@ SocketConfig::SocketConfig(SocketConfig&& other) noexcept
     other._send_timeout = 0;
     other._multicast_group.clear();
     other._multicast_interface.clear();
-    if (!_error && _ip.get_error())
-        _error = _ip.get_error();
-    if (!_error && _multicast_group.get_error())
-        _error = _multicast_group.get_error();
-    if (!_error && _multicast_interface.get_error())
-        _error = _multicast_interface.get_error();
+    if (this->_error_code == ER_SUCCESS && _ip.get_error())
+        this->set_error(_ip.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_group.get_error())
+        this->set_error(_multicast_group.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_interface.get_error())
+        this->set_error(_multicast_interface.get_error());
     return ;
 }
 
@@ -123,7 +126,7 @@ SocketConfig& SocketConfig::operator=(SocketConfig&& other) noexcept
 {
     if (this != &other)
     {
-        _error = other._error;
+        this->set_error(other._error_code);
         _type = other._type;
         other._ip = this->_ip;
         _port = other._port;
@@ -136,7 +139,6 @@ SocketConfig& SocketConfig::operator=(SocketConfig&& other) noexcept
         _send_timeout = other._send_timeout;
         other._multicast_group = this->_multicast_group;
         other._multicast_interface = this->_multicast_interface;
-        other._error = 0;
         other._type = SocketType::CLIENT;
         other._port = 0;
         other._backlog = 0;
@@ -148,13 +150,14 @@ SocketConfig& SocketConfig::operator=(SocketConfig&& other) noexcept
         other._send_timeout = 0;
         other._multicast_group.clear();
         other._multicast_interface.clear();
+        other.set_error(ER_SUCCESS);
     }
-    if (!_error && _ip.get_error())
-        _error = _ip.get_error();
-    if (!_error && _multicast_group.get_error())
-        _error = _multicast_group.get_error();
-    if (!_error && _multicast_interface.get_error())
-        _error = _multicast_interface.get_error();
+    if (this->_error_code == ER_SUCCESS && _ip.get_error())
+        this->set_error(_ip.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_group.get_error())
+        this->set_error(_multicast_group.get_error());
+    if (this->_error_code == ER_SUCCESS && _multicast_interface.get_error())
+        this->set_error(_multicast_interface.get_error());
     return (*this);
 }
 
@@ -165,10 +168,17 @@ SocketConfig::~SocketConfig()
 
 int SocketConfig::get_error()
 {
-    return (_error);
+    return (this->_error_code);
 }
 
 const char *SocketConfig::get_error_str()
 {
-    return (ft_strerror(_error));
+    return (ft_strerror(this->_error_code));
+}
+
+void SocketConfig::set_error(int error_code) noexcept
+{
+    ft_errno = error_code;
+    this->_error_code = ft_errno;
+    return ;
 }

--- a/Networking/networking.hpp
+++ b/Networking/networking.hpp
@@ -57,7 +57,8 @@ enum class SocketType
 class SocketConfig
 {
     private:
-        int _error;
+        mutable int _error_code;
+        void set_error(int error_code) noexcept;
 
     public:
         SocketType _type;

--- a/Networking/networking_setup_client.cpp
+++ b/Networking/networking_setup_client.cpp
@@ -18,15 +18,15 @@
 int ft_socket::setup_client(const SocketConfig &config)
 {
     if (create_socket(config) != ER_SUCCESS)
-        return (this->_error);
+        return (this->_error_code);
     if (config._non_blocking)
         if (set_non_blocking(config) != ER_SUCCESS)
-            return (this->_error);
+            return (this->_error_code);
     if (config._recv_timeout > 0 || config._send_timeout > 0)
         if (set_timeouts(config) != ER_SUCCESS)
-            return (this->_error);
+            return (this->_error_code);
     if (configure_address(config) != ER_SUCCESS)
-        return (this->_error);
+        return (this->_error_code);
     socklen_t addr_len;
     if (config._address_family == AF_INET)
         addr_len = sizeof(struct sockaddr_in);
@@ -34,22 +34,22 @@ int ft_socket::setup_client(const SocketConfig &config)
         addr_len = sizeof(struct sockaddr_in6);
     else
     {
-        handle_error(SOCKET_INVALID_CONFIGURATION);
+        this->set_error(SOCKET_INVALID_CONFIGURATION);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
     if (nw_connect(this->_socket_fd, reinterpret_cast<const struct sockaddr*>
                 (&this->_address), addr_len) < 0)
     {
-        handle_error(errno + ERRNO_OFFSET);
+        this->set_error(errno + ERRNO_OFFSET);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
     if (!config._multicast_group.empty())
         if (join_multicast_group(config) != ER_SUCCESS)
-            return (this->_error);
-    this->_error = ER_SUCCESS;
-    return (this->_error);
+            return (this->_error_code);
+    this->set_error(ER_SUCCESS);
+    return (this->_error_code);
 }

--- a/Networking/networking_setup_server.cpp
+++ b/Networking/networking_setup_server.cpp
@@ -75,9 +75,10 @@ int ft_socket::create_socket(const SocketConfig &config)
     this->_socket_fd = nw_socket(config._address_family, SOCK_STREAM, config._protocol);
     if (this->_socket_fd < 0)
     {
-        handle_error(errno + ERRNO_OFFSET);
-        return (this->_error);
+        this->set_error(errno + ERRNO_OFFSET);
+        return (this->_error_code);
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }
 
@@ -88,11 +89,12 @@ int ft_socket::set_reuse_address(const SocketConfig &config)
     int opt = 1;
     if (setsockopt_reuse(this->_socket_fd, opt) < 0)
     {
-        handle_error(errno + ERRNO_OFFSET);
+        this->set_error(errno + ERRNO_OFFSET);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }
 
@@ -102,11 +104,12 @@ int ft_socket::set_non_blocking(const SocketConfig &config)
         return (ER_SUCCESS);
     if (set_nonblocking_platform(this->_socket_fd) != 0)
     {
-        handle_error(errno + ERRNO_OFFSET);
+        this->set_error(errno + ERRNO_OFFSET);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }
 
@@ -116,22 +119,23 @@ int ft_socket::set_timeouts(const SocketConfig &config)
     {
         if (set_timeout_recv(this->_socket_fd, config._recv_timeout) < 0)
         {
-            handle_error(errno + ERRNO_OFFSET);
+            this->set_error(errno + ERRNO_OFFSET);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
     }
     if (config._send_timeout > 0)
     {
         if (set_timeout_send(this->_socket_fd, config._send_timeout) < 0)
         {
-            handle_error(errno + ERRNO_OFFSET);
+            this->set_error(errno + ERRNO_OFFSET);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }
 
@@ -146,10 +150,10 @@ int ft_socket::configure_address(const SocketConfig &config)
         addr_in->sin_port = htons(config._port);
         if (nw_inet_pton(AF_INET, config._ip, &addr_in->sin_addr) <= 0)
         {
-            handle_error(SOCKET_INVALID_CONFIGURATION);
+            this->set_error(SOCKET_INVALID_CONFIGURATION);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
     }
     else if (config._address_family == AF_INET6)
@@ -159,19 +163,20 @@ int ft_socket::configure_address(const SocketConfig &config)
         addr_in6->sin6_port = htons(config._port);
         if (nw_inet_pton(AF_INET6, config._ip, &addr_in6->sin6_addr) <= 0)
         {
-            handle_error(SOCKET_INVALID_CONFIGURATION);
+            this->set_error(SOCKET_INVALID_CONFIGURATION);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
     }
     else
     {
-        handle_error(SOCKET_INVALID_CONFIGURATION);
+        this->set_error(SOCKET_INVALID_CONFIGURATION);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }
 
@@ -185,19 +190,20 @@ int ft_socket::bind_socket(const SocketConfig &config)
         addr_len = sizeof(struct sockaddr_in6);
     else
     {
-        handle_error(SOCKET_INVALID_CONFIGURATION);
+        this->set_error(SOCKET_INVALID_CONFIGURATION);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
     if (nw_bind(this->_socket_fd, reinterpret_cast<const struct sockaddr*>(&this->_address),
                 addr_len) < 0)
     {
-        handle_error(errno + ERRNO_OFFSET);
+        this->set_error(errno + ERRNO_OFFSET);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }
 
@@ -206,45 +212,46 @@ int ft_socket::listen_socket(const SocketConfig &config)
 {
     if (nw_listen(this->_socket_fd, config._backlog) < 0)
     {
-        handle_error(errno + ERRNO_OFFSET);
+        this->set_error(errno + ERRNO_OFFSET);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }
 
-void ft_socket::handle_error(int error_code)
+void ft_socket::set_error(int error_code) const noexcept
 {
     ft_errno = error_code;
-    this->_error = ft_errno;
+    this->_error_code = ft_errno;
     return ;
 }
 
 int ft_socket::setup_server(const SocketConfig &config)
 {
     if (create_socket(config) != ER_SUCCESS)
-        return (this->_error);
+        return (this->_error_code);
     if (config._reuse_address)
         if (set_reuse_address(config) != ER_SUCCESS)
-            return (this->_error);
+            return (this->_error_code);
     if (config._non_blocking)
         if (set_non_blocking(config) != ER_SUCCESS)
-            return (this->_error);
+            return (this->_error_code);
     if (config._recv_timeout > 0 || config._send_timeout > 0)
         if (set_timeouts(config) != ER_SUCCESS)
-            return (this->_error);
+            return (this->_error_code);
     if (configure_address(config) != ER_SUCCESS)
-        return (this->_error);
+        return (this->_error_code);
     if (bind_socket(config) != ER_SUCCESS)
-        return (this->_error);
+        return (this->_error_code);
     if (listen_socket(config) != ER_SUCCESS)
-        return (this->_error);
+        return (this->_error_code);
     if (!config._multicast_group.empty())
         if (join_multicast_group(config) != ER_SUCCESS)
-            return (this->_error);
-    this->_error = ER_SUCCESS;
-    return (this->_error);
+            return (this->_error_code);
+    this->set_error(ER_SUCCESS);
+    return (this->_error_code);
 }
 
 int ft_socket::join_multicast_group(const SocketConfig &config)
@@ -257,27 +264,27 @@ int ft_socket::join_multicast_group(const SocketConfig &config)
         ft_bzero(&mreq, sizeof(mreq));
         if (nw_inet_pton(AF_INET, config._multicast_group.c_str(), &mreq.imr_multiaddr) <= 0)
         {
-            handle_error(SOCKET_INVALID_CONFIGURATION);
+            this->set_error(SOCKET_INVALID_CONFIGURATION);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
         if (config._multicast_interface.empty())
             mreq.imr_interface.s_addr = htonl(INADDR_ANY);
         else if (nw_inet_pton(AF_INET, config._multicast_interface.c_str(), &mreq.imr_interface) <= 0)
         {
-            handle_error(SOCKET_INVALID_CONFIGURATION);
+            this->set_error(SOCKET_INVALID_CONFIGURATION);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
         if (setsockopt(this->_socket_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP,
                        reinterpret_cast<const char*>(&mreq), sizeof(mreq)) < 0)
         {
-            handle_error(SOCKET_JOIN_GROUP_FAILED);
+            this->set_error(SOCKET_JOIN_GROUP_FAILED);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
     }
     else if (config._address_family == AF_INET6)
@@ -286,27 +293,28 @@ int ft_socket::join_multicast_group(const SocketConfig &config)
         ft_bzero(&mreq6, sizeof(mreq6));
         if (nw_inet_pton(AF_INET6, config._multicast_group.c_str(), &mreq6.ipv6mr_multiaddr) <= 0)
         {
-            handle_error(SOCKET_INVALID_CONFIGURATION);
+            this->set_error(SOCKET_INVALID_CONFIGURATION);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
         mreq6.ipv6mr_interface = 0;
         if (setsockopt(this->_socket_fd, IPPROTO_IPV6, IPV6_JOIN_GROUP,
                        reinterpret_cast<const char*>(&mreq6), sizeof(mreq6)) < 0)
         {
-            handle_error(SOCKET_JOIN_GROUP_FAILED);
+            this->set_error(SOCKET_JOIN_GROUP_FAILED);
             FT_CLOSE_SOCKET(this->_socket_fd);
             this->_socket_fd = -1;
-            return (this->_error);
+            return (this->_error_code);
         }
     }
     else
     {
-        handle_error(SOCKET_INVALID_CONFIGURATION);
+        this->set_error(SOCKET_INVALID_CONFIGURATION);
         FT_CLOSE_SOCKET(this->_socket_fd);
         this->_socket_fd = -1;
-        return (this->_error);
+        return (this->_error_code);
     }
+    this->set_error(ER_SUCCESS);
     return (ER_SUCCESS);
 }

--- a/Networking/networking_socket_class.cpp
+++ b/Networking/networking_socket_class.cpp
@@ -16,9 +16,10 @@
 # include <sys/socket.h>
 #endif
 
-ft_socket::ft_socket() : _socket_fd(-1), _error(ER_SUCCESS)
+ft_socket::ft_socket() : _socket_fd(-1), _error_code(ER_SUCCESS)
 {
     ft_bzero(&this->_address, sizeof(this->_address));
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -31,26 +32,26 @@ ssize_t ft_socket::send_data(const void *data, size_t size, int flags, int fd)
         {
             ssize_t bytes_sent = this->_connected[index].send_data(data, size, flags);
             if (bytes_sent < 0)
-            {
-                this->_error = errno + ERRNO_OFFSET;
-                ft_errno = this->_error;
-            }
+                this->set_error(errno + ERRNO_OFFSET);
+            else
+                this->set_error(ER_SUCCESS);
             return (bytes_sent);
         }
         index++;
     }
-    ft_errno = FT_EINVAL;
-    this->_error = ft_errno;
+    this->set_error(FT_EINVAL);
     return (-1);
 }
 
 int ft_socket::get_fd() const
 {
+        this->set_error(ER_SUCCESS);
         return (this->_socket_fd);
 }
 
 const struct sockaddr_storage &ft_socket::get_address() const
 {
+        this->set_error(ER_SUCCESS);
         return (this->_address);
 }
 
@@ -69,13 +70,14 @@ ssize_t ft_socket::broadcast_data(const void *data, size_t size, int flags, int 
         ssize_t bytes_sent = this->_connected[index].send_data(data, size, flags);
         if (bytes_sent < 0)
         {
-            ft_errno = errno + ERRNO_OFFSET;
-            this->_error = ft_errno;
+            this->set_error(errno + ERRNO_OFFSET);
             continue ;
         }
         total_bytes_sent += bytes_sent;
         index++;
     }
+    if (total_bytes_sent >= 0)
+        this->set_error(ER_SUCCESS);
     return (total_bytes_sent);
 }
 
@@ -89,13 +91,14 @@ ssize_t ft_socket::broadcast_data(const void *data, size_t size, int flags)
         ssize_t bytes_sent = this->_connected[index].send_data(data, size, flags);
         if (bytes_sent < 0)
         {
-            ft_errno = errno + ERRNO_OFFSET;
-            this->_error = ft_errno;
+            this->set_error(errno + ERRNO_OFFSET);
             continue ;
         }
         total_bytes_sent += bytes_sent;
         index++;
     }
+    if (total_bytes_sent >= 0)
+        this->set_error(ER_SUCCESS);
     return (total_bytes_sent);
 }
 
@@ -103,8 +106,7 @@ int ft_socket::accept_connection()
 {
     if (this->_socket_fd < 0)
     {
-        ft_errno = FT_EINVAL;
-        this->_error = ft_errno;
+        this->set_error(FT_EINVAL);
         return (-1);
     }
     struct sockaddr_storage client_addr;
@@ -114,17 +116,17 @@ int ft_socket::accept_connection()
                            &addr_len);
     if (new_fd < 0)
     {
-        ft_errno = errno + ERRNO_OFFSET;
-        this->_error = ft_errno;
+        this->set_error(errno + ERRNO_OFFSET);
         return (-1);
     }
     ft_socket new_socket(new_fd, client_addr);
     this->_connected.push_back(ft_move(new_socket));
     if (this->_connected.get_error())
     {
-        ft_errno = VECTOR_ALLOC_FAIL;
-        this->_error = ft_errno;
+        this->set_error(VECTOR_ALLOC_FAIL);
     }
+    else
+        this->set_error(ER_SUCCESS);
     return (new_fd);
 }
 
@@ -140,13 +142,12 @@ bool ft_socket::disconnect_client(int fd)
             if (index != last)
                     this->_connected[index] = ft_move(this->_connected[last]);
             this->_connected.pop_back();
-            this->_error = ER_SUCCESS;
+            this->set_error(ER_SUCCESS);
             return (true);
         }
         index++;
     }
-    ft_errno = FT_EINVAL;
-    this->_error = ft_errno;
+    this->set_error(FT_EINVAL);
     return (false);
 }
 
@@ -159,11 +160,13 @@ void ft_socket::disconnect_all_clients()
         index++;
     }
     this->_connected.clear();
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
 size_t ft_socket::get_client_count() const
 {
+    this->set_error(ER_SUCCESS);
     return (this->_connected.size());
 }
 
@@ -174,28 +177,33 @@ bool ft_socket::is_client_connected(int fd) const
     while (index < this->_connected.size())
     {
         if (this->_connected[index].get_fd() == fd)
+        {
+            this->set_error(ER_SUCCESS);
             return (true);
+        }
         index++;
     }
+    this->set_error(ER_SUCCESS);
     return (false);
 }
 
 ft_socket::ft_socket(int fd, const sockaddr_storage &addr) : _address(addr), _socket_fd(fd),
-                        _error(ER_SUCCESS)
+                        _error_code(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
-ft_socket::ft_socket(const SocketConfig &config) : _socket_fd(-1), _error(ER_SUCCESS)
+ft_socket::ft_socket(const SocketConfig &config) : _socket_fd(-1), _error_code(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     if (config._type == SocketType::SERVER)
         setup_server(config);
     else if (config._type == SocketType::CLIENT)
         setup_client(config);
     else
     {
-        ft_errno = SOCKET_UNSUPPORTED_TYPE;
-        this->_error = ft_errno;
+        this->set_error(SOCKET_UNSUPPORTED_TYPE);
     }
     return ;
 }
@@ -210,18 +218,14 @@ ssize_t ft_socket::send_data(const void *data, size_t size, int flags)
 {
     if (this->_socket_fd < 0)
     {
-        ft_errno = SOCKET_INVALID_CONFIGURATION;
-        this->_error = ft_errno;
+        this->set_error(SOCKET_INVALID_CONFIGURATION);
         return (-1);
     }
     ssize_t bytes_sent = nw_send(this->_socket_fd, data, size, flags);
     if (bytes_sent < 0)
-    {
-        ft_errno = errno + ERRNO_OFFSET;
-        this->_error = ft_errno;
-    }
+        this->set_error(errno + ERRNO_OFFSET);
     else
-        this->_error = ER_SUCCESS;
+        this->set_error(ER_SUCCESS);
     return (bytes_sent);
 }
 
@@ -229,8 +233,7 @@ ssize_t ft_socket::send_all(const void *data, size_t size, int flags)
 {
     if (this->_socket_fd < 0)
     {
-        ft_errno = SOCKET_INVALID_CONFIGURATION;
-        this->_error = ft_errno;
+        this->set_error(SOCKET_INVALID_CONFIGURATION);
         return (-1);
     }
     size_t total_sent = 0;
@@ -243,13 +246,12 @@ ssize_t ft_socket::send_all(const void *data, size_t size, int flags)
                                      flags);
         if (bytes_sent < 0)
         {
-            ft_errno = errno + ERRNO_OFFSET;
-            this->_error = ft_errno;
+            this->set_error(errno + ERRNO_OFFSET);
             return (-1);
         }
         total_sent += bytes_sent;
     }
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     return (static_cast<ssize_t>(total_sent));
 }
 
@@ -257,18 +259,14 @@ ssize_t ft_socket::receive_data(void *buffer, size_t size, int flags)
 {
     if (this->_socket_fd < 0)
     {
-        ft_errno = FT_EINVAL;
-        this->_error = ft_errno;
+        this->set_error(FT_EINVAL);
         return (-1);
-    } 
+    }
     ssize_t bytes_received = nw_recv(this->_socket_fd, buffer, size, flags);
     if (bytes_received < 0)
-    {
-        ft_errno = errno + ERRNO_OFFSET;
-        this->_error = ft_errno;
-    }
+        this->set_error(errno + ERRNO_OFFSET);
     else
-        this->_error = ER_SUCCESS;
+        this->set_error(ER_SUCCESS);
     return (bytes_received);
 }
 
@@ -279,35 +277,35 @@ bool ft_socket::close_socket()
         if (FT_CLOSE_SOCKET(this->_socket_fd) == 0)
         {
             this->_socket_fd = -1;
-            this->_error = ER_SUCCESS;
+            this->set_error(ER_SUCCESS);
             return (true);
         }
         else
         {
-            ft_errno = errno + ERRNO_OFFSET;
-            this->_error = ft_errno;
+            this->set_error(errno + ERRNO_OFFSET);
             return (false);
         }
     }
-    this->_error = ER_SUCCESS;
+    this->set_error(ER_SUCCESS);
     return (true);
 }
 
 int ft_socket::get_error() const
 {
-    return (this->_error);
+    return (this->_error_code);
 }
 
 const char* ft_socket::get_error_str() const
 {
-    return (ft_strerror(this->_error));
+    return (ft_strerror(this->_error_code));
 }
 
 ft_socket::ft_socket(ft_socket &&other) noexcept
     : _address(other._address), _connected(ft_move(other._connected)),
-    _socket_fd(other._socket_fd), _error(other._error)
+    _socket_fd(other._socket_fd), _error_code(other._error_code)
 {
     other._socket_fd = -1;
+    other.set_error(ER_SUCCESS);
     return ;
 }
 
@@ -318,9 +316,10 @@ ft_socket &ft_socket::operator=(ft_socket &&other) noexcept
         close_socket();
         this->_address = other._address;
         this->_socket_fd = other._socket_fd;
-        this->_error = other._error;
+        this->set_error(other._error_code);
         this->_connected = ft_move(other._connected);
         other._socket_fd = -1;
+        other.set_error(ER_SUCCESS);
     }
     return (*this);
 }
@@ -329,8 +328,7 @@ int ft_socket::initialize(const SocketConfig &config)
 {
     if (this->_socket_fd != -1)
     {
-        this->_error = SOCKET_ALRDY_INITIALIZED;
-        ft_errno = SOCKET_ALRDY_INITIALIZED;
+        this->set_error(SOCKET_ALRDY_INITIALIZED);
         return (1);
     }
     if (config._type == SocketType::SERVER)
@@ -339,8 +337,7 @@ int ft_socket::initialize(const SocketConfig &config)
         setup_client(config);
     else
     {
-        ft_errno = SOCKET_UNSUPPORTED_TYPE;
-        this->_error = ft_errno;
+        this->set_error(SOCKET_UNSUPPORTED_TYPE);
     }
     return (0);
 }

--- a/Networking/socket_class.hpp
+++ b/Networking/socket_class.hpp
@@ -38,12 +38,12 @@ class ft_socket
         int     bind_socket(const SocketConfig &config);
         int     listen_socket(const SocketConfig &config);
         int        accept_connection();
-        void     handle_error(int error_code);
+        void     set_error(int error_code) const noexcept;
 
         struct sockaddr_storage _address;
         ft_vector<ft_socket>     _connected;
         int                         _socket_fd;
-        int                     _error;
+        mutable int             _error_code;
 
         ft_socket(int fd, const sockaddr_storage &addr);
         ft_socket(const ft_socket &other) = delete;

--- a/Networking/udp_socket.hpp
+++ b/Networking/udp_socket.hpp
@@ -23,11 +23,11 @@ class udp_socket
         int     configure_address(const SocketConfig &config);
         int     bind_socket(const SocketConfig &config);
         int     connect_socket(const SocketConfig &config);
-        void    handle_error(int error_code);
+        void    set_error(int error_code) const noexcept;
 
         struct sockaddr_storage _address;
         int     _socket_fd;
-        int     _error;
+        mutable int _error_code;
 
     public:
         udp_socket();

--- a/Template/promise.hpp
+++ b/Template/promise.hpp
@@ -14,6 +14,7 @@ class ft_promise
         std::atomic_bool _ready;
         mutable int _error_code;
 
+    protected:
         void set_error(int error) const;
 
     public:
@@ -47,6 +48,7 @@ void ft_promise<ValueType>::set_value(const ValueType& value)
 {
     this->_value = value;
     this->_ready.store(true, std::memory_order_release);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
@@ -55,6 +57,7 @@ void ft_promise<ValueType>::set_value(ValueType&& value)
 {
     this->_value = ft_move(value);
     this->_ready.store(true, std::memory_order_release);
+    this->set_error(ER_SUCCESS);
     return ;
 }
 

--- a/Time/time_timer.cpp
+++ b/Time/time_timer.cpp
@@ -1,82 +1,125 @@
 #include "time.hpp"
 #include "timer.hpp"
 #include <chrono>
+#include "../Errno/errno.hpp"
 
-time_timer::time_timer()
+time_timer::time_timer() noexcept
+    : _duration_ms(0), _start_time(std::chrono::steady_clock::time_point()), _running(false), _error_code(ER_SUCCESS)
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
-time_timer::~time_timer()
+time_timer::~time_timer() noexcept
 {
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
-void    time_timer::start(long duration_ms)
+void    time_timer::start(long duration_ms) noexcept
 {
     if (duration_ms < 0)
     {
         this->_running = false;
+        this->set_error(FT_EINVAL);
         return ;
     }
     this->_duration_ms = duration_ms;
     this->_start_time = std::chrono::steady_clock::now();
     this->_running = true;
+    this->set_error(ER_SUCCESS);
     return ;
 }
 
-long time_timer::update()
+long time_timer::update() noexcept
 {
     if (!this->_running)
+    {
+        this->set_error(FT_EINVAL);
         return (-1);
+    }
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     long elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - this->_start_time).count();
     if (elapsed >= this->_duration_ms)
     {
         this->_running = false;
+        this->set_error(ER_SUCCESS);
         return (0);
     }
-    return (this->_duration_ms - elapsed);
+    long remaining = this->_duration_ms - elapsed;
+    this->set_error(ER_SUCCESS);
+    return (remaining);
 }
 
-long time_timer::add_time(long amount_ms)
+long time_timer::add_time(long amount_ms) noexcept
 {
     if (!this->_running || amount_ms < 0)
+    {
+        this->set_error(FT_EINVAL);
         return (-1);
+    }
     this->_duration_ms += amount_ms;
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     long elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - this->_start_time).count();
     if (elapsed >= this->_duration_ms)
     {
         this->_running = false;
+        this->set_error(ER_SUCCESS);
         return (0);
     }
-    return (this->_duration_ms - elapsed);
+    long remaining = this->_duration_ms - elapsed;
+    this->set_error(ER_SUCCESS);
+    return (remaining);
 }
 
-long time_timer::remove_time(long amount_ms)
+long time_timer::remove_time(long amount_ms) noexcept
 {
     if (!this->_running || amount_ms < 0)
+    {
+        this->set_error(FT_EINVAL);
         return (-1);
+    }
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     long elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - this->_start_time).count();
     if (amount_ms >= this->_duration_ms - elapsed)
     {
         this->_duration_ms = elapsed;
         this->_running = false;
+        this->set_error(ER_SUCCESS);
         return (0);
     }
     this->_duration_ms -= amount_ms;
-    return (this->_duration_ms - elapsed);
+    long remaining = this->_duration_ms - elapsed;
+    this->set_error(ER_SUCCESS);
+    return (remaining);
 }
 
-void    time_timer::sleep_remaining()
+void    time_timer::sleep_remaining() noexcept
 {
-    long remaining;
-
-    remaining = this->update();
+    long remaining = this->update();
+    if (remaining < 0)
+        return ;
     if (remaining > 0)
         time_sleep_ms(static_cast<unsigned int>(remaining));
+    this->set_error(ER_SUCCESS);
     return ;
 }
+
+int time_timer::get_error() const noexcept
+{
+    return (this->_error_code);
+}
+
+const char  *time_timer::get_error_str() const noexcept
+{
+    return (ft_strerror(this->_error_code));
+}
+
+void    time_timer::set_error(int error_code) const noexcept
+{
+    this->_error_code = error_code;
+    ft_errno = error_code;
+    return ;
+}
+
 

--- a/Time/timer.hpp
+++ b/Time/timer.hpp
@@ -9,15 +9,20 @@ class time_timer
         long    _duration_ms = 0;
         std::chrono::steady_clock::time_point _start_time = std::chrono::steady_clock::time_point();
         bool    _running = false;
+        mutable int _error_code;
+
+        void    set_error(int error_code) const noexcept;
 
     public:
-        time_timer();
-        ~time_timer();
-        void    start(long duration_ms);
-        long    update();
-        long    add_time(long amount_ms);
-        long    remove_time(long amount_ms);
-        void    sleep_remaining();
+        time_timer() noexcept;
+        ~time_timer() noexcept;
+        void    start(long duration_ms) noexcept;
+        long    update() noexcept;
+        long    add_time(long amount_ms) noexcept;
+        long    remove_time(long amount_ms) noexcept;
+        void    sleep_remaining() noexcept;
+        int     get_error() const noexcept;
+        const char  *get_error_str() const noexcept;
 };
 
 #endif


### PR DESCRIPTION
## Summary
- teach the template iterator and promise helpers to expose their `_error_code` state, while upgrading the object pool to validate locking, capacity exhaustion, and handle lifetimes before mirroring results into `ft_errno`
- extend the TLS client and promise wrappers to validate inputs, propagate socket and JSON failures with new pool-specific errno codes, and publish accessors so synchronous and async requests keep callers informed
- document the expanded Template and API error coverage in the README for downstream users

## Testing
- make -C Template
- make -C API

------
https://chatgpt.com/codex/tasks/task_e_68ce7de3e5248331955cd021458cd70f