### PR TITLE
Ensure file watcher threads stop cleanly

### DIFF
--- a/File/file_watch.cpp
+++ b/File/file_watch.cpp
@@ -92,30 +92,30 @@ int ft_file_watch::watch_directory(const char *path, void (*callback)(const char
 
 void ft_file_watch::stop()
 {
-    if (this->_running == false)
+    if (this->_running == false && this->_thread.joinable() == false)
         return ;
     this->_running = false;
-    if (this->_thread.joinable())
-        this->_thread.join();
 #ifdef __linux__
-    if (this->_watch >= 0)
+    if (this->_watch >= 0 && this->_fd >= 0)
         inotify_rm_watch(this->_fd, this->_watch);
+    this->_watch = -1;
     if (this->_fd >= 0)
         close(this->_fd);
-    this->_watch = -1;
     this->_fd = -1;
 #elif defined(__APPLE__) || defined(__FreeBSD__)
     if (this->_fd >= 0)
         close(this->_fd);
+    this->_fd = -1;
     if (this->_kqueue >= 0)
         close(this->_kqueue);
-    this->_fd = -1;
     this->_kqueue = -1;
 #elif defined(_WIN32)
     if (this->_handle != ft_nullptr)
         CloseHandle(this->_handle);
     this->_handle = ft_nullptr;
 #endif
+    if (this->_thread.joinable())
+        this->_thread.join();
     return ;
 }
 
@@ -141,7 +141,7 @@ void ft_file_watch::event_loop()
 
         length = read(this->_fd, buffer, sizeof(buffer));
         if (length <= 0)
-            continue;
+            break;
         pointer = buffer;
         while (pointer < buffer + static_cast<size_t>(length))
         {
@@ -166,7 +166,9 @@ void ft_file_watch::event_loop()
     {
         int event_count;
         event_count = kevent(this->_kqueue, &change_event, 1, &event, 1, ft_nullptr);
-        if (event_count > 0 && this->_callback != ft_nullptr)
+        if (event_count <= 0)
+            break;
+        if (this->_callback != ft_nullptr)
         {
             if (event.fflags & NOTE_DELETE)
                 this->_callback(this->_path.c_str(), FILE_WATCH_EVENT_DELETE, this->_user_data);
@@ -182,18 +184,17 @@ void ft_file_watch::event_loop()
     {
         if (ReadDirectoryChangesW(this->_handle, buffer, sizeof(buffer), FALSE,
             FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE,
-            &bytes_transferred, ft_nullptr, ft_nullptr))
+            &bytes_transferred, ft_nullptr, ft_nullptr) == FALSE)
+            break;
+        notification = reinterpret_cast<FILE_NOTIFY_INFORMATION *>(buffer);
+        if (this->_callback != ft_nullptr)
         {
-            notification = reinterpret_cast<FILE_NOTIFY_INFORMATION *>(buffer);
-            if (this->_callback != ft_nullptr)
-            {
-                if (notification->Action == FILE_ACTION_ADDED)
-                    this->_callback("", FILE_WATCH_EVENT_CREATE, this->_user_data);
-                else if (notification->Action == FILE_ACTION_MODIFIED)
-                    this->_callback("", FILE_WATCH_EVENT_MODIFY, this->_user_data);
-                else if (notification->Action == FILE_ACTION_REMOVED)
-                    this->_callback("", FILE_WATCH_EVENT_DELETE, this->_user_data);
-            }
+            if (notification->Action == FILE_ACTION_ADDED)
+                this->_callback("", FILE_WATCH_EVENT_CREATE, this->_user_data);
+            else if (notification->Action == FILE_ACTION_MODIFIED)
+                this->_callback("", FILE_WATCH_EVENT_MODIFY, this->_user_data);
+            else if (notification->Action == FILE_ACTION_REMOVED)
+                this->_callback("", FILE_WATCH_EVENT_DELETE, this->_user_data);
         }
     }
 #endif

--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,11 @@ The implementation uses inotify on Linux, kqueue on BSD and macOS and
 `ReadDirectoryChangesW` on Windows. These platform APIs must be available when
 building the library.
 
+`ft_file_watch::stop` closes the active watch handles before joining the worker
+thread so the blocking read calls terminate cleanly. The event loop on each
+platform now exits when its descriptor or handle is closed, preventing the
+watcher from spinning on invalid resources during shutdown.
+
 `System_utils/system_utils.hpp` provides cross-platform file descriptor utilities:
 
 ```


### PR DESCRIPTION
## Summary
- close each platform's watch handles before joining the worker thread
- break out of the platform-specific event loop when the descriptor or handle closes
- document the improved shutdown behaviour for the file watcher in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d047d70d048331863ee38bb02f7c33