### PR TITLE
Fix inotify watch cleanup failure

### DIFF
--- a/File/file_watch.cpp
+++ b/File/file_watch.cpp
@@ -56,6 +56,8 @@ int ft_file_watch::watch_directory(const char *path, void (*callback)(const char
     this->_watch = inotify_add_watch(this->_fd, path, IN_CREATE | IN_MODIFY | IN_DELETE);
     if (this->_watch < 0)
     {
+        close(this->_fd);
+        this->_fd = -1;
         this->set_error(FILE_INVALID_FD);
         return (-1);
     }

--- a/README.md
+++ b/README.md
@@ -1421,6 +1421,9 @@ thread so the blocking read calls terminate cleanly. The event loop on each
 platform now exits when its descriptor or handle is closed, preventing the
 watcher from spinning on invalid resources during shutdown.
 
+On Linux, `ft_file_watch::watch_directory` now closes the inotify descriptor if
+`inotify_add_watch` fails so the setup path does not leak file descriptors.
+
 `System_utils/system_utils.hpp` provides cross-platform file descriptor utilities:
 
 ```


### PR DESCRIPTION
## Summary
- close the inotify descriptor when adding the watch fails to prevent leaks
- document the Linux cleanup behavior in the file watch README section

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d04be01e9c8331a2f076e67382848f