### PR TITLE
Handle invalid characters in Base64 decoder

### DIFF
--- a/Compression/compression_base64.cpp
+++ b/Compression/compression_base64.cpp
@@ -121,18 +121,46 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
     while (input_index < input_size)
     {
         value_one = base64_char_value(input_buffer[input_index]);
+        if (value_one == -1)
+        {
+            cma_free(output_buffer);
+            *decoded_size = 0;
+            return (ft_nullptr);
+        }
         input_index++;
         value_two = base64_char_value(input_buffer[input_index]);
+        if (value_two == -1)
+        {
+            cma_free(output_buffer);
+            *decoded_size = 0;
+            return (ft_nullptr);
+        }
         input_index++;
         char_three = input_buffer[input_index];
         if (char_three != '=')
+        {
             value_three = base64_char_value(char_three);
+            if (value_three == -1)
+            {
+                cma_free(output_buffer);
+                *decoded_size = 0;
+                return (ft_nullptr);
+            }
+        }
         else
             value_three = 0;
         input_index++;
         char_four = input_buffer[input_index];
         if (char_four != '=')
+        {
             value_four = base64_char_value(char_four);
+            if (value_four == -1)
+            {
+                cma_free(output_buffer);
+                *decoded_size = 0;
+                return (ft_nullptr);
+            }
+        }
         else
             value_four = 0;
         input_index++;

--- a/README.md
+++ b/README.md
@@ -1283,6 +1283,7 @@ unsigned char *ft_base64_decode(const unsigned char *input_buffer, std::size_t i
 ```
 
 The streaming functions operate on file descriptors using `su_read` and `su_write`, and the Base64 helpers encode or decode buffers.
+`ft_base64_decode` validates every character; when an invalid character is detected it frees any allocated memory, sets the decoded size to `0`, and returns `ft_nullptr` to signal the error.
 
 #### JSon
 Creation, reading and manipulation helpers in `JSon/json.hpp`:

--- a/Test/Test/test_compression.cpp
+++ b/Test/Test/test_compression.cpp
@@ -180,3 +180,23 @@ FT_TEST(test_base64_round_trip, "base64 round trip")
     cma_free(decoded_buffer);
     return (0);
 }
+
+FT_TEST(test_base64_invalid_character, "base64 invalid character")
+{
+    const char      *invalid_input;
+    unsigned char   *decoded_buffer;
+    std::size_t     decoded_length;
+
+    invalid_input = "AAA!";
+    decoded_length = 42;
+    decoded_buffer = ft_base64_decode(reinterpret_cast<const unsigned char *>(invalid_input),
+        ft_strlen_size_t(invalid_input), &decoded_length);
+    if (decoded_buffer)
+    {
+        cma_free(decoded_buffer);
+        return (0);
+    }
+    if (decoded_length != 0)
+        return (0);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add validation checks in `ft_base64_decode` that free intermediate buffers, zero the decoded size, and return `ft_nullptr` when invalid characters are encountered
- document the decoding failure behavior in the compression section of the README
- extend the compression test suite with a case that confirms invalid Base64 input now fails instead of producing corrupted output

## Testing
- make -C Test
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d04cf67ed48331bef95db6fe405ac5