### PR TITLE
Guard compression helpers against oversize buffers

### DIFF
--- a/Compression/compression.hpp
+++ b/Compression/compression.hpp
@@ -4,6 +4,13 @@
 #include <cstddef>
 #include <cstdint>
 
+/*
+** Maximum number of bytes supported by the compression helpers. The original
+** size is stored alongside the payload using a 32-bit prefix, so values
+** greater than UINT32_MAX cannot be represented.
+*/
+static const std::size_t   compression_max_size = static_cast<std::size_t>(UINT32_MAX);
+
 unsigned char    *compress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size);
 unsigned char    *decompress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size);
 

--- a/Compression/compression_zlib.cpp
+++ b/Compression/compression_zlib.cpp
@@ -2,6 +2,7 @@
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include "compression.hpp"
 
 unsigned char    *compress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *compressed_size)
@@ -15,6 +16,12 @@ unsigned char    *compress_buffer(const unsigned char *input_buffer, std::size_t
 
     if (!input_buffer || !compressed_size)
         return (ft_nullptr);
+    if (input_size > compression_max_size)
+    {
+        ft_errno = FT_EINVAL;
+        *compressed_size = 0;
+        return (ft_nullptr);
+    }
     zlib_bound = compressBound(static_cast<uLong>(input_size));
     result_buffer = static_cast<unsigned char *>(cma_malloc(zlib_bound + sizeof(uint32_t)));
     if (!result_buffer)
@@ -45,6 +52,18 @@ unsigned char    *decompress_buffer(const unsigned char *input_buffer, std::size
     if (!input_buffer || input_size < sizeof(uint32_t) || !decompressed_size)
         return (ft_nullptr);
     ft_memcpy(&expected_size, input_buffer, sizeof(uint32_t));
+    if (static_cast<std::size_t>(expected_size) > compression_max_size)
+    {
+        ft_errno = FT_EINVAL;
+        *decompressed_size = 0;
+        return (ft_nullptr);
+    }
+    if (input_size - sizeof(uint32_t) > compression_max_size)
+    {
+        ft_errno = FT_EINVAL;
+        *decompressed_size = 0;
+        return (ft_nullptr);
+    }
     result_buffer = static_cast<unsigned char *>(cma_malloc(expected_size));
     if (!result_buffer)
         return (ft_nullptr);

--- a/README.md
+++ b/README.md
@@ -1269,6 +1269,11 @@ unsigned char *compress_buffer(const unsigned char *input_buffer, std::size_t in
 unsigned char *decompress_buffer(const unsigned char *input_buffer, std::size_t input_size, std::size_t *decompressed_size);
 ```
 
+The helpers prefix each payload with its uncompressed size stored as an
+unsigned 32-bit value. As a result, any request whose buffer exceeds
+`compression_max_size` (`UINT32_MAX` bytes) is rejected before reaching zlib and
+sets `ft_errno` to `FT_EINVAL`.
+
 The returned buffers are allocated with CMA and must be freed using `cma_free`.
 
 High level helpers are also available:

--- a/Test/Test/test_compression.cpp
+++ b/Test/Test/test_compression.cpp
@@ -2,9 +2,63 @@
 #include "../../CMA/CMA.hpp"
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include "../../System_utils/system_utils.hpp"
 #include <unistd.h>
+
+FT_TEST(test_compress_rejects_oversize_input, "compress rejects oversize input")
+{
+    unsigned char   input_byte;
+    unsigned char   *compressed_buffer;
+    std::size_t     oversize_length;
+    std::size_t     compressed_length;
+
+    if (compression_max_size == SIZE_MAX)
+        return (1);
+    input_byte = 0;
+    oversize_length = compression_max_size;
+    oversize_length++;
+    compressed_length = 42;
+    ft_errno = ER_SUCCESS;
+    compressed_buffer = compress_buffer(&input_byte, oversize_length, &compressed_length);
+    if (compressed_buffer)
+    {
+        cma_free(compressed_buffer);
+        return (0);
+    }
+    if (compressed_length != 0)
+        return (0);
+    if (ft_errno != FT_EINVAL)
+        return (0);
+    return (1);
+}
+
+FT_TEST(test_decompress_rejects_oversize_payload, "decompress rejects oversize payload")
+{
+    unsigned char   header[sizeof(uint32_t)];
+    unsigned char   *decompressed_buffer;
+    std::size_t     fake_input_size;
+    std::size_t     decompressed_length;
+
+    if (compression_max_size > SIZE_MAX - sizeof(uint32_t) - 1)
+        return (1);
+    ft_memset(header, 0, sizeof(uint32_t));
+    fake_input_size = compression_max_size + sizeof(uint32_t) + 1;
+    decompressed_length = 99;
+    ft_errno = ER_SUCCESS;
+    decompressed_buffer = decompress_buffer(header, fake_input_size, &decompressed_length);
+    if (decompressed_buffer)
+    {
+        cma_free(decompressed_buffer);
+        return (0);
+    }
+    if (decompressed_length != 0)
+        return (0);
+    if (ft_errno != FT_EINVAL)
+        return (0);
+    return (1);
+}
 
 FT_TEST(test_ft_compress_round_trip, "ft_compress round trip")
 {


### PR DESCRIPTION
## Summary
- expose a compression_max_size constant documenting the 4 GiB limit for compression helpers
- prevent compress_buffer and decompress_buffer from invoking zlib when sizes exceed the supported range and set ft_errno
- add tests and README guidance covering the oversize rejection paths

## Testing
- make -C Test
- Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d05021fcd8833198a17ffabccf2ce6