### PR TITLE
Handle readline helper failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1591,6 +1591,11 @@ void rl_clear_suggestions();
 char *rl_readline(const char *prompt);
 ```
 
+Helper failures now short-circuit the input loop so `rl_readline` immediately
+cleans up its buffer, restores terminal state, and returns `ft_nullptr`. The
+regression exercise in `Test/Test/test_readline.cpp` simulates a backspace
+error to ensure no code touches the released buffer after `rl_error` runs.
+
 #### API
 HTTP client helpers in `API/api.hpp` and asynchronous wrappers. URL parsing
 relies on the `ft_string` class instead of `std::string`, so any allocation

--- a/ReadLine/readline.cpp
+++ b/ReadLine/readline.cpp
@@ -55,21 +55,24 @@ char *rl_readline(const char *prompt)
             break ;
         }
         else if (character == 127 || character == '\b')
-            rl_handle_backspace(&state, prompt);
+        {
+            if (rl_handle_backspace(&state, prompt) == -1)
+                return (rl_error(&state));
+        }
         else if (character == 27)
         {
             if (rl_handle_escape_sequence(&state, prompt) == -1)
-                rl_error(&state);
+                return (rl_error(&state));
         }
         else if (character == '\t')
         {
             if (rl_handle_tab_completion(&state, prompt) == -1)
-                rl_error(&state);
+                return (rl_error(&state));
         }
         else if (character >= 32 && character <= 126)
         {
             if (rl_handle_printable_char(&state, character, prompt) == -1)
-                rl_error(&state);
+                return (rl_error(&state));
         }
     }
     int line_length = ft_strlen(state.buffer);

--- a/Test/Test/test_readline.cpp
+++ b/Test/Test/test_readline.cpp
@@ -1,0 +1,84 @@
+#include <unistd.h>
+#include "../../ReadLine/readline.hpp"
+#include "../../ReadLine/readline_internal.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+static int g_terminal_width_call_count;
+static int g_terminal_width_failure_call;
+
+int cmp_readline_enable_raw_mode(void)
+{
+    return (0);
+}
+
+void cmp_readline_disable_raw_mode(void)
+{
+    return ;
+}
+
+int cmp_readline_terminal_width(void)
+{
+    g_terminal_width_call_count++;
+    if (g_terminal_width_failure_call != 0
+        && g_terminal_width_call_count == g_terminal_width_failure_call)
+        return (-1);
+    return (80);
+}
+
+FT_TEST(test_readline_backspace_failure, "ReadLine handles helper failures")
+{
+    int result;
+    int stdin_backup;
+    int stdout_backup;
+    int pipe_descriptors[2];
+    const char input_sequence[3] = {'a', 127, '\n'};
+    int original_history;
+
+    result = 1;
+    stdin_backup = dup(STDIN_FILENO);
+    stdout_backup = dup(STDOUT_FILENO);
+    if (stdin_backup < 0 || stdout_backup < 0)
+        result = 0;
+    else if (pipe(pipe_descriptors) != 0)
+        result = 0;
+    else
+    {
+        ssize_t written;
+
+        written = write(pipe_descriptors[1], input_sequence, sizeof(input_sequence));
+        if (written != static_cast<ssize_t>(sizeof(input_sequence)))
+            result = 0;
+        else if (dup2(pipe_descriptors[0], STDIN_FILENO) == -1)
+            result = 0;
+        else
+        {
+            g_terminal_width_call_count = 0;
+            g_terminal_width_failure_call = 2;
+            original_history = history_count;
+            char *line = rl_readline("> ");
+            if (line != ft_nullptr)
+                result = 0;
+            else if (history_count != original_history)
+                result = 0;
+        }
+        close(pipe_descriptors[0]);
+        close(pipe_descriptors[1]);
+    }
+    if (stdin_backup >= 0)
+    {
+        dup2(stdin_backup, STDIN_FILENO);
+        close(stdin_backup);
+    }
+    if (stdout_backup >= 0)
+    {
+        dup2(stdout_backup, STDOUT_FILENO);
+        close(stdout_backup);
+    }
+    g_terminal_width_failure_call = 0;
+    g_terminal_width_call_count = 0;
+    if (result == 0)
+        return (0);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- stop `rl_readline` from continuing after helper failures so it returns `ft_nullptr` with a cleaned buffer
- add a regression test that simulates a backspace failure path while keeping history untouched
- document the new failure handling behaviour in the README

## Testing
- make tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d05bf765848331b13fa61cb2fb7df3