### PR TITLE
Handle partial HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,8 +901,11 @@ int main()
 
 `Networking/http_server.hpp` implements a minimal synchronous server that uses
 `ft_socket` for IPv4 and IPv6 support, optional non-blocking operation and
-configurable timeouts. The server accepts a single connection and parses basic
-GET or POST requests.
+configurable timeouts. The server accepts a single connection, buffers data
+until the headers and any declared body are fully received, and enforces a
+64 KiB request limit to guard against oversized payloads. Basic GET or POST
+requests, including POST bodies delivered across multiple TCP receives, are
+parsed and echoed back in the response body.
 
 ```c++
 #include "Networking/http_server.hpp"

--- a/Test/Test/test_http_server.cpp
+++ b/Test/Test/test_http_server.cpp
@@ -3,6 +3,7 @@
 #include "../../Libft/libft.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include "../../PThread/thread.hpp"
+#include <unistd.h>
 
 static void server_worker(ft_http_server *server)
 {
@@ -56,8 +57,14 @@ FT_TEST(test_http_server_post, "HTTP server POST")
         server_thread_object.join();
         return (0);
     }
-    const char *request_string = "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nConnection: close\r\n\r\nHello";
-    client_socket.send_all(request_string, ft_strlen(request_string), 0);
+    const char *request_headers = "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nConnection: close\r\n\r\n";
+    const char *body_prefix = "He";
+    const char *body_suffix = "llo";
+    client_socket.send_all(request_headers, ft_strlen(request_headers), 0);
+    usleep(50000);
+    client_socket.send_all(body_prefix, ft_strlen(body_prefix), 0);
+    usleep(50000);
+    client_socket.send_all(body_suffix, ft_strlen(body_suffix), 0);
     char buffer[256];
     ssize_t bytes_received = client_socket.receive_data(buffer, sizeof(buffer) - 1, 0);
     if (bytes_received <= 0)


### PR DESCRIPTION
## Summary
- read from client sockets until the HTTP headers and declared body have been received, enforcing a 64 KiB request limit
- close sockets on receive failures before parsing and trim buffered bodies before generating responses
- update the README and HTTP server test to cover multi-chunk POST payloads

## Testing
- `make -C Test`
- `./Test/libft_tests`


------
https://chatgpt.com/codex/tasks/task_e_68d0605de3a48331b0cd709ed983f3ee