### PR TITLE
Handle non-blocking connect in setup_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,12 @@ socket wrapper with IPv4 and IPv6 support.
 connection, or datagram operation clears successes and forwards system
 errors through `ft_errno`.
 
+Non-blocking client sockets leave the descriptor open when `connect`
+returns `EINPROGRESS`, `EWOULDBLOCK`, or `WSAEWOULDBLOCK`. Callers must
+wait for the socket to become writable using `nw_poll`, `select`, or the
+event loop helpers before checking the connection result (for example by
+querying `get_error` or `SO_ERROR`).
+
 The accompanying tests exercise basic send and receive paths and invalid
 configurations for both address families in `Test/test_networking.cpp`.
 


### PR DESCRIPTION
## Summary
- keep client sockets open when non-blocking connect reports EINPROGRESS/EWOULDBLOCK so callers can poll for completion
- document the follow-up expectations for pending non-blocking connections in the networking module README

## Testing
- make -C Networking

------
https://chatgpt.com/codex/tasks/task_e_68d067b3fa6c8331beabd9d2f3bc3974