### PR TITLE
Implement proper unsigned strtoul and extend coverage

### DIFF
--- a/Test/Test/test_strtoul.cpp
+++ b/Test/Test/test_strtoul.cpp
@@ -1,5 +1,8 @@
+#include <cstdio>
 #include "../../Libft/libft.hpp"
+#include "../../Libft/limits.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strtoul_decimal, "ft_strtoul decimal with end pointer")
@@ -27,5 +30,48 @@ FT_TEST(test_strtoul_base0, "ft_strtoul base 0 hex prefix")
     char *end;
     FT_ASSERT_EQ(static_cast<unsigned long>(0x2a), ft_strtoul("0x2a", &end, 0));
     FT_ASSERT_EQ('\0', *end);
+    return (1);
+}
+
+FT_TEST(test_strtoul_above_long_max, "ft_strtoul parses values above FT_LONG_MAX")
+{
+    char value_buffer[64];
+    char *end;
+    unsigned long expected_value = static_cast<unsigned long>(FT_LONG_MAX);
+
+    expected_value = expected_value + 1UL;
+    std::snprintf(value_buffer, sizeof(value_buffer), "%lu", expected_value);
+    ft_errno = FT_ERANGE;
+    FT_ASSERT_EQ(expected_value, ft_strtoul(value_buffer, &end, 10));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ('\0', *end);
+    return (1);
+}
+
+FT_TEST(test_strtoul_unsigned_long_max, "ft_strtoul parses FT_ULONG_MAX without overflow")
+{
+    char value_buffer[64];
+    char *end;
+
+    std::snprintf(value_buffer, sizeof(value_buffer), "%lu", FT_ULONG_MAX);
+    ft_errno = FT_ERANGE;
+    FT_ASSERT_EQ(FT_ULONG_MAX, ft_strtoul(value_buffer, &end, 10));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ('\0', *end);
+    return (1);
+}
+
+FT_TEST(test_strtoul_overflow, "ft_strtoul clamps overflow and reports error")
+{
+    char value_buffer[64];
+    char *end;
+
+    std::snprintf(value_buffer, sizeof(value_buffer), "%lu", FT_ULONG_MAX);
+    ft_string overflow_string = value_buffer;
+    overflow_string.append('9');
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_ULONG_MAX, ft_strtoul(overflow_string.c_str(), &end, 10));
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
+    FT_ASSERT_EQ('9', *end);
     return (1);
 }


### PR DESCRIPTION
## Summary
- implement full unsigned parsing in `ft_strtoul`, including prefix handling, overflow detection, and `ft_errno` reporting
- extend `test_strtoul` to cover values above `FT_LONG_MAX`, `FT_ULONG_MAX`, and overflow scenarios

## Testing
- make
- ./libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d06c06f56c83319e54cf7cda2b3624