### PR TITLE
Handle partial network writes across HTTP and WebSocket

### DIFF
--- a/Networking/http_client.hpp
+++ b/Networking/http_client.hpp
@@ -2,8 +2,11 @@
 #define HTTP_CLIENT_HPP
 
 #include "../CPP_class/class_string_class.hpp"
+#include "ssl_wrapper.hpp"
 
 int http_get(const char *host, const char *path, ft_string &response, bool use_ssl = false, const char *custom_port = NULL);
 int http_post(const char *host, const char *path, const ft_string &body, ft_string &response, bool use_ssl = false, const char *custom_port = NULL);
+int http_client_send_plain_request(int socket_fd, const char *buffer, size_t length);
+int http_client_send_ssl_request(SSL *ssl_connection, const char *buffer, size_t length);
 
 #endif

--- a/Networking/networking_ssl_wrapper.cpp
+++ b/Networking/networking_ssl_wrapper.cpp
@@ -1,11 +1,31 @@
 #include "ssl_wrapper.hpp"
 
-ssize_t nw_ssl_write(SSL *ssl, const void *buf, size_t len)
+static ssize_t ssl_write_platform(SSL *ssl, const void *buf, size_t len)
 {
-    int ret = SSL_write(ssl, buf, static_cast<int>(len));
+    int ret;
+
+    ret = SSL_write(ssl, buf, static_cast<int>(len));
     if (ret <= 0)
         return (-1);
     return (ret);
+}
+
+static ssize_t (*g_ssl_write_function)(SSL *ssl, const void *buffer, size_t length) = &ssl_write_platform;
+
+void nw_set_ssl_write_stub(ssize_t (*ssl_write_stub)(SSL *ssl, const void *buffer, size_t length))
+{
+    if (ssl_write_stub == NULL)
+    {
+        g_ssl_write_function = &ssl_write_platform;
+        return ;
+    }
+    g_ssl_write_function = ssl_write_stub;
+    return ;
+}
+
+ssize_t nw_ssl_write(SSL *ssl, const void *buf, size_t len)
+{
+    return (g_ssl_write_function(ssl, buf, len));
 }
 
 ssize_t nw_ssl_read(SSL *ssl, void *buf, size_t len)

--- a/Networking/ssl_wrapper.hpp
+++ b/Networking/ssl_wrapper.hpp
@@ -12,5 +12,6 @@ typedef SSIZE_T ssize_t;
 
 ssize_t nw_ssl_write(SSL *ssl, const void *buf, size_t len);
 ssize_t nw_ssl_read(SSL *ssl, void *buf, size_t len);
+void nw_set_ssl_write_stub(ssize_t (*ssl_write_stub)(SSL *ssl, const void *buffer, size_t length));
 
 #endif

--- a/README.md
+++ b/README.md
@@ -826,6 +826,13 @@ indefinitely. This ensures callers can react promptly to closed connections.
 Tests can inject custom behavior into the network shim through
 `nw_set_send_stub`, passing `NULL` after the check to restore the default
 `nw_send` implementation.
+
+The HTTP client exposes `http_client_send_plain_request` and
+`http_client_send_ssl_request` helpers to retry partial transmissions and
+surface `SOCKET_SEND_FAILED` through `ft_errno` when the peer stops
+accepting data. Tests may override the SSL write path as well by calling
+`nw_set_ssl_write_stub` to substitute a custom `nw_ssl_write`
+implementation.
 The compatibility layer exposes `cmp_socket_send_all`, letting C callers invoke
 `ft_socket::send_all` while preserving the same error propagation and return
 values as the C++ method.

--- a/Test/Test/test_http_server.cpp
+++ b/Test/Test/test_http_server.cpp
@@ -1,9 +1,72 @@
 #include "../../Networking/http_server.hpp"
 #include "../../Networking/socket_class.hpp"
+#include "../../Networking/networking.hpp"
 #include "../../Libft/libft.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include "../../PThread/thread.hpp"
+#include "../../Errno/errno.hpp"
 #include <unistd.h>
+
+static size_t g_http_server_partial_calls = 0;
+static size_t g_http_server_partial_total = 0;
+static size_t g_http_server_expected_total = 0;
+static int g_http_server_error_stub_called = 0;
+static int g_http_server_partial_active = 0;
+
+static ssize_t http_server_partial_send_stub(int socket_fd, const void *buffer,
+                                            size_t length, int flags)
+{
+    const char *char_buffer;
+    size_t chunk_size;
+    ssize_t send_result;
+
+    (void)socket_fd;
+    (void)flags;
+    char_buffer = static_cast<const char *>(buffer);
+    if (length >= 4 && ft_strncmp(char_buffer, "HTTP", 4) == 0)
+        g_http_server_partial_active = 1;
+    if (g_http_server_partial_active != 0)
+    {
+        g_http_server_partial_calls++;
+        if (length > 7)
+            chunk_size = 7;
+        else
+            chunk_size = length;
+        nw_set_send_stub(NULL);
+        send_result = nw_send(socket_fd, buffer, chunk_size, flags);
+        nw_set_send_stub(&http_server_partial_send_stub);
+        if (send_result > 0)
+            g_http_server_partial_total += static_cast<size_t>(send_result);
+        if (length <= 7)
+            g_http_server_partial_active = 0;
+        return (send_result);
+    }
+    nw_set_send_stub(NULL);
+    send_result = nw_send(socket_fd, buffer, length, flags);
+    nw_set_send_stub(&http_server_partial_send_stub);
+    return (send_result);
+}
+
+static ssize_t http_server_short_write_stub(int socket_fd, const void *buffer,
+                                            size_t length, int flags)
+{
+    const char *char_buffer;
+    ssize_t send_result;
+
+    (void)socket_fd;
+    (void)flags;
+    char_buffer = static_cast<const char *>(buffer);
+    if (length >= 4 && ft_strncmp(char_buffer, "HTTP", 4) == 0)
+    {
+        g_http_server_error_stub_called = 1;
+        nw_set_send_stub(NULL);
+        return (0);
+    }
+    nw_set_send_stub(NULL);
+    send_result = nw_send(socket_fd, buffer, length, flags);
+    nw_set_send_stub(&http_server_short_write_stub);
+    return (send_result);
+}
 
 static void server_worker(ft_http_server *server)
 {
@@ -75,4 +138,69 @@ FT_TEST(test_http_server_post, "HTTP server POST")
     buffer[bytes_received] = '\0';
     server_thread_object.join();
     return (ft_strnstr(buffer, "Hello", bytes_received) != ft_nullptr);
+}
+
+FT_TEST(test_http_server_partial_send_retries, "HTTP server retries partial nw_send")
+{
+    ft_http_server server;
+    const char *expected_response;
+
+    if (server.start("127.0.0.1", 54332) != 0)
+        return (0);
+    expected_response = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nGET";
+    g_http_server_partial_calls = 0;
+    g_http_server_partial_total = 0;
+    g_http_server_expected_total = ft_strlen(expected_response);
+    g_http_server_partial_active = 0;
+    nw_set_send_stub(&http_server_partial_send_stub);
+    ft_thread server_thread_object(server_worker, &server);
+    SocketConfig client_configuration;
+    client_configuration._type = SocketType::CLIENT;
+    client_configuration._port = 54332;
+    ft_socket client_socket(client_configuration);
+    if (client_socket.get_error() != ER_SUCCESS)
+    {
+        server_thread_object.join();
+        nw_set_send_stub(NULL);
+        return (0);
+    }
+    const char *request_string = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    client_socket.send_all(request_string, ft_strlen(request_string), 0);
+    server_thread_object.join();
+    nw_set_send_stub(NULL);
+    if (server.get_error() != ER_SUCCESS)
+        return (0);
+    if (g_http_server_partial_calls < 2)
+        return (0);
+    if (g_http_server_partial_total != g_http_server_expected_total)
+        return (0);
+    return (1);
+}
+
+FT_TEST(test_http_server_short_write_sets_error, "HTTP server detects short write")
+{
+    ft_http_server server;
+
+    if (server.start("127.0.0.1", 54333) != 0)
+        return (0);
+    g_http_server_error_stub_called = 0;
+    nw_set_send_stub(&http_server_short_write_stub);
+    ft_thread server_thread_object(server_worker, &server);
+    SocketConfig client_configuration;
+    client_configuration._type = SocketType::CLIENT;
+    client_configuration._port = 54333;
+    ft_socket client_socket(client_configuration);
+    if (client_socket.get_error() != ER_SUCCESS)
+    {
+        server_thread_object.join();
+        nw_set_send_stub(NULL);
+        return (0);
+    }
+    const char *request_string = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    client_socket.send_all(request_string, ft_strlen(request_string), 0);
+    server_thread_object.join();
+    nw_set_send_stub(NULL);
+    if (g_http_server_error_stub_called == 0)
+        return (0);
+    return (server.get_error() == SOCKET_SEND_FAILED);
 }


### PR DESCRIPTION
## Summary
- retry partial sends in the HTTP server and websocket handshake while surfacing SOCKET_SEND_FAILED on short writes
- add reusable HTTP client send helpers, SSL write stubbing, and document the new hooks
- expand networking regression tests to simulate short writes across HTTP server, HTTP client (plain/SSL), and websocket handshake

## Testing
- make -C Networking
- make Full_Libft.a
- make -C Test
- ./Test/libft_tests


------
https://chatgpt.com/codex/tasks/task_e_68d0db3e28c48331af6edd4c1aa4f174