### PR TITLE
Handle masked websocket payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,7 +941,9 @@ int main()
 
 `Networking/websocket_client.hpp` and `websocket_server.hpp` add helpers for
 the WebSocket protocol including the opening handshake, frame parsing and
-basic ping/pong handling.
+basic ping/pong handling. The client now accepts both masked and unmasked
+server frames so responses from minimal implementations are decoded without
+extra configuration.
 
 ```c++
 #include "Networking/websocket_client.hpp"


### PR DESCRIPTION
## Summary
- update the websocket client to read masking metadata only when the frame is masked and to skip the XOR step for unmasked payloads
- add a websocket test helper that simulates masked and unmasked server frames and verify the client decodes both cases
- document in the README that the client now accepts unmasked server frames

## Testing
- make tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d0f1f92988833190861de3f5421ead