### PR TITLE
Handle SSL post-send disconnect detection

### DIFF
--- a/Networking/Makefile
+++ b/Networking/Makefile
@@ -2,6 +2,7 @@ TARGET := networking.a
 DEBUG_TARGET := networking_debug.a
 
 SRCS := networking_socket_class.cpp \
+        networking_send_utils.cpp \
         networking.cpp \
         networking_setup_server.cpp \
         networking_setup_client.cpp \
@@ -35,6 +36,7 @@ else
 endif
 
 HEADERS := socket_class.hpp \
+           networking_send_utils.hpp \
            networking.hpp \
            udp_socket.hpp \
            ssl_wrapper.hpp \

--- a/Networking/http_client.cpp
+++ b/Networking/http_client.cpp
@@ -1,5 +1,6 @@
 #include "http_client.hpp"
 #include "socket_class.hpp"
+#include "networking_send_utils.hpp"
 #include "ssl_wrapper.hpp"
 #include <cstring>
 #include <cstdio>
@@ -33,6 +34,9 @@ int http_client_send_plain_request(int socket_fd, const char *buffer, size_t len
         }
         total_sent += static_cast<size_t>(send_result);
     }
+    if (networking_check_socket_after_send(socket_fd) != 0)
+        return (-1);
+    ft_errno = ER_SUCCESS;
     return (0);
 }
 
@@ -52,6 +56,9 @@ int http_client_send_ssl_request(SSL *ssl_connection, const char *buffer, size_t
         }
         total_sent += static_cast<size_t>(send_result);
     }
+    if (networking_check_ssl_after_send(ssl_connection) != 0)
+        return (-1);
+    ft_errno = ER_SUCCESS;
     return (0);
 }
 

--- a/Networking/http_server.cpp
+++ b/Networking/http_server.cpp
@@ -1,4 +1,5 @@
 #include "http_server.hpp"
+#include "networking_send_utils.hpp"
 #include "../Errno/errno.hpp"
 #include "../Libft/libft.hpp"
 #include <cstring>
@@ -257,6 +258,12 @@ int ft_http_server::run_once()
             return (1);
         }
         total_sent += static_cast<size_t>(send_result);
+    }
+    if (networking_check_socket_after_send(client_socket) != 0)
+    {
+        FT_CLOSE_SOCKET(client_socket);
+        this->set_error(ft_errno);
+        return (1);
     }
     FT_CLOSE_SOCKET(client_socket);
     this->_error_code = ER_SUCCESS;

--- a/Networking/networking_send_utils.cpp
+++ b/Networking/networking_send_utils.cpp
@@ -1,0 +1,253 @@
+#include "networking_send_utils.hpp"
+#include "networking.hpp"
+#include "socket_class.hpp"
+#include "../Errno/errno.hpp"
+#include <thread>
+#include <chrono>
+#include <cerrno>
+#ifdef _WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
+#else
+# include <sys/socket.h>
+#endif
+
+int networking_check_socket_after_send(int socket_fd)
+{
+    int attempt_count;
+    int attempt_limit;
+    bool disconnect_detected;
+
+    if (socket_fd < 0)
+        return (0);
+    attempt_limit = 3;
+    attempt_count = 0;
+    disconnect_detected = false;
+    while (attempt_count < attempt_limit)
+    {
+        int poll_descriptor;
+        int poll_result;
+        char peek_buffer;
+        ssize_t recv_result;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        poll_descriptor = socket_fd;
+        poll_result = nw_poll(&poll_descriptor, 1, NULL, 0, 0);
+        if (poll_result < 0)
+        {
+#ifdef _WIN32
+            int last_error;
+
+            last_error = WSAGetLastError();
+            if (last_error == WSAEINTR)
+            {
+                attempt_count++;
+                continue ;
+            }
+            ft_errno = last_error + ERRNO_OFFSET;
+#else
+            if (errno == EINTR)
+            {
+                attempt_count++;
+                continue ;
+            }
+            ft_errno = errno + ERRNO_OFFSET;
+#endif
+            return (-1);
+        }
+        if (poll_result == 0 || poll_descriptor == -1)
+        {
+            attempt_count++;
+            continue ;
+        }
+        peek_buffer = 0;
+        recv_result = nw_recv(socket_fd, &peek_buffer, 1, MSG_PEEK);
+        if (recv_result == 0)
+        {
+            disconnect_detected = true;
+            break;
+        }
+        if (recv_result < 0)
+        {
+#ifdef _WIN32
+            int last_error;
+
+            last_error = WSAGetLastError();
+            if (last_error == WSAEWOULDBLOCK || last_error == WSAEINTR)
+            {
+                attempt_count++;
+                continue ;
+            }
+            ft_errno = last_error + ERRNO_OFFSET;
+#else
+            if (errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR)
+            {
+                attempt_count++;
+                continue ;
+            }
+            ft_errno = errno + ERRNO_OFFSET;
+#endif
+            return (-1);
+        }
+        break;
+    }
+    int socket_error;
+#ifdef _WIN32
+    int option_length;
+
+    socket_error = 0;
+    option_length = sizeof(socket_error);
+    if (getsockopt(static_cast<SOCKET>(socket_fd),
+                   SOL_SOCKET,
+                   SO_ERROR,
+                   reinterpret_cast<char*>(&socket_error),
+                   &option_length) == SOCKET_ERROR)
+    {
+        ft_errno = WSAGetLastError() + ERRNO_OFFSET;
+        return (-1);
+    }
+#else
+    socklen_t option_length;
+
+    socket_error = 0;
+    option_length = sizeof(socket_error);
+    if (getsockopt(socket_fd,
+                   SOL_SOCKET,
+                   SO_ERROR,
+                   &socket_error,
+                   &option_length) < 0)
+    {
+        ft_errno = errno + ERRNO_OFFSET;
+        return (-1);
+    }
+#endif
+    if (socket_error != 0)
+    {
+        ft_errno = socket_error + ERRNO_OFFSET;
+        return (-1);
+    }
+    if (disconnect_detected)
+    {
+        ft_errno = SOCKET_SEND_FAILED;
+        return (-1);
+    }
+    return (0);
+}
+
+int networking_check_ssl_after_send(SSL *ssl_connection)
+{
+    int attempt_count;
+    int attempt_limit;
+    int socket_fd;
+
+    if (ssl_connection == NULL)
+    {
+        ft_errno = SOCKET_SEND_FAILED;
+        return (-1);
+    }
+    attempt_limit = 3;
+    attempt_count = 0;
+    socket_fd = SSL_get_fd(ssl_connection);
+    if (socket_fd < 0)
+    {
+        ft_errno = ER_SUCCESS;
+        return (0);
+    }
+    while (attempt_count < attempt_limit)
+    {
+        char peek_buffer;
+        int peek_result;
+        int ssl_error;
+        int poll_descriptor;
+        int poll_result;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        poll_descriptor = socket_fd;
+        poll_result = nw_poll(&poll_descriptor, 1, NULL, 0, 0);
+        if (poll_result < 0)
+        {
+#ifdef _WIN32
+            int last_error;
+
+            last_error = WSAGetLastError();
+            if (last_error == WSAEINTR)
+            {
+                attempt_count++;
+                continue ;
+            }
+            ft_errno = last_error + ERRNO_OFFSET;
+#else
+            if (errno == EINTR)
+            {
+                attempt_count++;
+                continue ;
+            }
+            ft_errno = errno + ERRNO_OFFSET;
+#endif
+            return (-1);
+        }
+        if (poll_result == 0 || poll_descriptor == -1)
+        {
+            attempt_count++;
+            continue ;
+        }
+        peek_buffer = 0;
+        peek_result = SSL_peek(ssl_connection, &peek_buffer, 1);
+        if (peek_result > 0)
+            break;
+        if (peek_result == 0)
+        {
+            ft_errno = SOCKET_SEND_FAILED;
+            return (-1);
+        }
+        ssl_error = SSL_get_error(ssl_connection, peek_result);
+        if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE)
+        {
+            attempt_count++;
+            continue ;
+        }
+        if (ssl_error == SSL_ERROR_ZERO_RETURN)
+        {
+            ft_errno = SOCKET_SEND_FAILED;
+            return (-1);
+        }
+#ifdef _WIN32
+        if (ssl_error == SSL_ERROR_SYSCALL)
+        {
+            int last_error;
+
+            last_error = WSAGetLastError();
+            if (last_error == WSAEWOULDBLOCK || last_error == WSAEINTR)
+            {
+                attempt_count++;
+                continue ;
+            }
+            if (last_error != 0)
+                ft_errno = last_error + ERRNO_OFFSET;
+            else
+                ft_errno = SOCKET_SEND_FAILED;
+            return (-1);
+        }
+#else
+        if (ssl_error == SSL_ERROR_SYSCALL)
+        {
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+            {
+                attempt_count++;
+                continue ;
+            }
+            if (errno != 0)
+                ft_errno = errno + ERRNO_OFFSET;
+            else
+                ft_errno = SOCKET_SEND_FAILED;
+            return (-1);
+        }
+#endif
+        ft_errno = SOCKET_SEND_FAILED;
+        return (-1);
+    }
+    if (networking_check_socket_after_send(socket_fd) != 0)
+        return (-1);
+    ft_errno = ER_SUCCESS;
+    return (0);
+}

--- a/Networking/networking_send_utils.hpp
+++ b/Networking/networking_send_utils.hpp
@@ -1,0 +1,9 @@
+#ifndef NETWORKING_SEND_UTILS_HPP
+#define NETWORKING_SEND_UTILS_HPP
+
+#include "ssl_wrapper.hpp"
+
+int networking_check_socket_after_send(int socket_fd);
+int networking_check_ssl_after_send(SSL *ssl_connection);
+
+#endif

--- a/Networking/networking_socket_class.cpp
+++ b/Networking/networking_socket_class.cpp
@@ -1,4 +1,5 @@
 #include "socket_class.hpp"
+#include "networking_send_utils.hpp"
 #include "../Libft/libft.hpp"
 #include "../Errno/errno.hpp"
 #include "../Template/move.hpp"
@@ -255,6 +256,11 @@ ssize_t ft_socket::send_all(const void *data, size_t size, int flags)
             return (-1);
         }
         total_sent += bytes_sent;
+    }
+    if (networking_check_socket_after_send(this->_socket_fd) != 0)
+    {
+        this->set_error(ft_errno);
+        return (-1);
     }
     this->set_error(ER_SUCCESS);
     return (static_cast<ssize_t>(total_sent));

--- a/Networking/websocket_client.cpp
+++ b/Networking/websocket_client.cpp
@@ -1,5 +1,6 @@
 #include "websocket_client.hpp"
 #include "networking.hpp"
+#include "networking_send_utils.hpp"
 #include "socket_class.hpp"
 #include "../Compression/compression.hpp"
 #include "../CMA/CMA.hpp"
@@ -163,6 +164,11 @@ int ft_websocket_client::perform_handshake(const char *host, const char *path)
             return (1);
         }
         total_sent += static_cast<size_t>(send_result);
+    }
+    if (networking_check_socket_after_send(this->_socket_fd) != 0)
+    {
+        this->set_error(ft_errno);
+        return (1);
     }
     response.clear();
     while (true)

--- a/Test/Test/test_http_server.cpp
+++ b/Test/Test/test_http_server.cpp
@@ -179,7 +179,7 @@ FT_TEST(test_http_server_partial_send_retries, "HTTP server retries partial nw_s
         return (0);
     if (read_result.status != 0)
         return (0);
-    if (read_result.data != expected_response)
+    if (!(read_result.data == expected_response))
         return (0);
     return (read_result.read_iterations > 1);
 }

--- a/Test/Test/test_networking.cpp
+++ b/Test/Test/test_networking.cpp
@@ -823,7 +823,7 @@ FT_TEST(test_http_client_plain_partial_retry, "http client retries partial nw_se
         return (0);
     if (read_result.status != 0)
         return (0);
-    if (read_result.data != request_string)
+    if (!(read_result.data == request_string))
         return (0);
     return (read_result.read_iterations > 1);
 }
@@ -922,7 +922,7 @@ FT_TEST(test_http_client_ssl_partial_retry, "http client retries partial SSL wri
         return (0);
     if (read_result.status != 0)
         return (0);
-    if (read_result.data != request_string)
+    if (!(read_result.data == request_string))
         return (0);
     return (read_result.read_iterations > 1);
 }


### PR DESCRIPTION
## Summary
- add a networking_check_ssl_after_send helper that polls the TLS socket, peeks with SSL_peek, and reuses the existing post-send checks to surface deferred disconnects
- call the new SSL-aware helper from http_client_send_ssl_request so the HTTP client notices short writes and connection resets during TLS transfers
- export the helper in networking_send_utils.hpp for use by TLS callers

## Testing
- timeout 300 ./Test/libft_tests Networking/test_http_client_ssl_partial_retry *(times out in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2444bd0c88331847224ee158fbf16