### PR TITLE
Add regression tests for defensive Libft changes

### DIFF
--- a/Libft/libft_atoi.cpp
+++ b/Libft/libft_atoi.cpp
@@ -1,5 +1,6 @@
 #include "libft.hpp"
 #include "limits.hpp"
+#include "../CPP_class/class_nullptr.hpp"
 
 int    ft_atoi(const char *string)
 {
@@ -9,6 +10,8 @@ int    ft_atoi(const char *string)
     const unsigned long long positive_limit = static_cast<unsigned long long>(FT_INT_MAX);
     const unsigned long long negative_limit = static_cast<unsigned long long>(FT_INT_MAX) + 1ULL;
 
+    if (string == ft_nullptr)
+        return (0);
     while (string[index] == ' ' || ((string[index] >= '\t')
                 && (string[index] <= '\r')))
         index++;

--- a/Libft/libft_atol.cpp
+++ b/Libft/libft_atol.cpp
@@ -1,5 +1,6 @@
 #include "libft.hpp"
 #include "limits.hpp"
+#include "../CPP_class/class_nullptr.hpp"
 
 long ft_atol(const char *string)
 {
@@ -11,6 +12,8 @@ long ft_atol(const char *string)
     const long negative_limit_divider = FT_LONG_MIN / 10;
     const long negative_limit_remainder = -(FT_LONG_MIN % 10);
 
+    if (string == ft_nullptr)
+        return (0);
     while (string[index] == ' ' || (string[index] >= '\t' && string[index] <= '\r'))
         index++;
     if (string[index] == '+' || string[index] == '-')

--- a/Libft/libft_strncmp.cpp
+++ b/Libft/libft_strncmp.cpp
@@ -1,10 +1,13 @@
 #include "libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
 #include <unistd.h>
 
 int ft_strncmp(const char *string_1, const char *string_2, size_t max_len)
 {
     unsigned int current_index = 0;
 
+    if (string_1 == ft_nullptr || string_2 == ft_nullptr)
+        return (-1);
     while (string_1[current_index] != '\0' &&
            string_2[current_index] != '\0' &&
            current_index < max_len)

--- a/Libft/libft_strnstr.cpp
+++ b/Libft/libft_strnstr.cpp
@@ -5,9 +5,13 @@ char    *ft_strnstr(const char *haystack, const char *needle, size_t Length)
 {
     size_t    haystackIndex = 0;
     size_t    matchIndex;
-    size_t    needleLength = ft_strlen(needle);
-    char    *haystackPointer = const_cast<char *>(haystack);
+    char    *haystackPointer;
+    size_t    needleLength;
 
+    if (haystack == ft_nullptr || needle == ft_nullptr)
+        return (ft_nullptr);
+    haystackPointer = const_cast<char *>(haystack);
+    needleLength = ft_strlen(needle);
     if (needleLength == 0 || haystack == needle)
         return (haystackPointer);
     while (haystackPointer[haystackIndex] != '\0' && haystackIndex < Length)

--- a/Libft/libft_strtok.cpp
+++ b/Libft/libft_strtok.cpp
@@ -1,26 +1,18 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
-#include "../PThread/pthread.hpp"
 
 char    *ft_strtok(char *string, const char *delimiters)
 {
-    static char *saved_string = ft_nullptr;
-    static pt_mutex g_strtok_mutex;
+    static thread_local char *saved_string = ft_nullptr;
     char    *token_start;
     char    *current_pointer;
     int     is_delimiter;
     size_t  delimiter_index;
 
-    if (g_strtok_mutex.lock(THREAD_ID) != SUCCES)
-        return (ft_nullptr);
     if (string != ft_nullptr)
         saved_string = string;
     if (saved_string == ft_nullptr || delimiters == ft_nullptr)
-    {
-        if (g_strtok_mutex.unlock(THREAD_ID) != SUCCES)
-            return (ft_nullptr);
         return (ft_nullptr);
-    }
     current_pointer = saved_string;
     while (*current_pointer != '\0')
     {
@@ -42,8 +34,6 @@ char    *ft_strtok(char *string, const char *delimiters)
     if (*current_pointer == '\0')
     {
         saved_string = ft_nullptr;
-        if (g_strtok_mutex.unlock(THREAD_ID) != SUCCES)
-            return (ft_nullptr);
         return (ft_nullptr);
     }
     token_start = current_pointer;
@@ -73,8 +63,6 @@ char    *ft_strtok(char *string, const char *delimiters)
         *current_pointer = '\0';
         saved_string = current_pointer + 1;
     }
-    if (g_strtok_mutex.unlock(THREAD_ID) != SUCCES)
-        return (ft_nullptr);
     return (token_start);
 }
 

--- a/Libft/libft_strtol.cpp
+++ b/Libft/libft_strtol.cpp
@@ -1,5 +1,6 @@
 #include "libft.hpp"
 #include "limits.hpp"
+#include "../CPP_class/class_nullptr.hpp"
 #include "../Errno/errno.hpp"
 
 static int ft_digit_value(char character)
@@ -24,6 +25,13 @@ long ft_strtol(const char *input_string, char **end_pointer, int numeric_base)
     unsigned long negative_limit;
     unsigned long base_value;
 
+    if (current_character == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        if (end_pointer != ft_nullptr)
+            *end_pointer = ft_nullptr;
+        return (0L);
+    }
     ft_errno = ER_SUCCESS;
     while (*current_character == ' ' || (*current_character >= '\t'
                 && *current_character <= '\r'))

--- a/Libft/libft_strtoul.cpp
+++ b/Libft/libft_strtoul.cpp
@@ -1,5 +1,6 @@
 #include "libft.hpp"
 #include "limits.hpp"
+#include "../CPP_class/class_nullptr.hpp"
 #include "../Errno/errno.hpp"
 
 static int ft_digit_value(char character)
@@ -23,6 +24,13 @@ unsigned long ft_strtoul(const char *input_string, char **end_pointer, int numer
     unsigned long base_value;
     unsigned long limit_value;
 
+    if (current_character == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        if (end_pointer != ft_nullptr)
+            *end_pointer = ft_nullptr;
+        return (0UL);
+    }
     ft_errno = ER_SUCCESS;
     while (*current_character == ' ' || (*current_character >= '\t'
                 && *current_character <= '\r'))

--- a/RNG/rng_random_float.cpp
+++ b/RNG/rng_random_float.cpp
@@ -4,8 +4,8 @@
 float ft_random_float(void)
 {
     ft_init_srand();
-    float result = 0.0f;
-    while (result <= 1e-12f)
-        result = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-    return (result);
+    float random_value;
+
+    random_value = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    return (random_value);
 }

--- a/RNG/rng_random_int.cpp
+++ b/RNG/rng_random_int.cpp
@@ -4,8 +4,8 @@
 int ft_random_int(void)
 {
     ft_init_srand();
-    int result = 0;
-    while (result == 0)
-        result = rand();
-    return (result);
+    int random_value;
+
+    random_value = rand();
+    return (random_value);
 }

--- a/Test/Test/test_atoi.cpp
+++ b/Test/Test/test_atoi.cpp
@@ -1,6 +1,7 @@
 #include "../../Libft/libft.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include "../../Libft/limits.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
 
 FT_TEST(test_atoi_simple, "ft_atoi simple")
 {
@@ -72,5 +73,11 @@ FT_TEST(test_atoi_plus_sign, "ft_atoi plus sign")
 FT_TEST(test_atoi_zero, "ft_atoi zero")
 {
     FT_ASSERT_EQ(0, ft_atoi("0"));
+    return (1);
+}
+
+FT_TEST(test_atoi_null_input, "ft_atoi null input returns zero")
+{
+    FT_ASSERT_EQ(0, ft_atoi(ft_nullptr));
     return (1);
 }

--- a/Test/Test/test_atol.cpp
+++ b/Test/Test/test_atol.cpp
@@ -1,6 +1,7 @@
 #include "../../Libft/libft.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include "../../Libft/limits.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
 
 FT_TEST(test_atol_overflow_clamps_to_long_max, "ft_atol clamps overflow to FT_LONG_MAX")
 {
@@ -19,5 +20,11 @@ FT_TEST(test_atol_underflow_clamps_to_long_min, "ft_atol clamps underflow to FT_
     underflow_string = ft_to_string(FT_LONG_MIN);
     underflow_string += "9";
     FT_ASSERT_EQ(FT_LONG_MIN, ft_atol(underflow_string.c_str()));
+    return (1);
+}
+
+FT_TEST(test_atol_null_input, "ft_atol null input returns zero")
+{
+    FT_ASSERT_EQ(0L, ft_atol(ft_nullptr));
     return (1);
 }

--- a/Test/Test/test_rng.cpp
+++ b/Test/Test/test_rng.cpp
@@ -3,6 +3,39 @@
 #include "../../System_utils/test_runner.hpp"
 #include <cstdlib>
 
+FT_TEST(test_rng_random_int_matches_stdlib, "ft_random_int matches rand output")
+{
+    g_srand_init = true;
+    srand(246);
+    int expected_value = rand();
+
+    g_srand_init = true;
+    srand(246);
+    int random_value = ft_random_int();
+
+    FT_ASSERT_EQ(expected_value, random_value);
+    return (1);
+}
+
+FT_TEST(test_rng_random_float_matches_stdlib, "ft_random_float matches normalized rand")
+{
+    g_srand_init = true;
+    srand(97531);
+    int raw_random_value = rand();
+    float expected_value = static_cast<float>(raw_random_value)
+        / static_cast<float>(RAND_MAX);
+
+    g_srand_init = true;
+    srand(97531);
+    float random_value = ft_random_float();
+    float difference_value = random_value - expected_value;
+
+    if (difference_value < 0.0f)
+        difference_value = -difference_value;
+    FT_ASSERT(difference_value <= 0.000001f);
+    return (1);
+}
+
 FT_TEST(test_rng_random_normal, "ft_random_normal mean")
 {
     g_srand_init = true;

--- a/Test/Test/test_strncmp.cpp
+++ b/Test/Test/test_strncmp.cpp
@@ -1,4 +1,5 @@
 #include "../../Libft/libft.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strncmp_prefix_equal, "ft_strncmp equal prefix")
@@ -34,5 +35,12 @@ FT_TEST(test_strncmp_shorter_first, "ft_strncmp shorter first")
 FT_TEST(test_strncmp_shorter_second, "ft_strncmp shorter second")
 {
     FT_ASSERT(ft_strncmp("abc", "ab", 3) > 0);
+    return (1);
+}
+
+FT_TEST(test_strncmp_null_arguments, "ft_strncmp null arguments return error")
+{
+    FT_ASSERT_EQ(-1, ft_strncmp(ft_nullptr, "abc", 3));
+    FT_ASSERT_EQ(-1, ft_strncmp("abc", ft_nullptr, 3));
     return (1);
 }

--- a/Test/Test/test_strnstr.cpp
+++ b/Test/Test/test_strnstr.cpp
@@ -35,3 +35,10 @@ FT_TEST(test_strnstr_zero_size, "ft_strnstr zero size")
     FT_ASSERT_EQ(ft_nullptr, ft_strnstr("hello", "he", 0));
     return (1);
 }
+
+FT_TEST(test_strnstr_null_arguments, "ft_strnstr null arguments return nullptr")
+{
+    FT_ASSERT_EQ(ft_nullptr, ft_strnstr(ft_nullptr, "abc", 3));
+    FT_ASSERT_EQ(ft_nullptr, ft_strnstr("abc", ft_nullptr, 3));
+    return (1);
+}

--- a/Test/Test/test_strtok.cpp
+++ b/Test/Test/test_strtok.cpp
@@ -1,5 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../System_utils/test_runner.hpp"
+#include <thread>
 
 FT_TEST(test_strtok_basic, "ft_strtok basic")
 {
@@ -40,5 +41,44 @@ FT_TEST(test_strtok_reinitialize, "ft_strtok resets when given a new string")
     token = ft_strtok(ft_nullptr, " ");
     FT_ASSERT_EQ(0, ft_strcmp("delta", token));
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, " "));
+    return (1);
+}
+
+FT_TEST(test_strtok_thread_local_state, "ft_strtok maintains thread local state")
+{
+    char first_thread_buffer[32] = "red blue";
+    char second_thread_buffer[32] = "green yellow";
+    char *first_thread_token_one = ft_nullptr;
+    char *first_thread_token_two = ft_nullptr;
+    char *second_thread_token_one = ft_nullptr;
+    char *second_thread_token_two = ft_nullptr;
+
+    std::thread first_thread([
+    &first_thread_buffer,
+    &first_thread_token_one,
+    &first_thread_token_two
+    ]()
+    {
+        first_thread_token_one = ft_strtok(first_thread_buffer, " ");
+        first_thread_token_two = ft_strtok(ft_nullptr, " ");
+        return ;
+    });
+    std::thread second_thread([
+    &second_thread_buffer,
+    &second_thread_token_one,
+    &second_thread_token_two
+    ]()
+    {
+        second_thread_token_one = ft_strtok(second_thread_buffer, " ");
+        second_thread_token_two = ft_strtok(ft_nullptr, " ");
+        return ;
+    });
+
+    first_thread.join();
+    second_thread.join();
+    FT_ASSERT_EQ(0, ft_strcmp("red", first_thread_token_one));
+    FT_ASSERT_EQ(0, ft_strcmp("blue", first_thread_token_two));
+    FT_ASSERT_EQ(0, ft_strcmp("green", second_thread_token_one));
+    FT_ASSERT_EQ(0, ft_strcmp("yellow", second_thread_token_two));
     return (1);
 }

--- a/Test/Test/test_strtol.cpp
+++ b/Test/Test/test_strtol.cpp
@@ -89,3 +89,14 @@ FT_TEST(test_strtol_negative_overflow, "ft_strtol clamps negative overflow and r
     FT_ASSERT_EQ('9', *end);
     return (1);
 }
+
+FT_TEST(test_strtol_null_input, "ft_strtol null input sets errno and end pointer")
+{
+    char *end_pointer = reinterpret_cast<char *>(0x1);
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, ft_strtol(ft_nullptr, &end_pointer, 10));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(ft_nullptr, end_pointer);
+    return (1);
+}

--- a/Test/Test/test_strtoul.cpp
+++ b/Test/Test/test_strtoul.cpp
@@ -75,3 +75,14 @@ FT_TEST(test_strtoul_overflow, "ft_strtoul clamps overflow and reports error")
     FT_ASSERT_EQ('9', *end);
     return (1);
 }
+
+FT_TEST(test_strtoul_null_input, "ft_strtoul null input sets errno and end pointer")
+{
+    char *end_pointer = reinterpret_cast<char *>(0x1);
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0UL, ft_strtoul(ft_nullptr, &end_pointer, 10));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(ft_nullptr, end_pointer);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add explicit null-input coverage for ft_atoi/ft_atol, ft_strncmp, and ft_strnstr
- exercise the new errno/null-pointer handling in ft_strtol and ft_strtoul
- confirm the RNG wrappers now forward stdlib rand() results, including zero, and that ft_strtok keeps per-thread state

## Testing
- make tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d3d945ed58833197e4be232a11f0ff