### PR TITLE
Fix null handling in cma_split and ft_strlcat

### DIFF
--- a/CMA/cma_split.cpp
+++ b/CMA/cma_split.cpp
@@ -94,10 +94,10 @@ char    **cma_split(char const *string, char delimiter)
 
     if (!string)
     {
-        strings = static_cast<char **>(cma_malloc(sizeof(char) * 1));
+        strings = static_cast<char **>(cma_malloc(sizeof(*strings)));
         if (!strings)
             return (ft_nullptr);
-        *strings = ft_nullptr;
+        strings[0] = ft_nullptr;
         return (strings);
     }
     word_count = ft_count_words(string, delimiter);

--- a/Libft/libft_strlcat.cpp
+++ b/Libft/libft_strlcat.cpp
@@ -1,10 +1,18 @@
 #include "libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 size_t    ft_strlcat(char *destination, const char *source, size_t bufferSize)
 {
     size_t    destLength = 0;
     size_t    sourceIndex = 0;
 
+    ft_errno = ER_SUCCESS;
+    if (destination == ft_nullptr || source == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (0);
+    }
     while (destination[destLength] && destLength < bufferSize)
         destLength++;
     while (source[sourceIndex] && (destLength + sourceIndex + 1) < bufferSize)

--- a/Test/Test/test_extra_libft.cpp
+++ b/Test/Test/test_extra_libft.cpp
@@ -195,6 +195,23 @@ int test_strlcat_truncate(void)
     return (r == 7 && std::strcmp(dst, "hiwor") == 0);
 }
 
+int test_strlcat_null_destination(void)
+{
+    size_t result;
+
+    result = ft_strlcat(ft_nullptr, "abc", 5);
+    return (result == 0);
+}
+
+int test_strlcat_null_source(void)
+{
+    char dst[8] = "hi";
+    size_t result;
+
+    result = ft_strlcat(dst, ft_nullptr, sizeof(dst));
+    return (result == 0 && std::strcmp(dst, "hi") == 0);
+}
+
 int test_strncmp_basic(void)
 {
     return (ft_strncmp("abc", "abd", 2) == 0);


### PR DESCRIPTION
## Summary
- fix `cma_split`'s null-input allocation to reserve space for a pointer terminator
- guard `ft_strlcat` against null pointers and set `ft_errno` to `FT_EINVAL`
- add regression coverage for null inputs in the `ft_strlcat` extra tests

## Testing
- `make tests`
- `./Test/libft_tests`


------
https://chatgpt.com/codex/tasks/task_e_68d3ee2f36b88331b098e23a70dd9aee