### PR TITLE
Replace RNG mutex with internal pt_mutex

### DIFF
--- a/RNG/rng_engine.cpp
+++ b/RNG/rng_engine.cpp
@@ -1,15 +1,17 @@
 #include "rng_internal.hpp"
 #include <atomic>
-#include <mutex>
 #include <random>
+#include "../PThread/unique_lock.hpp"
 
 std::mt19937 g_random_engine;
-std::mutex g_random_engine_mutex;
+pt_mutex g_random_engine_mutex;
 std::atomic<bool> g_random_engine_seeded(false);
 
 void ft_seed_random_engine(uint32_t seed_value)
 {
-    std::lock_guard<std::mutex> guard(g_random_engine_mutex);
+    ft_unique_lock<pt_mutex> guard(g_random_engine_mutex);
+    if (guard.get_error() != ER_SUCCESS)
+        return ;
     g_random_engine.seed(static_cast<std::mt19937::result_type>(seed_value));
     g_random_engine_seeded.store(true, std::memory_order_release);
     return ;

--- a/RNG/rng_internal.hpp
+++ b/RNG/rng_internal.hpp
@@ -3,11 +3,11 @@
 
 #include <atomic>
 #include <cstdint>
-#include <mutex>
 #include <random>
+#include "../PThread/mutex.hpp"
 
 extern std::mt19937 g_random_engine;
-extern std::mutex g_random_engine_mutex;
+extern pt_mutex g_random_engine_mutex;
 extern std::atomic<bool> g_random_engine_seeded;
 
 void ft_seed_random_engine(uint32_t seed_value);

--- a/RNG/rng_random_float.cpp
+++ b/RNG/rng_random_float.cpp
@@ -1,7 +1,7 @@
 #include "rng.hpp"
 #include "rng_internal.hpp"
-#include <mutex>
 #include <random>
+#include "../PThread/unique_lock.hpp"
 
 float ft_random_float(void)
 {
@@ -9,9 +9,9 @@ float ft_random_float(void)
     std::uniform_real_distribution<float> distribution(0.0f, 1.0f);
     float random_value;
 
-    {
-        std::lock_guard<std::mutex> guard(g_random_engine_mutex);
-        random_value = distribution(g_random_engine);
-    }
+    ft_unique_lock<pt_mutex> guard(g_random_engine_mutex);
+    if (guard.get_error() != ER_SUCCESS)
+        return (0.0f);
+    random_value = distribution(g_random_engine);
     return (random_value);
 }

--- a/RNG/rng_random_int.cpp
+++ b/RNG/rng_random_int.cpp
@@ -1,8 +1,8 @@
 #include "rng.hpp"
 #include "rng_internal.hpp"
 #include <limits>
-#include <mutex>
 #include <random>
+#include "../PThread/unique_lock.hpp"
 
 int ft_random_int(void)
 {
@@ -10,9 +10,9 @@ int ft_random_int(void)
     std::uniform_int_distribution<int> distribution(0, std::numeric_limits<int>::max());
     int random_value;
 
-    {
-        std::lock_guard<std::mutex> guard(g_random_engine_mutex);
-        random_value = distribution(g_random_engine);
-    }
+    ft_unique_lock<pt_mutex> guard(g_random_engine_mutex);
+    if (guard.get_error() != ER_SUCCESS)
+        return (0);
+    random_value = distribution(g_random_engine);
     return (random_value);
 }


### PR DESCRIPTION
## Summary
- replace the RNG module's std::mutex usage with the library's pt_mutex wrapper
- guard accesses to the global random engine with ft_unique_lock and handle locking failures
- update headers to include the internal threading primitives

## Testing
- make -C RNG

------
https://chatgpt.com/codex/tasks/task_e_68d41a02127c8331bf1ed18a75003b45