### PR TITLE
Improve floating formatting and error handling

### DIFF
--- a/Libft/libft_memcpy.cpp
+++ b/Libft/libft_memcpy.cpp
@@ -1,13 +1,18 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include <cstdint>
 
 void* ft_memcpy(void* destination, const void* source, size_t size)
 {
+    ft_errno = ER_SUCCESS;
     if (size == 0)
         return (destination);
     if (destination == ft_nullptr || source == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
 
     unsigned char*       dest = static_cast<unsigned char*>(destination);
     const unsigned char* src = static_cast<const unsigned char*>(source);

--- a/Libft/libft_memmove.cpp
+++ b/Libft/libft_memmove.cpp
@@ -1,5 +1,6 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 void *ft_memmove(void *destination, const void *source, size_t size)
 {
@@ -7,10 +8,14 @@ void *ft_memmove(void *destination, const void *source, size_t size)
     const unsigned char *source_pointer = static_cast<const unsigned char *>(source);
     size_t index;
 
+    ft_errno = ER_SUCCESS;
     if (size == 0 || destination == source)
         return (destination);
-    if (!destination || !source)
+    if (destination == ft_nullptr || source == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     if (destination_pointer < source_pointer)
     {
         index = 0;

--- a/Libft/libft_strcmp.cpp
+++ b/Libft/libft_strcmp.cpp
@@ -1,9 +1,15 @@
 #include "libft.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 int    ft_strcmp(const char *string1, const char *string2)
 {
-    if (!string1 || !string2)
+    ft_errno = ER_SUCCESS;
+    if (string1 == ft_nullptr || string2 == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (-1);
+    }
     while (*string1 && (*string1) == (*string2))
     {
         string1++;

--- a/Printf/printf_format.cpp
+++ b/Printf/printf_format.cpp
@@ -14,6 +14,8 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
 
     while (format[index])
     {
+        if (count == SIZE_MAX)
+            break ;
         if (format[index] == '%')
         {
             index++;
@@ -136,13 +138,13 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
             {
                 bool uppercase = (spec == 'E');
                 double number = va_arg(args, double);
-                ft_putscientific_fd(number, uppercase, fd, &count);
+                ft_putscientific_fd(number, uppercase, fd, &count, precision);
             }
             else if (spec == 'g' || spec == 'G')
             {
                 bool uppercase = (spec == 'G');
                 double number = va_arg(args, double);
-                ft_putgeneral_fd(number, uppercase, fd, &count);
+                ft_putgeneral_fd(number, uppercase, fd, &count, precision);
             }
             else if (spec == 'p')
             {
@@ -159,23 +161,26 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
             }
             else if (spec == 'n')
             {
-                if (len_mod == LEN_L)
+                if (count != SIZE_MAX)
                 {
-                    long *out = va_arg(args, long *);
-                    if (out)
-                        *out = static_cast<long>(count);
-                }
-                else if (len_mod == LEN_Z)
-                {
-                    size_t *out = va_arg(args, size_t *);
-                    if (out)
-                        *out = count;
-                }
-                else
-                {
-                    int *out = va_arg(args, int *);
-                    if (out)
-                        *out = static_cast<int>(count);
+                    if (len_mod == LEN_L)
+                    {
+                        long *out = va_arg(args, long *);
+                        if (out)
+                            *out = static_cast<long>(count);
+                    }
+                    else if (len_mod == LEN_Z)
+                    {
+                        size_t *out = va_arg(args, size_t *);
+                        if (out)
+                            *out = count;
+                    }
+                    else
+                    {
+                        int *out = va_arg(args, int *);
+                        if (out)
+                            *out = static_cast<int>(count);
+                    }
                 }
             }
             else if (spec == '%')
@@ -190,5 +195,9 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
             ft_putchar_fd(format[index], fd, &count);
         index++;
     }
+    if (count == SIZE_MAX)
+        return (-1);
+    if (count > static_cast<size_t>(INT_MAX))
+        return (-1);
     return (static_cast<int>(count));
 }

--- a/Printf/printf_internal.hpp
+++ b/Printf/printf_internal.hpp
@@ -30,8 +30,8 @@ void ft_putoctal_fd(uintmax_t number, int fd, size_t *count);
 void ft_putptr_fd(void *pointer, int fd, size_t *count);
 
 void ft_putfloat_fd(double number, int fd, size_t *count, int precision);
-void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count);
-void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count);
+void ft_putscientific_fd(double number, bool uppercase, int fd, size_t *count, int precision);
+void ft_putgeneral_fd(double number, bool uppercase, int fd, size_t *count, int precision);
 int pf_printf_fd_v(int fd, const char *format, va_list args);
 
 #endif

--- a/Printf/printf_snprintf.cpp
+++ b/Printf/printf_snprintf.cpp
@@ -1,27 +1,15 @@
 #include "printf.hpp"
-#include "../Libft/libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 int pf_snprintf(char *string, size_t size, const char *format, ...)
 {
     if (string == ft_nullptr || format == ft_nullptr)
         return (0);
     va_list args;
-    char *buffer = ft_nullptr;
-    size_t buffer_size = 0;
-    FILE *stream = open_memstream(&buffer, &buffer_size);
-    if (stream == ft_nullptr)
-        return (0);
     va_start(args, format);
-    int printed = ft_vfprintf(stream, format, args);
+    int printed = pf_vsnprintf(string, size, format, args);
     va_end(args);
-    fclose(stream);
-    if (buffer != ft_nullptr && size > 0)
-        ft_strlcpy(string, buffer, size);
-    free(buffer);
     return (printed);
 }
 

--- a/Printf/printf_vsnprintf.cpp
+++ b/Printf/printf_vsnprintf.cpp
@@ -1,27 +1,58 @@
 #include "printf.hpp"
-#include "../Libft/libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include <stdarg.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 int pf_vsnprintf(char *string, size_t size, const char *format, va_list args)
 {
     if (string == ft_nullptr || format == ft_nullptr)
         return (0);
-    char *buffer = ft_nullptr;
-    size_t buffer_size = 0;
-    FILE *stream = open_memstream(&buffer, &buffer_size);
+    FILE *stream = tmpfile();
     if (stream == ft_nullptr)
+    {
+        if (size > 0)
+            string[0] = '\0';
         return (0);
+    }
     va_list copy;
     va_copy(copy, args);
     int printed = ft_vfprintf(stream, format, copy);
     va_end(copy);
+    if (printed < 0)
+    {
+        fclose(stream);
+        if (size > 0)
+            string[0] = '\0';
+        return (printed);
+    }
+    int flush_status = fflush(stream);
+    if (flush_status != 0)
+    {
+        fclose(stream);
+        if (size > 0)
+            string[0] = '\0';
+        return (0);
+    }
+    long position = ftell(stream);
+    if (position < 0)
+    {
+        fclose(stream);
+        if (size > 0)
+            string[0] = '\0';
+        return (0);
+    }
+    rewind(stream);
+    if (size > 0)
+    {
+        size_t copy_length = static_cast<size_t>(position);
+        if (copy_length >= size)
+            copy_length = size - 1;
+        size_t read_bytes = 0;
+        if (copy_length > 0)
+            read_bytes = fread(string, 1, copy_length, stream);
+        string[read_bytes] = '\0';
+    }
     fclose(stream);
-    if (buffer != ft_nullptr && size > 0)
-        ft_strlcpy(string, buffer, size);
-    free(buffer);
     return (printed);
 }
 


### PR DESCRIPTION
## Summary
- add reusable helpers that stop counting and flag SIZE_MAX when su_write or stdio writes fail, ensuring the printf emitters no longer report success on errors
- format %f/%e/%g output with snprintf so rounding, NaN/Inf, and caller precision are respected for both descriptor and FILE* printers
- return -1 from pf_printf_fd_v and ft_vfprintf when a write fails and suppress %n updates once an error has occurred

## Testing
- make -C Printf

------
https://chatgpt.com/codex/tasks/task_e_68d41b4e09388331a791fca5a51ad331