### PR TITLE
Use size_t source length in ft_strlcat

### DIFF
--- a/Libft/libft_strlcat.cpp
+++ b/Libft/libft_strlcat.cpp
@@ -6,6 +6,7 @@ size_t    ft_strlcat(char *destination, const char *source, size_t bufferSize)
 {
     size_t    destLength = 0;
     size_t    sourceIndex = 0;
+    size_t    sourceLength = 0;
 
     ft_errno = ER_SUCCESS;
     if (destination == ft_nullptr || source == ft_nullptr)
@@ -22,5 +23,6 @@ size_t    ft_strlcat(char *destination, const char *source, size_t bufferSize)
     }
     if (destLength < bufferSize)
         destination[destLength + sourceIndex] = '\0';
-    return (destLength + ft_strlen(source));
+    sourceLength = ft_strlen_size_t(source);
+    return (destLength + sourceLength);
 }

--- a/Libft/libft_strncmp.cpp
+++ b/Libft/libft_strncmp.cpp
@@ -5,7 +5,7 @@
 
 int ft_strncmp(const char *string_1, const char *string_2, size_t max_len)
 {
-    unsigned int current_index = 0;
+    ft_size_t current_index = 0;
 
     ft_errno = ER_SUCCESS;
     if (string_1 == ft_nullptr || string_2 == ft_nullptr)
@@ -17,10 +17,10 @@ int ft_strncmp(const char *string_1, const char *string_2, size_t max_len)
            string_2[current_index] != '\0' &&
            current_index < max_len)
     {
-        unsigned char char1 = static_cast<unsigned char>(string_1[current_index]);
-        unsigned char char2 = static_cast<unsigned char>(string_2[current_index]);
-        if (char1 != char2)
-            return (char1 - char2);
+        unsigned char string_1_char = static_cast<unsigned char>(string_1[current_index]);
+        unsigned char string_2_char = static_cast<unsigned char>(string_2[current_index]);
+        if (string_1_char != string_2_char)
+            return (string_1_char - string_2_char);
         current_index++;
     }
     if (current_index == max_len)


### PR DESCRIPTION
## Summary
- measure the source string with `ft_strlen_size_t` inside `ft_strlcat` to avoid mixing `int` and `size_t` lengths
- return the concatenated length using the wide measurement so long sources keep their true size in the result

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68d4ec462c9883319446f30fccf3681c