### PR TITLE
Fix TLS stubs linkage and chunk parser trailers

### DIFF
--- a/API/tls_client.hpp
+++ b/API/tls_client.hpp
@@ -5,8 +5,10 @@
 #include "../CPP_class/class_string_class.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../Errno/errno.hpp"
+#include "../PThread/thread.hpp"
 #include <openssl/ssl.h>
 #include <cstdint>
+#include "../Template/vector.hpp"
 
 typedef void (*api_callback)(char *body, int status, void *user_data);
 
@@ -19,6 +21,7 @@ class api_tls_client
         ft_string _host;
         int _timeout;
         mutable int _error_code;
+        ft_vector<ft_thread> _async_workers;
 
         void set_error(int error_code) const noexcept;
 

--- a/Libft/libft_atoi.cpp
+++ b/Libft/libft_atoi.cpp
@@ -1,6 +1,7 @@
 #include "libft.hpp"
 #include "limits.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 int    ft_atoi(const char *string)
 {
@@ -9,9 +10,14 @@ int    ft_atoi(const char *string)
     unsigned long long result = 0;
     const unsigned long long positive_limit = static_cast<unsigned long long>(FT_INT_MAX);
     const unsigned long long negative_limit = static_cast<unsigned long long>(FT_INT_MAX) + 1ULL;
+    bool    digit_found = false;
 
     if (string == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (0);
+    }
+    ft_errno = ER_SUCCESS;
     while (string[index] == ' ' || ((string[index] >= '\t')
                 && (string[index] <= '\r')))
         index++;
@@ -26,25 +32,45 @@ int    ft_atoi(const char *string)
     {
         int    digit = string[index] - '0';
 
+        digit_found = true;
         if (sign == 1)
         {
             if (result > positive_limit / 10)
+            {
+                ft_errno = FT_ERANGE;
                 return (FT_INT_MAX);
+            }
             if (result == positive_limit / 10
                 && static_cast<unsigned long long>(digit) > positive_limit % 10)
+            {
+                ft_errno = FT_ERANGE;
                 return (FT_INT_MAX);
+            }
         }
         else
         {
             if (result > negative_limit / 10)
+            {
+                ft_errno = FT_ERANGE;
                 return (FT_INT_MIN);
+            }
             if (result == negative_limit / 10
                 && static_cast<unsigned long long>(digit) > negative_limit % 10)
+            {
+                ft_errno = FT_ERANGE;
                 return (FT_INT_MIN);
+            }
         }
         result = result * 10 + static_cast<unsigned long long>(digit);
         index++;
     }
+    if (digit_found == false)
+    {
+        ft_errno = FT_EINVAL;
+        return (0);
+    }
+    if (string[index] != '\0')
+        ft_errno = FT_EINVAL;
     if (sign == -1)
     {
         long long signed_result = -static_cast<long long>(result);

--- a/Libft/libft_atol.cpp
+++ b/Libft/libft_atol.cpp
@@ -1,20 +1,25 @@
 #include "libft.hpp"
 #include "limits.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 long ft_atol(const char *string)
 {
     long index = 0;
     long sign = 1;
-    long result = 0;
-    const long positive_limit_divider = FT_LONG_MAX / 10;
-    const long positive_limit_remainder = FT_LONG_MAX % 10;
-    const long negative_limit_divider = FT_LONG_MIN / 10;
-    const long negative_limit_remainder = -(FT_LONG_MIN % 10);
+    unsigned long long result = 0;
+    const unsigned long long positive_limit = static_cast<unsigned long long>(FT_LONG_MAX);
+    const unsigned long long negative_limit = static_cast<unsigned long long>(FT_LONG_MAX) + 1ULL;
+    bool digit_found = false;
 
     if (string == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (0);
-    while (string[index] == ' ' || (string[index] >= '\t' && string[index] <= '\r'))
+    }
+    ft_errno = ER_SUCCESS;
+    while (string[index] == ' ' || ((string[index] >= '\t')
+            && (string[index] <= '\r')))
         index++;
     if (string[index] == '+' || string[index] == '-')
     {
@@ -22,27 +27,57 @@ long ft_atol(const char *string)
             sign = -1;
         index++;
     }
-    while (string[index] >= '0' && string[index] <= '9')
+    while (string[index] && ((string[index] >= '0')
+            && (string[index] <= '9')))
     {
         int digit = string[index] - '0';
 
+        digit_found = true;
         if (sign == 1)
         {
-            if (result > positive_limit_divider)
+            if (result > positive_limit / 10)
+            {
+                ft_errno = FT_ERANGE;
                 return (FT_LONG_MAX);
-            if (result == positive_limit_divider && digit > positive_limit_remainder)
+            }
+            if (result == positive_limit / 10
+                && static_cast<unsigned long long>(digit) > positive_limit % 10)
+            {
+                ft_errno = FT_ERANGE;
                 return (FT_LONG_MAX);
-            result = result * 10 + digit;
+            }
         }
         else
         {
-            if (result < negative_limit_divider)
+            if (result > negative_limit / 10)
+            {
+                ft_errno = FT_ERANGE;
                 return (FT_LONG_MIN);
-            if (result == negative_limit_divider && digit > negative_limit_remainder)
+            }
+            if (result == negative_limit / 10
+                && static_cast<unsigned long long>(digit) > negative_limit % 10)
+            {
+                ft_errno = FT_ERANGE;
                 return (FT_LONG_MIN);
-            result = result * 10 - digit;
+            }
         }
+        result = result * 10 + static_cast<unsigned long long>(digit);
         index++;
     }
-    return (result);
+    if (digit_found == false)
+    {
+        ft_errno = FT_EINVAL;
+        return (0);
+    }
+    if (string[index] != '\0')
+        ft_errno = FT_EINVAL;
+    if (sign == -1)
+    {
+        if (result == negative_limit)
+            return (FT_LONG_MIN);
+        long signed_result = -static_cast<long>(result);
+
+        return (signed_result);
+    }
+    return (static_cast<long>(result));
 }

--- a/Networking/networking_ssl_wrapper.cpp
+++ b/Networking/networking_ssl_wrapper.cpp
@@ -15,21 +15,24 @@ static ssize_t ssl_write_platform(SSL *ssl, const void *buf, size_t len)
     return (ret);
 }
 
-ssize_t nw_ssl_write(SSL *ssl, const void *buf, size_t len)
+extern "C"
 {
-    return (ssl_write_platform(ssl, buf, len));
-}
+    ssize_t nw_ssl_write(SSL *ssl, const void *buf, size_t len)
+    {
+        return (ssl_write_platform(ssl, buf, len));
+    }
 
-ssize_t nw_ssl_read(SSL *ssl, void *buf, size_t len)
-{
-    int read_length;
-    int ret;
+    ssize_t nw_ssl_read(SSL *ssl, void *buf, size_t len)
+    {
+        int read_length;
+        int ret;
 
-    if (len > static_cast<size_t>(INT_MAX))
-        return (-1);
-    read_length = static_cast<int>(len);
-    ret = SSL_read(ssl, buf, read_length);
-    if (ret <= 0)
-        return (-1);
-    return (ret);
+        if (len > static_cast<size_t>(INT_MAX))
+            return (-1);
+        read_length = static_cast<int>(len);
+        ret = SSL_read(ssl, buf, read_length);
+        if (ret <= 0)
+            return (-1);
+        return (ret);
+    }
 }

--- a/Networking/ssl_wrapper.hpp
+++ b/Networking/ssl_wrapper.hpp
@@ -10,7 +10,16 @@ typedef SSIZE_T ssize_t;
 # include <sys/types.h>
 #endif
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 ssize_t nw_ssl_write(SSL *ssl, const void *buf, size_t len);
 ssize_t nw_ssl_read(SSL *ssl, void *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/Test/Test/test_api_tls_client.cpp
+++ b/Test/Test/test_api_tls_client.cpp
@@ -1,0 +1,186 @@
+#define private public
+#include "../../API/tls_client.hpp"
+#undef private
+#include "../../System_utils/test_runner.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
+#include <openssl/ssl.h>
+#include <climits>
+
+static bool g_mock_tls_io_enabled = false;
+
+static const char *g_mock_read_buffers[8];
+static size_t g_mock_read_sizes[8];
+static size_t g_mock_read_count = 0;
+static size_t g_mock_read_index = 0;
+static size_t g_mock_read_offset = 0;
+
+static void mock_tls_reset_reads()
+{
+    g_mock_read_count = 0;
+    g_mock_read_index = 0;
+    g_mock_read_offset = 0;
+}
+
+static void mock_tls_add_read(const char *data)
+{
+    size_t length;
+
+    if (g_mock_read_count >= 8)
+        return ;
+    length = ft_strlen(data);
+    g_mock_read_buffers[g_mock_read_count] = data;
+    g_mock_read_sizes[g_mock_read_count] = length;
+    g_mock_read_count += 1;
+}
+
+extern "C"
+{
+    ssize_t nw_ssl_write(SSL *ssl, const void *buf, size_t len)
+    {
+        int write_length;
+        int write_result;
+        size_t copy_index;
+        const char *source;
+
+        if (len > static_cast<size_t>(INT_MAX))
+            return (-1);
+        if (!g_mock_tls_io_enabled)
+        {
+            write_length = static_cast<int>(len);
+            write_result = ::SSL_write(ssl, buf, write_length);
+            if (write_result <= 0)
+                return (-1);
+            return (write_result);
+        }
+        source = static_cast<const char *>(buf);
+        copy_index = 0;
+        while (copy_index < len)
+        {
+            (void)source[copy_index];
+            copy_index += 1;
+        }
+        return (static_cast<ssize_t>(len));
+    }
+
+    ssize_t nw_ssl_read(SSL *ssl, void *buf, size_t len)
+    {
+        int read_length;
+        int read_result;
+        char *destination;
+        size_t remaining;
+        size_t copy_length;
+        size_t copy_index;
+        const char *source;
+
+        if (len > static_cast<size_t>(INT_MAX))
+            return (-1);
+        if (!g_mock_tls_io_enabled)
+        {
+            read_length = static_cast<int>(len);
+            read_result = ::SSL_read(ssl, buf, read_length);
+            if (read_result <= 0)
+                return (-1);
+            return (read_result);
+        }
+        (void)ssl;
+        while (g_mock_read_index < g_mock_read_count)
+        {
+            remaining = g_mock_read_sizes[g_mock_read_index] - g_mock_read_offset;
+            if (remaining != 0)
+                break;
+            g_mock_read_index += 1;
+            g_mock_read_offset = 0;
+        }
+        if (g_mock_read_index >= g_mock_read_count)
+            return (0);
+        remaining = g_mock_read_sizes[g_mock_read_index] - g_mock_read_offset;
+        copy_length = len;
+        if (copy_length > remaining)
+            copy_length = remaining;
+        destination = static_cast<char *>(buf);
+        source = g_mock_read_buffers[g_mock_read_index];
+        copy_index = 0;
+        while (copy_index < copy_length)
+        {
+            destination[copy_index] = source[g_mock_read_offset + copy_index];
+            copy_index += 1;
+        }
+        g_mock_read_offset += copy_length;
+        if (g_mock_read_offset >= g_mock_read_sizes[g_mock_read_index])
+        {
+            g_mock_read_index += 1;
+            g_mock_read_offset = 0;
+        }
+        return (static_cast<ssize_t>(copy_length));
+    }
+}
+
+static void prepare_mock_client(api_tls_client &client)
+{
+    client._ssl = reinterpret_cast<SSL *>(0x1);
+    client._sock = -1;
+    client._error_code = ER_SUCCESS;
+    ft_errno = ER_SUCCESS;
+    client._host = "mock.local";
+}
+
+FT_TEST(test_api_tls_client_chunked_response, "api_tls_client handles chunked bodies")
+{
+    api_tls_client client(ft_nullptr, 0, 0);
+
+    prepare_mock_client(client);
+    mock_tls_reset_reads();
+    mock_tls_add_read("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n");
+    g_mock_tls_io_enabled = true;
+    int status_value;
+    char *body;
+    int result;
+
+    status_value = -1;
+    body = client.request("GET", "/chunked", ft_nullptr, ft_nullptr, &status_value);
+    g_mock_tls_io_enabled = false;
+    if (!body)
+        return (0);
+    result = 1;
+    if (ft_strcmp(body, "Wikipedia") != 0)
+        result = 0;
+    if (status_value != 200)
+        result = 0;
+    if (client.get_error() != ER_SUCCESS)
+        result = 0;
+    cma_free(body);
+    client._ssl = ft_nullptr;
+    return (result);
+}
+
+FT_TEST(test_api_tls_client_connection_close_response, "api_tls_client reads connection close bodies")
+{
+    api_tls_client client(ft_nullptr, 0, 0);
+
+    prepare_mock_client(client);
+    mock_tls_reset_reads();
+    mock_tls_add_read("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n");
+    g_mock_tls_io_enabled = true;
+    int status_value;
+    char *body;
+    int result;
+
+    status_value = -1;
+    body = client.request("GET", "/close", ft_nullptr, ft_nullptr, &status_value);
+    g_mock_tls_io_enabled = false;
+    result = 1;
+    if (!body)
+        result = 0;
+    if (body && body[0] != '\0')
+        result = 0;
+    if (status_value != 204)
+        result = 0;
+    if (client.get_error() != ER_SUCCESS)
+        result = 0;
+    if (body)
+        cma_free(body);
+    client._ssl = ft_nullptr;
+    return (result);
+}

--- a/Test/Test/test_atoi.cpp
+++ b/Test/Test/test_atoi.cpp
@@ -2,16 +2,21 @@
 #include "../../System_utils/test_runner.hpp"
 #include "../../Libft/limits.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 
 FT_TEST(test_atoi_simple, "ft_atoi simple")
 {
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(42, ft_atoi("42"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_atoi_negative, "ft_atoi negative")
 {
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(-13, ft_atoi("-13"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -20,7 +25,9 @@ FT_TEST(test_atoi_intmax, "ft_atoi INT_MAX")
     ft_string integer_string;
 
     integer_string = ft_to_string(FT_INT_MAX);
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(FT_INT_MAX, ft_atoi(integer_string.c_str()));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -29,55 +36,88 @@ FT_TEST(test_atoi_intmin, "ft_atoi INT_MIN")
     ft_string integer_string;
 
     integer_string = ft_to_string(FT_INT_MIN);
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(FT_INT_MIN, ft_atoi(integer_string.c_str()));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
-FT_TEST(test_atoi_overflow_clamps_to_int_max, "ft_atoi clamps overflow to INT_MAX")
+FT_TEST(test_atoi_overflow_sets_erange, "ft_atoi clamps overflow to INT_MAX")
 {
     ft_string overflow_string;
 
     overflow_string = ft_to_string(FT_INT_MAX);
     overflow_string += "9";
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(FT_INT_MAX, ft_atoi(overflow_string.c_str()));
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
     return (1);
 }
 
-FT_TEST(test_atoi_underflow_clamps_to_int_min, "ft_atoi clamps underflow to INT_MIN")
+FT_TEST(test_atoi_underflow_sets_erange, "ft_atoi clamps underflow to INT_MIN")
 {
     ft_string underflow_string;
 
     underflow_string = ft_to_string(FT_INT_MIN);
     underflow_string += "9";
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(FT_INT_MIN, ft_atoi(underflow_string.c_str()));
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
     return (1);
 }
-FT_TEST(test_atoi_whitespace, "ft_atoi leading and trailing whitespace")
+
+FT_TEST(test_atoi_trailing_whitespace_sets_einval, "ft_atoi trailing whitespace sets FT_EINVAL")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(42, ft_atoi("  \t\n42  "));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
-FT_TEST(test_atoi_trailing_chars, "ft_atoi stops at non-digit")
+FT_TEST(test_atoi_trailing_chars_sets_einval, "ft_atoi stops at non-digit")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(123, ft_atoi("123abc"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
-FT_TEST(test_atoi_plus_sign, "ft_atoi plus sign")
+FT_TEST(test_atoi_plus_sign_success, "ft_atoi plus sign")
 {
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(7, ft_atoi("+7"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
-FT_TEST(test_atoi_zero, "ft_atoi zero")
+FT_TEST(test_atoi_zero_success, "ft_atoi zero")
 {
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(0, ft_atoi("0"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
-FT_TEST(test_atoi_null_input, "ft_atoi null input returns zero")
+FT_TEST(test_atoi_null_input_sets_einval, "ft_atoi null input returns zero")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_atoi(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_atoi_no_digits_sets_einval, "ft_atoi no digits sets FT_EINVAL")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, ft_atoi("abc"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_atoi_digits_only_clears_errno, "ft_atoi digits clear ft_errno")
+{
+    ft_errno = FT_ERANGE;
+    FT_ASSERT_EQ(314, ft_atoi("314"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_atol.cpp
+++ b/Test/Test/test_atol.cpp
@@ -2,29 +2,82 @@
 #include "../../System_utils/test_runner.hpp"
 #include "../../Libft/limits.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 
-FT_TEST(test_atol_overflow_clamps_to_long_max, "ft_atol clamps overflow to FT_LONG_MAX")
+FT_TEST(test_atol_simple_success, "ft_atol simple parses value")
+{
+    ft_errno = FT_ERANGE;
+    FT_ASSERT_EQ(1234L, ft_atol("1234"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_atol_overflow_sets_erange, "ft_atol clamps overflow to FT_LONG_MAX")
 {
     ft_string overflow_string;
 
     overflow_string = ft_to_string(FT_LONG_MAX);
     overflow_string += "9";
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(FT_LONG_MAX, ft_atol(overflow_string.c_str()));
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
     return (1);
 }
 
-FT_TEST(test_atol_underflow_clamps_to_long_min, "ft_atol clamps underflow to FT_LONG_MIN")
+FT_TEST(test_atol_underflow_sets_erange, "ft_atol clamps underflow to FT_LONG_MIN")
 {
     ft_string underflow_string;
 
     underflow_string = ft_to_string(FT_LONG_MIN);
     underflow_string += "9";
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(FT_LONG_MIN, ft_atol(underflow_string.c_str()));
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
     return (1);
 }
 
-FT_TEST(test_atol_null_input, "ft_atol null input returns zero")
+FT_TEST(test_atol_null_input_sets_einval, "ft_atol null input returns zero")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0L, ft_atol(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_atol_trailing_chars_sets_einval, "ft_atol stops at non-digit")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(98765L, ft_atol("98765abc"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_atol_no_digits_sets_einval, "ft_atol rejects non-numeric input")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0L, ft_atol("abc"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_atol_long_min_exact_success, "ft_atol FT_LONG_MIN exact")
+{
+    ft_string integer_string;
+
+    integer_string = ft_to_string(FT_LONG_MIN);
+    ft_errno = FT_ERANGE;
+    FT_ASSERT_EQ(FT_LONG_MIN, ft_atol(integer_string.c_str()));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_atol_long_max_exact_success, "ft_atol FT_LONG_MAX exact")
+{
+    ft_string integer_string;
+
+    integer_string = ft_to_string(FT_LONG_MAX);
+    ft_errno = FT_ERANGE;
+    FT_ASSERT_EQ(FT_LONG_MAX, ft_atol(integer_string.c_str()));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }


### PR DESCRIPTION
## Summary
- expose nw_ssl_read/nw_ssl_write with C linkage so the TLS test harness stubs override the production wrappers
- adjust chunked-response parsing to stop before the blank trailer line and only read more bytes when needed, preventing the mock socket from being drained
- update the TLS harness stubs so non-mocked calls reproduce the production guards instead of bypassing oversize-length checks

## Testing
- make -C Test OPT_LEVEL=0
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d4efa6c8188331a970bc8ddf010c86