### PR TITLE
Propagate zlib helper errors

### DIFF
--- a/Compression/compression_base64.cpp
+++ b/Compression/compression_base64.cpp
@@ -18,6 +18,23 @@ static int base64_char_value(unsigned char character)
     return (-1);
 }
 
+static int  is_base64_whitespace(unsigned char character)
+{
+    if (character == ' ')
+        return (1);
+    if (character == '\n')
+        return (1);
+    if (character == '\r')
+        return (1);
+    if (character == '\t')
+        return (1);
+    if (character == '\f')
+        return (1);
+    if (character == '\v')
+        return (1);
+    return (0);
+}
+
 unsigned char    *ft_base64_encode(const unsigned char *input_buffer, std::size_t input_size, std::size_t *encoded_size)
 {
     const char      *base64_table;
@@ -35,7 +52,7 @@ unsigned char    *ft_base64_encode(const unsigned char *input_buffer, std::size_
         return (ft_nullptr);
     base64_table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     output_length = ((input_size + 2) / 3) * 4;
-    output_buffer = static_cast<unsigned char *>(cma_malloc(output_length));
+    output_buffer = static_cast<unsigned char *>(cma_malloc(output_length + 1));
     if (!output_buffer)
         return (ft_nullptr);
     input_index = 0;
@@ -85,6 +102,7 @@ unsigned char    *ft_base64_encode(const unsigned char *input_buffer, std::size_
             output_index++;
         }
     }
+    output_buffer[output_index] = '\0';
     *encoded_size = output_index;
     return (output_buffer);
 }
@@ -93,7 +111,9 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
 {
     unsigned char   *output_buffer;
     std::size_t     output_length;
+    std::size_t     sanitized_length;
     std::size_t     input_index;
+    std::size_t     sanitized_index;
     std::size_t     output_index;
     int             value_one;
     int             value_two;
@@ -101,77 +121,134 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
     int             value_four;
     unsigned char   char_three;
     unsigned char   char_four;
+    unsigned char   current_character;
+    unsigned char   chunk[4];
+    int             chunk_count;
+    int             has_char_three;
+    int             has_char_four;
 
     if (!input_buffer || !decoded_size)
         return (ft_nullptr);
-    if (input_size % 4 != 0)
-        return (ft_nullptr);
-    output_length = (input_size / 4) * 3;
-    if (input_buffer[input_size - 1] == '=')
+    *decoded_size = 0;
+    sanitized_length = 0;
+    input_index = 0;
+    while (input_index < input_size)
     {
-        output_length--;
-        if (input_buffer[input_size - 2] == '=')
-            output_length--;
+        if (!is_base64_whitespace(input_buffer[input_index]))
+            sanitized_length++;
+        input_index++;
     }
+    if (sanitized_length == 0)
+    {
+        output_buffer = static_cast<unsigned char *>(cma_malloc(1));
+        if (!output_buffer)
+            return (ft_nullptr);
+        return (output_buffer);
+    }
+    if (sanitized_length % 4 == 1)
+        return (ft_nullptr);
+    output_length = ((sanitized_length + 3) / 4) * 3;
     output_buffer = static_cast<unsigned char *>(cma_malloc(output_length));
     if (!output_buffer)
         return (ft_nullptr);
     input_index = 0;
+    sanitized_index = 0;
     output_index = 0;
-    while (input_index < input_size)
+    while (sanitized_index < sanitized_length)
     {
-        value_one = base64_char_value(input_buffer[input_index]);
+        chunk_count = 0;
+        while (chunk_count < 4 && input_index < input_size)
+        {
+            current_character = input_buffer[input_index];
+            input_index++;
+            if (is_base64_whitespace(current_character))
+                continue;
+            chunk[chunk_count] = current_character;
+            chunk_count++;
+        }
+        if (chunk_count == 0)
+            break ;
+        sanitized_index += chunk_count;
+        if (chunk_count < 2)
+        {
+            cma_free(output_buffer);
+            return (ft_nullptr);
+        }
+        value_one = base64_char_value(chunk[0]);
         if (value_one == -1)
         {
             cma_free(output_buffer);
-            *decoded_size = 0;
             return (ft_nullptr);
         }
-        input_index++;
-        value_two = base64_char_value(input_buffer[input_index]);
+        value_two = base64_char_value(chunk[1]);
         if (value_two == -1)
         {
             cma_free(output_buffer);
-            *decoded_size = 0;
             return (ft_nullptr);
         }
-        input_index++;
-        char_three = input_buffer[input_index];
-        if (char_three != '=')
+        has_char_three = 0;
+        value_three = 0;
+        if (chunk_count > 2)
+        {
+            char_three = chunk[2];
+            has_char_three = 1;
+        }
+        else
+        {
+            char_three = '=';
+        }
+        has_char_four = 0;
+        value_four = 0;
+        if (chunk_count > 3)
+        {
+            char_four = chunk[3];
+            has_char_four = 1;
+        }
+        else
+        {
+            char_four = '=';
+        }
+        if (has_char_three && char_three != '=')
         {
             value_three = base64_char_value(char_three);
             if (value_three == -1)
             {
                 cma_free(output_buffer);
-                *decoded_size = 0;
                 return (ft_nullptr);
             }
         }
         else
             value_three = 0;
-        input_index++;
-        char_four = input_buffer[input_index];
-        if (char_four != '=')
+        if (has_char_four && char_four != '=')
         {
             value_four = base64_char_value(char_four);
             if (value_four == -1)
             {
                 cma_free(output_buffer);
-                *decoded_size = 0;
                 return (ft_nullptr);
             }
         }
-        else
-            value_four = 0;
-        input_index++;
+        if (has_char_three && char_three == '=' && has_char_four && char_four != '=')
+        {
+            cma_free(output_buffer);
+            return (ft_nullptr);
+        }
+        if ((has_char_three && char_three == '=') || (has_char_four && char_four == '='))
+        {
+            if (sanitized_index < sanitized_length)
+            {
+                cma_free(output_buffer);
+                return (ft_nullptr);
+            }
+        }
         output_buffer[output_index] = static_cast<unsigned char>((value_one << 2) | (value_two >> 4));
         output_index++;
-        if (char_three != '=')
+        if (has_char_three && char_three != '=')
         {
             output_buffer[output_index] = static_cast<unsigned char>(((value_two & 0x0F) << 4) | (value_three >> 2));
             output_index++;
         }
-        if (char_four != '=')
+        if (has_char_four && char_four != '=')
         {
             output_buffer[output_index] = static_cast<unsigned char>(((value_three & 0x03) << 6) | value_four);
             output_index++;

--- a/TODO.md
+++ b/TODO.md
@@ -10,9 +10,9 @@
     - Time formatting and parsing
 
 - Compression Module
-    - ft_compress and ft_decompress
-    - Stream compression
-    - Base64 encode and decode
+    - Expand automated tests for block and streaming helpers
+    - Document compression usage patterns and error reporting
+    - Evaluate adding alternative algorithms (e.g., LZ4, Brotli)
 
 - Image / Media Module
     - Load and save PNG or BMP

--- a/Test/Test/test_compression.cpp
+++ b/Test/Test/test_compression.cpp
@@ -235,6 +235,102 @@ FT_TEST(test_base64_round_trip, "base64 round trip")
     return (0);
 }
 
+FT_TEST(test_base64_encode_null_terminator, "base64 encode appends null terminator")
+{
+    const char      *input_string;
+    const char      *expected_encoding;
+    unsigned char   *encoded_buffer;
+    std::size_t     input_length;
+    std::size_t     encoded_length;
+    std::size_t     expected_length;
+
+    input_string = "hi";
+    expected_encoding = "aGk=";
+    input_length = 2;
+    encoded_length = 0;
+    encoded_buffer = ft_base64_encode(reinterpret_cast<const unsigned char *>(input_string), input_length, &encoded_length);
+    if (!encoded_buffer)
+        return (0);
+    expected_length = ft_strlen_size_t(expected_encoding);
+    if (encoded_length != expected_length)
+    {
+        cma_free(encoded_buffer);
+        return (0);
+    }
+    if (ft_strncmp(reinterpret_cast<const char *>(encoded_buffer), expected_encoding, expected_length) != 0)
+    {
+        cma_free(encoded_buffer);
+        return (0);
+    }
+    if (encoded_buffer[encoded_length] != '\0')
+    {
+        cma_free(encoded_buffer);
+        return (0);
+    }
+    cma_free(encoded_buffer);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_ignores_whitespace, "base64 decode ignores whitespace")
+{
+    const char      *input_string;
+    const char      *expected_output;
+    unsigned char   *decoded_buffer;
+    std::size_t     decoded_length;
+    std::size_t     expected_length;
+
+    input_string = "SGVs bG8s\nIHdvcmxkIQ==\r\n";
+    expected_output = "Hello, world!";
+    decoded_length = 0;
+    decoded_buffer = ft_base64_decode(reinterpret_cast<const unsigned char *>(input_string),
+        ft_strlen_size_t(input_string), &decoded_length);
+    if (!decoded_buffer)
+        return (0);
+    expected_length = ft_strlen_size_t(expected_output);
+    if (decoded_length != expected_length)
+    {
+        cma_free(decoded_buffer);
+        return (0);
+    }
+    if (ft_memcmp(decoded_buffer, expected_output, expected_length) != 0)
+    {
+        cma_free(decoded_buffer);
+        return (0);
+    }
+    cma_free(decoded_buffer);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_paddingless_tail, "base64 decode paddingless tail")
+{
+    const char      *input_string;
+    const char      *expected_output;
+    unsigned char   *decoded_buffer;
+    std::size_t     decoded_length;
+    std::size_t     expected_length;
+
+    input_string = "YW55IGNhcm5hbCBwbGVhc3Vy";
+    expected_output = "any carnal pleasur";
+    decoded_length = 0;
+    decoded_buffer = ft_base64_decode(reinterpret_cast<const unsigned char *>(input_string),
+        ft_strlen_size_t(input_string), &decoded_length);
+    if (!decoded_buffer)
+        return (0);
+    expected_length = ft_strlen_size_t(expected_output);
+    if (decoded_length != expected_length)
+    {
+        cma_free(decoded_buffer);
+        return (0);
+    }
+    if (ft_memcmp(decoded_buffer, expected_output, expected_length) != 0)
+    {
+        cma_free(decoded_buffer);
+        return (0);
+    }
+    cma_free(decoded_buffer);
+    return (1);
+}
+
 FT_TEST(test_base64_invalid_character, "base64 invalid character")
 {
     const char      *invalid_input;


### PR DESCRIPTION
## Summary
- initialize output sizes to zero before validating inputs in the zlib helpers
- set ft_errno for invalid arguments, allocation failures, and zlib status errors so callers get diagnostics
- allow Base64 decoding to skip whitespace and accept a padding-free tail while keeping strict error handling
- null-terminate Base64 encodings so callers can treat them as C strings
- refresh the Compression section of TODO.md so it reflects the helpers that already exist
- extend the compression tests to cover Base64 whitespace tolerance, padding-free tails, and encoded null terminators

## Testing
- make -C Compression
- make -C Test
- ./Test/libft_tests


------
https://chatgpt.com/codex/tasks/task_e_68d5566237d08331ba445d91975e131c