### PR TITLE
Remove improvements placeholder document

### DIFF
--- a/Libft/libft_memset.cpp
+++ b/Libft/libft_memset.cpp
@@ -1,19 +1,29 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include <cstdint>
 
 void *ft_memset(void *destination, int value, size_t number_of_bytes)
 {
     if (destination == ft_nullptr)
+    {
+        if (number_of_bytes == 0)
+        {
+            ft_errno = ER_SUCCESS;
+            return (ft_nullptr);
+        }
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
-
+    }
+    ft_errno = ER_SUCCESS;
     unsigned char *dest = static_cast<unsigned char *>(destination);
-    unsigned char byte  = static_cast<unsigned char>(value);
+    unsigned char byte = static_cast<unsigned char>(value);
 
     while (number_of_bytes && (reinterpret_cast<uintptr_t>(dest) & (sizeof(size_t) - 1)))
     {
-        *dest++ = byte;
-        --number_of_bytes;
+        *dest = byte;
+        dest++;
+        number_of_bytes--;
     }
 
     size_t pattern = byte;
@@ -25,15 +35,17 @@ void *ft_memset(void *destination, int value, size_t number_of_bytes)
     size_t *dest_word = reinterpret_cast<size_t *>(dest);
     while (number_of_bytes >= sizeof(size_t))
     {
-        *dest_word++ = pattern;
+        *dest_word = pattern;
+        dest_word++;
         number_of_bytes -= sizeof(size_t);
     }
 
     dest = reinterpret_cast<unsigned char *>(dest_word);
     while (number_of_bytes)
     {
-        *dest++ = byte;
-        --number_of_bytes;
+        *dest = byte;
+        dest++;
+        number_of_bytes--;
     }
 
     return (destination);

--- a/Test/Test/test_memset.cpp
+++ b/Test/Test/test_memset.cpp
@@ -1,10 +1,13 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_memset_null, "ft_memset nullptr")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_memset(ft_nullptr, 'A', 3));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
@@ -42,8 +45,10 @@ FT_TEST(test_memset_zero_length, "ft_memset zero length")
     buffer[1] = 'b';
     buffer[2] = 'c';
     buffer[3] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(buffer, ft_memset(buffer, 'x', 0));
     FT_ASSERT_EQ(0, ft_strcmp(buffer, "abc"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 


### PR DESCRIPTION
## Summary
- ensure `ft_memset` reports null-pointer misuse via `ft_errno` while leaving zero-length calls successful
- extend the unit tests to cover the updated error handling and zero-length behavior
- remove the outdated `IMPROVEMENTS.md` document per review feedback

## Testing
- make -C Libft/Test OPT_LEVEL=0
- ./Libft/Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d6290f9e8083318253ee66098e8cb7