### PR TITLE
Ensure ft_time_ms reports success and errors

### DIFF
--- a/Libft/libft_time.cpp
+++ b/Libft/libft_time.cpp
@@ -10,18 +10,16 @@ int64_t ft_time_ms(void)
     struct timeval time_value;
     int64_t milliseconds;
 
+    ft_errno = ER_SUCCESS;
     if (cmp_time_get_time_of_day(&time_value) != 0)
     {
         int system_error;
 
         system_error = errno;
-        if (ft_errno == ER_SUCCESS)
-        {
-            if (system_error != 0)
-                ft_errno = system_error + ERRNO_OFFSET;
-            else
-                ft_errno = FT_ETERM;
-        }
+        if (system_error != 0)
+            ft_errno = system_error + ERRNO_OFFSET;
+        else
+            ft_errno = FT_ETERM;
         return (-1);
     }
     milliseconds = static_cast<int64_t>(time_value.tv_sec) * 1000;


### PR DESCRIPTION
## Summary
- initialize ft_errno to ER_SUCCESS before requesting the current time
- always set ft_errno to an error code when gettimeofday fails while leaving success unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b733e8a4833189c80a5da2ef0f2b