### PR TITLE
Handle ft_errno in ft_strmapi

### DIFF
--- a/Libft/libft_strmapi.cpp
+++ b/Libft/libft_strmapi.cpp
@@ -1,15 +1,25 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include "../CMA/CMA.hpp"
 
 char *ft_strmapi(const char *string, char (*function)(unsigned int, char))
 {
+    ft_errno = ER_SUCCESS;
     if (string == ft_nullptr || function == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     size_t length = ft_strlen_size_t(string);
+    if (ft_errno != ER_SUCCESS)
+        return (ft_nullptr);
     char *result = static_cast<char*>(cma_malloc(length + 1));
     if (result == ft_nullptr)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     unsigned int index = 0;
     while (index < length)
     {


### PR DESCRIPTION
## Summary
- initialize ft_errno in ft_strmapi and set validation errors before returning
- stop processing on ft_strlen_size_t failures and flag allocation failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b8edcac883319b25a3bf5dac7824