### PR TITLE
Validate numeric base inputs in ft_strtol/ft_strtoul

### DIFF
--- a/Libft/libft_strtol.cpp
+++ b/Libft/libft_strtol.cpp
@@ -32,6 +32,13 @@ long ft_strtol(const char *input_string, char **end_pointer, int numeric_base)
             *end_pointer = ft_nullptr;
         return (0L);
     }
+    if (numeric_base != 0 && (numeric_base < 2 || numeric_base > 36))
+    {
+        ft_errno = FT_EINVAL;
+        if (end_pointer != ft_nullptr)
+            *end_pointer = const_cast<char *>(input_string);
+        return (0L);
+    }
     ft_errno = ER_SUCCESS;
     while (*current_character == ' ' || (*current_character >= '\t'
                 && *current_character <= '\r'))

--- a/Libft/libft_strtoul.cpp
+++ b/Libft/libft_strtoul.cpp
@@ -31,6 +31,13 @@ unsigned long ft_strtoul(const char *input_string, char **end_pointer, int numer
             *end_pointer = ft_nullptr;
         return (0UL);
     }
+    if (numeric_base != 0 && (numeric_base < 2 || numeric_base > 36))
+    {
+        ft_errno = FT_EINVAL;
+        if (end_pointer != ft_nullptr)
+            *end_pointer = const_cast<char *>(input_string);
+        return (0UL);
+    }
     ft_errno = ER_SUCCESS;
     while (*current_character == ' ' || (*current_character >= '\t'
                 && *current_character <= '\r'))

--- a/Test/Test/test_strtol.cpp
+++ b/Test/Test/test_strtol.cpp
@@ -50,6 +50,25 @@ FT_TEST(test_strtol_invalid, "ft_strtol invalid string")
     return (1);
 }
 
+FT_TEST(test_strtol_invalid_base, "ft_strtol invalid base returns error and input pointer")
+{
+    const char *input_string = "123";
+    char *end_pointer;
+
+    end_pointer = reinterpret_cast<char *>(0x1);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, ft_strtol(input_string, &end_pointer, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(const_cast<char *>(input_string), end_pointer);
+
+    end_pointer = reinterpret_cast<char *>(0x1);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, ft_strtol(input_string, &end_pointer, 37));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(const_cast<char *>(input_string), end_pointer);
+    return (1);
+}
+
 FT_TEST(test_strtol_maximum_in_range, "ft_strtol handles FT_LONG_MAX without overflow")
 {
     char *end;

--- a/Test/Test/test_strtoul.cpp
+++ b/Test/Test/test_strtoul.cpp
@@ -33,6 +33,25 @@ FT_TEST(test_strtoul_base0, "ft_strtoul base 0 hex prefix")
     return (1);
 }
 
+FT_TEST(test_strtoul_invalid_base, "ft_strtoul invalid base returns error and input pointer")
+{
+    const char *input_string = "456";
+    char *end_pointer;
+
+    end_pointer = reinterpret_cast<char *>(0x1);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0UL, ft_strtoul(input_string, &end_pointer, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(const_cast<char *>(input_string), end_pointer);
+
+    end_pointer = reinterpret_cast<char *>(0x1);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0UL, ft_strtoul(input_string, &end_pointer, 37));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(const_cast<char *>(input_string), end_pointer);
+    return (1);
+}
+
 FT_TEST(test_strtoul_above_long_max, "ft_strtoul parses values above FT_LONG_MAX")
 {
     char value_buffer[64];


### PR DESCRIPTION
## Summary
- validate that numeric bases passed to `ft_strtol` and `ft_strtoul` are zero or within the 2-36 range before conversion
- report `FT_EINVAL`, reset the end pointer, and return zero when an invalid base is supplied
- add unit coverage that exercises invalid-base handling for both functions

## Testing
- make -C Test
- ./Test/libft_tests


------
https://chatgpt.com/codex/tasks/task_e_68d6ba0f816083318e31f5cb6549d27c