### PR TITLE
Align directory existence checks with file_exists semantics

### DIFF
--- a/Compatebility/Compatebility_file_dir.cpp
+++ b/Compatebility/Compatebility_file_dir.cpp
@@ -63,8 +63,8 @@ int cmp_directory_exists(const char *path)
 {
     DWORD attr = GetFileAttributesA(path);
     if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY))
-        return (0);
-    return (1);
+        return (1);
+    return (0);
 }
 
 #else
@@ -180,8 +180,8 @@ int cmp_directory_exists(const char *path)
 {
     struct stat stat_buffer;
     if (stat(path, &stat_buffer) == 0 && S_ISDIR(stat_buffer.st_mode))
-        return (0);
-    return (1);
+        return (1);
+    return (0);
 }
 
 #endif

--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,8 @@ ft_string   file_path_normalize(const char *path);
 
 The `file_copy` and `file_move` helpers return (-1) on failure to allow error handling. `file_copy` uses `CopyFile` on Windows and `std::filesystem::copy_file` on POSIX systems. `file_move` wraps `MoveFile` or `rename` to provide portable file operations. `file_exists` returns (1) if the file exists and (0) otherwise. `file_delete` wraps `remove` or `unlink` to delete a file and returns (-1) on failure.
 
+`file_dir_exists` follows the same convention as `file_exists`, returning (1) when the directory exists and (0) otherwise.
+
 `file_path_join` combines two path fragments using the platform's separator, removing redundant separators. `file_path_normalize` converts mixed separators to the current platform and collapses duplicates:
 
 ```

--- a/Test/Test/test_file_utils.cpp
+++ b/Test/Test/test_file_utils.cpp
@@ -1,9 +1,27 @@
 #include "../../File/file_utils.hpp"
+#include "../../File/open_dir.hpp"
 #include "../../Libft/libft.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include "../../Compatebility/compatebility_internal.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
 #include <cstdio>
+#if defined(_WIN32) || defined(_WIN64)
+# include <windows.h>
+#else
+# include <unistd.h>
+#endif
+
+static void remove_directory_if_present(const char *directory_path)
+{
+    if (cmp_directory_exists(directory_path) != 1)
+        return ;
+#if defined(_WIN32) || defined(_WIN64)
+    RemoveDirectoryA(directory_path);
+#else
+    rmdir(directory_path);
+#endif
+    return ;
+}
 
 static void create_cross_device_test_file(const char *path)
 {
@@ -59,5 +77,18 @@ FT_TEST(test_file_move_cross_device_fallback, "file_move falls back to copy and 
     FT_ASSERT_EQ(0, ft_strcmp(destination_buffer, "cross-device move payload"));
     FT_ASSERT_EQ(FT_SUCCESS, ft_fclose(destination_file));
     FT_ASSERT_EQ(0, file_delete(destination_path));
+    return (1);
+}
+
+FT_TEST(test_file_dir_exists_matches_file_exists_semantics, "file_dir_exists returns 1 when directory exists")
+{
+    const char *directory_path = "test_file_dir_exists_matches_file_exists_semantics";
+
+    remove_directory_if_present(directory_path);
+    FT_ASSERT_EQ(0, file_dir_exists(directory_path));
+    FT_ASSERT_EQ(0, file_create_directory(directory_path, 0777));
+    FT_ASSERT_EQ(1, file_dir_exists(directory_path));
+    remove_directory_if_present(directory_path);
+    FT_ASSERT_EQ(0, file_dir_exists(directory_path));
     return (1);
 }


### PR DESCRIPTION
## Summary
- update cmp_directory_exists to return 1 when a directory exists on both Windows and POSIX
- ensure file_dir_exists documentation and tests follow the same convention as file_exists
- add a regression test covering the new directory existence semantics

## Testing
- not run (local build too heavy for the environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6c2161a5c8331a16159c63eda1fc5