### PR TITLE
Fix Windows directory enumeration search pattern

### DIFF
--- a/Compatebility/Compatebility_file_dir.cpp
+++ b/Compatebility/Compatebility_file_dir.cpp
@@ -15,7 +15,30 @@
 file_dir *cmp_dir_open(const char *directory_path)
 {
     WIN32_FIND_DATAA find_data;
-    HANDLE handle = FindFirstFileA(directory_path, &find_data);
+    if (directory_path == ft_nullptr)
+        return (ft_nullptr);
+    size_t directory_path_length = ft_strlen(directory_path);
+    size_t allocation_size = directory_path_length + 3;
+    char *search_path = reinterpret_cast<char*>(cma_malloc(allocation_size));
+    if (!search_path)
+        return (ft_nullptr);
+    ft_strlcpy(search_path, directory_path, allocation_size);
+    size_t search_path_length = ft_strlen(search_path);
+    if (search_path_length > 0
+        && (search_path[search_path_length - 1] == '\\'
+            || search_path[search_path_length - 1] == '/'))
+    {
+        search_path[search_path_length] = '*';
+        search_path[search_path_length + 1] = '\0';
+    }
+    else
+    {
+        search_path[search_path_length] = '\\';
+        search_path[search_path_length + 1] = '*';
+        search_path[search_path_length + 2] = '\0';
+    }
+    HANDLE handle = FindFirstFileA(search_path, &find_data);
+    cma_free(search_path);
     if (handle == INVALID_HANDLE_VALUE)
         return (ft_nullptr);
     file_dir *directory_stream = reinterpret_cast<file_dir*>(cma_malloc(sizeof(file_dir)));

--- a/Test/Test/test_file_io.cpp
+++ b/Test/Test/test_file_io.cpp
@@ -1,6 +1,7 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
 #include "../../Errno/errno.hpp"
+#include "../../File/open_dir.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include <cerrno>
 #include <cstdio>
@@ -109,5 +110,18 @@ FT_TEST(test_fgets_edge_cases, "ft_fgets edge cases")
     FT_ASSERT_EQ(ft_nullptr, ft_fgets(buffer, 5, ft_nullptr));
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     FT_ASSERT_EQ(FT_SUCCESS, ft_fclose(file));
+    return (1);
+}
+
+FT_TEST(test_file_readdir_returns_entries, "file_readdir yields directory entries")
+{
+    file_dir *directory_stream;
+    file_dirent *directory_entry;
+
+    directory_stream = file_opendir(".");
+    FT_ASSERT(directory_stream != ft_nullptr);
+    directory_entry = file_readdir(directory_stream);
+    FT_ASSERT(directory_entry != ft_nullptr);
+    FT_ASSERT_EQ(0, file_closedir(directory_stream));
     return (1);
 }


### PR DESCRIPTION
## Summary
- append a wildcard search suffix to Windows directory queries using the project allocator
- ensure the temporary search buffer is freed before each exit path
- add regression coverage verifying file_readdir produces directory entries

## Testing
- make test *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68d6c5d0d3f88331aeb8f5b187e52617