### PR TITLE
Handle time_local failure in ft_time_format

### DIFF
--- a/Libft/libft_time.cpp
+++ b/Libft/libft_time.cpp
@@ -38,6 +38,10 @@ char *ft_time_format(char *buffer, size_t buffer_size)
     ft_errno = ER_SUCCESS;
     current_time = time_now();
     time_local(current_time, &time_info);
+    if (ft_errno != ER_SUCCESS)
+    {
+        return (ft_nullptr);
+    }
     formatted_length = time_strftime(buffer, buffer_size, "%Y-%m-%d %H:%M:%S", &time_info);
     if (formatted_length == 0)
     {


### PR DESCRIPTION
## Summary
- check ft_errno immediately after time_local and abort formatting when the call fails
- add test hooks to simulate time_local failures and verify ft_time_format preserves ft_errno

## Testing
- make -C Test objs/Test/test_time.o

------
https://chatgpt.com/codex/tasks/task_e_68d6d1472e24833192ea4807642bd2ce