### PR TITLE
Ensure strchr family manages errno properly

### DIFF
--- a/Libft/libft_strchr.cpp
+++ b/Libft/libft_strchr.cpp
@@ -1,10 +1,15 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 char    *ft_strchr(const char *string, int char_to_find)
 {
+    ft_errno = ER_SUCCESS;
     if (!string)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     char target_char = static_cast<char>(char_to_find);
     while (*string)
     {

--- a/Libft/libft_strrchr.cpp
+++ b/Libft/libft_strrchr.cpp
@@ -1,10 +1,14 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 char    *ft_strrchr(const char *string, int char_to_find)
 {
     if (!string)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     size_t string_length = ft_strlen_size_t(string);
     char target_char = static_cast<char>(char_to_find);
     while (string_length > 0)

--- a/Libft/libft_strstr.cpp
+++ b/Libft/libft_strstr.cpp
@@ -1,12 +1,19 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 char    *ft_strstr(const char *haystack, const char *needle)
 {
     size_t  haystack_length;
 
-    if (!haystack || !needle)
+    ft_errno = ER_SUCCESS;
+    if (haystack == ft_nullptr || needle == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
-    haystack_length = ft_strlen(haystack);
+    }
+    haystack_length = ft_strlen_size_t(haystack);
+    if (ft_errno != ER_SUCCESS)
+        return (ft_nullptr);
     return (ft_strnstr(haystack, needle, haystack_length));
 }

--- a/Test/Test/test_strchr.cpp
+++ b/Test/Test/test_strchr.cpp
@@ -1,11 +1,14 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strchr_basic, "ft_strchr basic")
 {
     const char *string = "hello";
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(string + 1, ft_strchr(string, 'e'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -17,7 +20,9 @@ FT_TEST(test_strchr_not_found, "ft_strchr not found")
 
 FT_TEST(test_strchr_null, "ft_strchr nullptr")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_strchr(ft_nullptr, 'a'));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_strrchr.cpp
+++ b/Test/Test/test_strrchr.cpp
@@ -1,12 +1,15 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strrchr_last, "ft_strrchr last occurrence")
 {
     const char *string = "banana";
 
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(string + 5, ft_strrchr(string, 'a'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -18,7 +21,9 @@ FT_TEST(test_strrchr_not_found, "ft_strrchr not found")
 
 FT_TEST(test_strrchr_null, "ft_strrchr nullptr")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_strrchr(ft_nullptr, 'a'));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_strstr.cpp
+++ b/Test/Test/test_strstr.cpp
@@ -1,5 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strstr_basic, "ft_strstr basic match")
@@ -7,7 +8,9 @@ FT_TEST(test_strstr_basic, "ft_strstr basic match")
     const char *haystack = "hello world";
     const char *needle = "world";
 
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(haystack + 6, ft_strstr(haystack, needle));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -41,7 +44,11 @@ FT_TEST(test_strstr_null, "ft_strstr with nullptr")
 {
     const char *haystack = "abc";
 
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_strstr(ft_nullptr, "a"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_strstr(haystack, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }


### PR DESCRIPTION
## Summary
- reset `ft_errno` on successful `ft_strchr`, guard null arguments in `ft_strchr`/`ft_strrchr`, and validate both parameters in `ft_strstr`
- extend unit tests to confirm successful lookups clear `ft_errno` and null inputs report `FT_EINVAL`

## Testing
- make -C Libft/Test libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d6e7af4b6c83319cef14cb300b62ce