### PR TITLE
Handle invalid input in ft_memchr

### DIFF
--- a/Libft/libft_memchr.cpp
+++ b/Libft/libft_memchr.cpp
@@ -1,12 +1,23 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 void* ft_memchr(const void* pointer, int number, size_t size)
 {
     size_t index;
-    const unsigned char *string = static_cast<const unsigned char*>(pointer);
-    unsigned char character = static_cast<unsigned char>(number);
+    const unsigned char *string;
+    unsigned char character;
 
+    ft_errno = ER_SUCCESS;
+    if (size == 0)
+        return (ft_nullptr);
+    if (pointer == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    string = static_cast<const unsigned char*>(pointer);
+    character = static_cast<unsigned char>(number);
     index = 0;
     while (index < size)
     {


### PR DESCRIPTION
## Summary
- include the errno helper in ft_memchr
- clear ft_errno before running and mirror other helpers by returning early for zero length
- guard against null pointers with size to avoid invalid input access

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6eb83ab2c8331ac67853ea0347625