### PR TITLE
Handle error reporting in ft_memcmp

### DIFF
--- a/Libft/libft_memcmp.cpp
+++ b/Libft/libft_memcmp.cpp
@@ -1,11 +1,21 @@
 #include "libft.hpp"
-#include <unistd.h>
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 int    ft_memcmp(const void *pointer1, const void *pointer2, size_t size)
 {
     const unsigned char    *string1;
     const unsigned char    *string2;
     size_t                index;
+
+    ft_errno = ER_SUCCESS;
+    if (size == 0)
+        return (0);
+    if (pointer1 == ft_nullptr || pointer2 == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (0);
+    }
 
     index = 0;
     string1 = static_cast<const unsigned char *>(pointer1);


### PR DESCRIPTION
## Summary
- include the errno and ft_nullptr helpers in ft_memcmp
- clear ft_errno before work and guard zero-length comparisons
- report FT_EINVAL when a non-zero comparison receives null input pointers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ed76fb5c8331a5507aa200d5bd9f