### PR TITLE
Fix Windows recv error propagation in HTTP server

### DIFF
--- a/Networking/http_server.cpp
+++ b/Networking/http_server.cpp
@@ -128,7 +128,16 @@ int ft_http_server::run_once()
         if (bytes_received < 0)
         {
             FT_CLOSE_SOCKET(client_socket);
+#ifdef _WIN32
+            int last_error;
+            int library_error_code;
+
+            last_error = WSAGetLastError();
+            library_error_code = last_error + ERRNO_OFFSET;
+            this->set_error(library_error_code);
+#else
             this->set_error(errno + ERRNO_OFFSET);
+#endif
             return (1);
         }
         if (bytes_received == 0)

--- a/README.md
+++ b/README.md
@@ -932,6 +932,10 @@ until the headers and any declared body are fully received, and enforces a
 requests, including POST bodies delivered across multiple TCP receives, are
 parsed and echoed back in the response body.
 
+Windows builds translate socket receive failures reported by `run_once` using
+`WSAGetLastError()` into the library error namespace before exposing the value
+through `get_error`, while POSIX platforms continue to rely on `errno`.
+
 ```c++
 #include "Networking/http_server.hpp"
 


### PR DESCRIPTION
## Summary
- ensure ft_http_server propagates WSA receive failures using the library error space
- document the Windows-specific error propagation behavior of ft_http_server::run_once in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d793a822948331bfd3edb6b3baa32b