### PR TITLE
Ensure async logger reports success errno

### DIFF
--- a/Logger/logger_log_async.cpp
+++ b/Logger/logger_log_async.cpp
@@ -96,6 +96,7 @@ void ft_log_enable_async(bool enable)
         if (g_async_running)
         {
             pthread_mutex_unlock(&g_condition_mutex);
+            ft_errno = ER_SUCCESS;
             return ;
         }
         g_async_running = true;
@@ -110,12 +111,15 @@ void ft_log_enable_async(bool enable)
             g_async_running = false;
             pthread_mutex_unlock(&g_condition_mutex);
         }
+        else
+            ft_errno = ER_SUCCESS;
     }
     else
     {
         if (!g_async_running)
         {
             pthread_mutex_unlock(&g_condition_mutex);
+            ft_errno = ER_SUCCESS;
             return ;
         }
         g_async_running = false;
@@ -124,6 +128,7 @@ void ft_log_enable_async(bool enable)
             return ;
         if (pt_thread_join(g_log_thread, ft_nullptr) != 0)
             return ;
+        ft_errno = ER_SUCCESS;
     }
     return ;
 }


### PR DESCRIPTION
## Summary
- set `ft_errno` to `ER_SUCCESS` when async logging enablement/disablement paths succeed
- leave existing error handling untouched so failure codes still propagate
- remove braces from the single-statement `else` path in async logger to match style guidance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7ba8acbec8331bb59cbaffc8c4faf