### PR TITLE
Add errno regression tests for Libft helpers

### DIFF
--- a/Test/Test/test_atoi.cpp
+++ b/Test/Test/test_atoi.cpp
@@ -114,6 +114,14 @@ FT_TEST(test_atoi_no_digits_sets_einval, "ft_atoi no digits sets FT_EINVAL")
     return (1);
 }
 
+FT_TEST(test_atoi_whitespace_only_sets_einval, "ft_atoi whitespace only sets FT_EINVAL")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, ft_atoi(" \t\r\n\v\f"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_atoi_digits_only_clears_errno, "ft_atoi digits clear ft_errno")
 {
     ft_errno = FT_ERANGE;

--- a/Test/Test/test_atol.cpp
+++ b/Test/Test/test_atol.cpp
@@ -81,3 +81,13 @@ FT_TEST(test_atol_long_max_exact_success, "ft_atol FT_LONG_MAX exact")
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
+
+FT_TEST(test_atol_skips_leading_whitespace_and_sign, "ft_atol trims whitespace before sign")
+{
+    const char *input_string = " \t\n +0042";
+
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(42L, ft_atol(input_string));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_bzero.cpp
+++ b/Test/Test/test_bzero.cpp
@@ -1,5 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_bzero_basic, "ft_bzero basic")
@@ -53,6 +54,32 @@ FT_TEST(test_bzero_zero_length, "ft_bzero zero length")
 FT_TEST(test_bzero_null_zero, "ft_bzero nullptr zero")
 {
     ft_bzero(ft_nullptr, 0);
+    return (1);
+}
+
+FT_TEST(test_bzero_null_sets_errno, "ft_bzero null pointer with length sets errno")
+{
+    ft_errno = ER_SUCCESS;
+    ft_bzero(ft_nullptr, 4);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_bzero_recovers_errno_after_error, "ft_bzero clears errno after recovering from error")
+{
+    char buffer[3];
+
+    buffer[0] = 'x';
+    buffer[1] = 'y';
+    buffer[2] = 'z';
+    ft_errno = ER_SUCCESS;
+    ft_bzero(ft_nullptr, 2);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_bzero(buffer, 2);
+    FT_ASSERT_EQ(0, buffer[0]);
+    FT_ASSERT_EQ(0, buffer[1]);
+    FT_ASSERT_EQ('z', buffer[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_environment.cpp
+++ b/Test/Test/test_environment.cpp
@@ -13,6 +13,34 @@ FT_TEST(test_ft_unsetenv_rejects_empty_name, "ft_unsetenv rejects empty names")
     return (1);
 }
 
+FT_TEST(test_ft_getenv_empty_name_sets_errno, "ft_getenv rejects empty names")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_getenv(""));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_getenv_missing_clears_errno, "ft_getenv clears errno when variable absent")
+{
+    const char *variable_name;
+
+    variable_name = "LIBFT_TEST_GETENV_MISSING";
+    ft_unsetenv(variable_name);
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, ft_getenv(variable_name));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_setenv_null_value_sets_errno, "ft_setenv null value sets FT_EINVAL")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, ft_setenv("LIBFT_TEST_NULL_VALUE", ft_nullptr, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_ft_unsetenv_rejects_equals_sign, "ft_unsetenv rejects names containing equals")
 {
     ft_errno = ER_SUCCESS;

--- a/Test/Test/test_isalnum.cpp
+++ b/Test/Test/test_isalnum.cpp
@@ -9,3 +9,10 @@ FT_TEST(test_isalnum, "ft_isalnum")
     FT_ASSERT_EQ(0, ft_isalnum(-1));
     return (1);
 }
+
+FT_TEST(test_isalnum_extended_ascii, "ft_isalnum rejects extended ASCII")
+{
+    FT_ASSERT_EQ(0, ft_isalnum(0xC0));
+    FT_ASSERT_EQ(0, ft_isalnum(0xFF));
+    return (1);
+}

--- a/Test/Test/test_isalpha.cpp
+++ b/Test/Test/test_isalpha.cpp
@@ -10,3 +10,10 @@ FT_TEST(test_isalpha, "ft_isalpha")
     FT_ASSERT_EQ(0, ft_isalpha(-1));
     return (1);
 }
+
+FT_TEST(test_isalpha_high_bit, "ft_isalpha rejects high-bit characters")
+{
+    FT_ASSERT_EQ(0, ft_isalpha(0xC0));
+    FT_ASSERT_EQ(0, ft_isalpha(0xFF));
+    return (1);
+}

--- a/Test/Test/test_isdigit.cpp
+++ b/Test/Test/test_isdigit.cpp
@@ -16,3 +16,10 @@ FT_TEST(test_isdigit_false, "ft_isdigit false")
     FT_ASSERT_EQ(0, ft_isdigit(-1));
     return (1);
 }
+
+FT_TEST(test_isdigit_extended_ascii, "ft_isdigit rejects extended ASCII")
+{
+    FT_ASSERT_EQ(0, ft_isdigit(0xC8));
+    FT_ASSERT_EQ(0, ft_isdigit(0xFF));
+    return (1);
+}

--- a/Test/Test/test_islower.cpp
+++ b/Test/Test/test_islower.cpp
@@ -10,3 +10,12 @@ FT_TEST(test_islower, "ft_islower")
     FT_ASSERT_EQ(0, ft_islower(-1));
     return (1);
 }
+
+FT_TEST(test_islower_rejects_adjacent_ascii, "ft_islower rejects punctuation and extended ASCII")
+{
+    FT_ASSERT_EQ(0, ft_islower('`'));
+    FT_ASSERT_EQ(0, ft_islower('{'));
+    FT_ASSERT_EQ(0, ft_islower(0xE1));
+    FT_ASSERT_EQ(0, ft_islower(0x5F));
+    return (1);
+}

--- a/Test/Test/test_isprint.cpp
+++ b/Test/Test/test_isprint.cpp
@@ -10,3 +10,10 @@ FT_TEST(test_isprint, "ft_isprint")
     FT_ASSERT_EQ(0, ft_isprint(-1));
     return (1);
 }
+
+FT_TEST(test_isprint_extended_ascii, "ft_isprint rejects bytes above ASCII")
+{
+    FT_ASSERT_EQ(0, ft_isprint(0x80));
+    FT_ASSERT_EQ(0, ft_isprint(0xA0));
+    return (1);
+}

--- a/Test/Test/test_isspace.cpp
+++ b/Test/Test/test_isspace.cpp
@@ -10,3 +10,13 @@ FT_TEST(test_isspace, "ft_isspace")
     FT_ASSERT_EQ(0, ft_isspace(0));
     return (1);
 }
+
+FT_TEST(test_isspace_additional_controls, "ft_isspace handles form feed and vertical tab")
+{
+    FT_ASSERT_EQ(1, ft_isspace('\f'));
+    FT_ASSERT_EQ(1, ft_isspace('\r'));
+    FT_ASSERT_EQ(1, ft_isspace('\v'));
+    FT_ASSERT_EQ(0, ft_isspace('\b'));
+    FT_ASSERT_EQ(0, ft_isspace(0xA0));
+    return (1);
+}

--- a/Test/Test/test_isupper.cpp
+++ b/Test/Test/test_isupper.cpp
@@ -10,3 +10,12 @@ FT_TEST(test_isupper, "ft_isupper")
     FT_ASSERT_EQ(0, ft_isupper(-1));
     return (1);
 }
+
+FT_TEST(test_isupper_rejects_adjacent_ascii, "ft_isupper rejects punctuation and extended ASCII")
+{
+    FT_ASSERT_EQ(0, ft_isupper('@'));
+    FT_ASSERT_EQ(0, ft_isupper('['));
+    FT_ASSERT_EQ(0, ft_isupper(0xC0));
+    FT_ASSERT_EQ(0, ft_isupper(0x7B));
+    return (1);
+}

--- a/Test/Test/test_memchr.cpp
+++ b/Test/Test/test_memchr.cpp
@@ -1,5 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_memchr_found, "ft_memchr finds character")
@@ -45,5 +46,58 @@ FT_TEST(test_memchr_zero_length, "ft_memchr zero length")
 FT_TEST(test_memchr_nullptr_zero, "ft_memchr nullptr zero length")
 {
     FT_ASSERT_EQ(ft_nullptr, ft_memchr(ft_nullptr, 'a', 0));
+    return (1);
+}
+
+FT_TEST(test_memchr_zero_length_clears_errno, "ft_memchr zero length clears errno")
+{
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, ft_memchr(ft_nullptr, 'a', 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_memchr_null_sets_errno, "ft_memchr null pointer sets FT_EINVAL")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_memchr(ft_nullptr, 'a', 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_memchr_limit_stops_search, "ft_memchr respects length limit")
+{
+    char buffer[4];
+
+    buffer[0] = 'a';
+    buffer[1] = 'b';
+    buffer[2] = 'c';
+    buffer[3] = 'd';
+    FT_ASSERT_EQ(ft_nullptr, ft_memchr(buffer, 'c', 2));
+    return (1);
+}
+
+FT_TEST(test_memchr_signed_byte, "ft_memchr matches signed byte values")
+{
+    char buffer[3];
+
+    buffer[0] = 'a';
+    buffer[1] = static_cast<char>(0xF2);
+    buffer[2] = '\0';
+    FT_ASSERT_EQ(buffer + 1, ft_memchr(buffer, 0xF2, 3));
+    return (1);
+}
+
+FT_TEST(test_memchr_miss_clears_errno, "ft_memchr clears errno when byte missing")
+{
+    char buffer[4];
+
+    buffer[0] = 'a';
+    buffer[1] = 'b';
+    buffer[2] = 'c';
+    buffer[3] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, ft_memchr(buffer, 'z', 4));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_memcmp.cpp
+++ b/Test/Test/test_memcmp.cpp
@@ -1,5 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_memcmp_equal, "ft_memcmp equal buffers")
@@ -54,6 +55,14 @@ FT_TEST(test_memcmp_zero_length, "ft_memcmp zero length")
     return (1);
 }
 
+FT_TEST(test_memcmp_zero_length_clears_errno, "ft_memcmp zero length clears errno")
+{
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(0, ft_memcmp(ft_nullptr, ft_nullptr, 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_memcmp_high_bit, "ft_memcmp high-bit comparison")
 {
     char a[1];
@@ -61,5 +70,37 @@ FT_TEST(test_memcmp_high_bit, "ft_memcmp high-bit comparison")
     a[0] = (char)0x80;
     b[0] = 0;
     FT_ASSERT(ft_memcmp(a, b, 1) > 0);
+    return (1);
+}
+
+FT_TEST(test_memcmp_limit_hides_late_difference, "ft_memcmp stops comparing after limit")
+{
+    char first[4];
+    char second[4];
+
+    first[0] = 'a';
+    first[1] = 'b';
+    first[2] = 'c';
+    first[3] = '\0';
+    second[0] = 'a';
+    second[1] = 'b';
+    second[2] = 'x';
+    second[3] = '\0';
+    FT_ASSERT_EQ(0, ft_memcmp(first, second, 2));
+    return (1);
+}
+
+FT_TEST(test_memcmp_null_pointer_sets_errno, "ft_memcmp null pointer sets FT_EINVAL")
+{
+    char buffer[2];
+
+    buffer[0] = 'x';
+    buffer[1] = '\0';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, ft_memcmp(buffer, ft_nullptr, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, ft_memcmp(ft_nullptr, buffer, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }

--- a/Test/Test/test_memcpy.cpp
+++ b/Test/Test/test_memcpy.cpp
@@ -43,6 +43,14 @@ FT_TEST(test_memcpy_zero_length_nullptr, "ft_memcpy zero length with nullptr")
     return (1);
 }
 
+FT_TEST(test_memcpy_zero_length_clears_errno, "ft_memcpy zero length recovers errno")
+{
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, ft_memcpy(ft_nullptr, ft_nullptr, 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_memcpy_null, "ft_memcpy with nullptr")
 {
     char source[1];
@@ -83,5 +91,42 @@ FT_TEST(test_memcpy_overlapping_regions, "ft_memcpy overlapping regions")
     FT_ASSERT_EQ('2', buffer[1]);
     FT_ASSERT_EQ('4', buffer[3]);
     FT_ASSERT_EQ(FT_EOVERLAP, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_memcpy_null_sets_errno, "ft_memcpy null arguments set errno")
+{
+    char source[2];
+
+    source[0] = 'q';
+    source[1] = '\0';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_memcpy(ft_nullptr, source, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_memcpy(source, ft_nullptr, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_memcpy_success_clears_errno, "ft_memcpy success clears ft_errno")
+{
+    char source[5];
+    char destination[5];
+
+    source[0] = 'f';
+    source[1] = 'o';
+    source[2] = 'o';
+    source[3] = '!';
+    source[4] = '\0';
+    destination[0] = 'x';
+    destination[1] = 'x';
+    destination[2] = 'x';
+    destination[3] = 'x';
+    destination[4] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(destination, ft_memcpy(destination, source, 5));
+    FT_ASSERT_EQ(0, ft_strcmp(destination, source));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_memdup.cpp
+++ b/Test/Test/test_memdup.cpp
@@ -1,5 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include "../../CMA/CMA.hpp"
 
@@ -40,5 +41,30 @@ FT_TEST(test_memdup_zero_size, "ft_memdup zero size")
 FT_TEST(test_memdup_null_source, "ft_memdup null source")
 {
     FT_ASSERT_EQ(ft_nullptr, ft_memdup(ft_nullptr, 5));
+    return (1);
+}
+
+FT_TEST(test_memdup_independent_copy, "ft_memdup duplicates without sharing storage")
+{
+    char source[4];
+    unsigned char *duplicate;
+
+    source[0] = 'f';
+    source[1] = 'o';
+    source[2] = 'o';
+    source[3] = '!';
+    ft_errno = FT_EINVAL;
+    duplicate = static_cast<unsigned char *>(ft_memdup(source, sizeof(source)));
+    FT_ASSERT(duplicate != ft_nullptr);
+    duplicate[0] = 'b';
+    duplicate[1] = 'a';
+    duplicate[2] = 'r';
+    duplicate[3] = '?';
+    FT_ASSERT_EQ('f', source[0]);
+    FT_ASSERT_EQ('o', source[1]);
+    FT_ASSERT_EQ('o', source[2]);
+    FT_ASSERT_EQ('!', source[3]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(duplicate);
     return (1);
 }

--- a/Test/Test/test_memmove.cpp
+++ b/Test/Test/test_memmove.cpp
@@ -60,6 +60,14 @@ FT_TEST(test_memmove_zero_length, "ft_memmove zero length")
     return (1);
 }
 
+FT_TEST(test_memmove_null_zero_length_clears_errno, "ft_memmove zero length nullptr clears errno")
+{
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, ft_memmove(ft_nullptr, ft_nullptr, 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_memmove_null, "ft_memmove with nullptr")
 {
     char source[1];
@@ -80,5 +88,33 @@ FT_TEST(test_memmove_same_pointer, "ft_memmove same pointer")
     FT_ASSERT_EQ(buffer, ft_memmove(buffer, buffer, 4));
     FT_ASSERT_EQ('h', buffer[0]);
     FT_ASSERT_EQ('k', buffer[3]);
+    return (1);
+}
+
+FT_TEST(test_memmove_errno_recovers_after_failure, "ft_memmove resets errno after null failure")
+{
+    char source[5];
+    char destination[5];
+
+    source[0] = 'a';
+    source[1] = 'b';
+    source[2] = 'c';
+    source[3] = 'd';
+    source[4] = '\0';
+    destination[0] = 'x';
+    destination[1] = 'x';
+    destination[2] = 'x';
+    destination[3] = 'x';
+    destination[4] = '\0';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_memmove(ft_nullptr, source, 3));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(destination, ft_memmove(destination, source, 4));
+    FT_ASSERT_EQ('a', destination[0]);
+    FT_ASSERT_EQ('b', destination[1]);
+    FT_ASSERT_EQ('c', destination[2]);
+    FT_ASSERT_EQ('d', destination[3]);
+    FT_ASSERT_EQ('\0', destination[4]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_memset.cpp
+++ b/Test/Test/test_memset.cpp
@@ -52,6 +52,14 @@ FT_TEST(test_memset_zero_length, "ft_memset zero length")
     return (1);
 }
 
+FT_TEST(test_memset_null_zero_length_recovers_errno, "ft_memset nullptr zero length clears errno")
+{
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, ft_memset(ft_nullptr, 'a', 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_memset_negative, "ft_memset negative value")
 {
     char buffer[4];

--- a/Test/Test/test_strchr.cpp
+++ b/Test/Test/test_strchr.cpp
@@ -32,3 +32,46 @@ FT_TEST(test_strchr_terminator, "ft_strchr terminator")
     FT_ASSERT_EQ(string + 5, ft_strchr(string, '\0'));
     return (1);
 }
+
+FT_TEST(test_strchr_returns_first_match, "ft_strchr returns first occurrence")
+{
+    const char *string = "mississippi";
+
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(string + 2, ft_strchr(string, 's'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strchr_negative_value, "ft_strchr handles negative search values")
+{
+    char string[4];
+
+    string[0] = 'a';
+    string[1] = static_cast<char>(0xFF);
+    string[2] = 'b';
+    string[3] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(string + 1, ft_strchr(string, -1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strchr_not_found_preserves_errno, "ft_strchr clears errno when character missing")
+{
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, ft_strchr("sample", 'z'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strchr_terminator_clears_errno, "ft_strchr terminator search resets errno")
+{
+    const char *string;
+
+    string = "edge";
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(string + 4, ft_strchr(string, '\0'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_strcmp.cpp
+++ b/Test/Test/test_strcmp.cpp
@@ -52,3 +52,17 @@ FT_TEST(test_strcmp_both_null, "ft_strcmp both nullptr")
     FT_ASSERT_EQ(-1, ft_strcmp(ft_nullptr, ft_nullptr));
     return (1);
 }
+
+FT_TEST(test_strcmp_high_bit_ordering, "ft_strcmp treats bytes as unsigned")
+{
+    char left[2];
+    char right[2];
+
+    left[0] = static_cast<char>(0x90);
+    left[1] = '\0';
+    right[0] = static_cast<char>(0x7F);
+    right[1] = '\0';
+    FT_ASSERT(ft_strcmp(left, right) > 0);
+    FT_ASSERT(ft_strcmp(right, left) < 0);
+    return (1);
+}

--- a/Test/Test/test_striteri.cpp
+++ b/Test/Test/test_striteri.cpp
@@ -9,6 +9,20 @@ static void to_upper_iter(unsigned int index, char *character)
     return ;
 }
 
+static unsigned int g_striteri_index_capture[8];
+static unsigned int g_striteri_call_count = 0;
+
+static void record_index_iter(unsigned int index, char *character)
+{
+    if (g_striteri_call_count < 8)
+    {
+        g_striteri_index_capture[g_striteri_call_count] = index;
+        g_striteri_call_count++;
+    }
+    *character = static_cast<char>(*character + static_cast<char>(index + 1));
+    return ;
+}
+
 FT_TEST(test_striteri_basic, "ft_striteri basic")
 {
     char buffer[4];
@@ -22,5 +36,57 @@ FT_TEST(test_striteri_basic, "ft_striteri basic")
 
     ft_striteri(ft_nullptr, to_upper_iter);
     ft_striteri(buffer, ft_nullptr);
+    return (1);
+}
+
+FT_TEST(test_striteri_respects_terminator, "ft_striteri stops iterating at the null terminator")
+{
+    char buffer[6];
+
+    buffer[0] = 'a';
+    buffer[1] = 'b';
+    buffer[2] = '\0';
+    buffer[3] = 'x';
+    buffer[4] = 'y';
+    buffer[5] = '\0';
+    g_striteri_call_count = 0;
+    g_striteri_index_capture[0] = 99u;
+    g_striteri_index_capture[1] = 99u;
+    g_striteri_index_capture[2] = 99u;
+    g_striteri_index_capture[3] = 99u;
+    ft_striteri(buffer, record_index_iter);
+    FT_ASSERT_EQ('b', buffer[0]);
+    FT_ASSERT_EQ('d', buffer[1]);
+    FT_ASSERT_EQ('\0', buffer[2]);
+    FT_ASSERT_EQ('x', buffer[3]);
+    FT_ASSERT_EQ('y', buffer[4]);
+    FT_ASSERT_EQ('\0', buffer[5]);
+    FT_ASSERT_EQ(2u, g_striteri_call_count);
+    FT_ASSERT_EQ(0u, g_striteri_index_capture[0]);
+    FT_ASSERT_EQ(1u, g_striteri_index_capture[1]);
+    FT_ASSERT_EQ(99u, g_striteri_index_capture[2]);
+    return (1);
+}
+
+FT_TEST(test_striteri_null_callback_no_modification, "ft_striteri ignores null callback and string")
+{
+    char buffer[5];
+    char snapshot[5];
+
+    buffer[0] = 'f';
+    buffer[1] = 'o';
+    buffer[2] = 'o';
+    buffer[3] = '!';
+    buffer[4] = '\0';
+    snapshot[0] = buffer[0];
+    snapshot[1] = buffer[1];
+    snapshot[2] = buffer[2];
+    snapshot[3] = buffer[3];
+    snapshot[4] = buffer[4];
+    g_striteri_call_count = 42u;
+    ft_striteri(buffer, ft_nullptr);
+    FT_ASSERT_EQ(0, ft_strcmp(snapshot, buffer));
+    ft_striteri(ft_nullptr, record_index_iter);
+    FT_ASSERT_EQ(42u, g_striteri_call_count);
     return (1);
 }

--- a/Test/Test/test_strjoin_multiple.cpp
+++ b/Test/Test/test_strjoin_multiple.cpp
@@ -59,3 +59,16 @@ FT_TEST(test_strjoin_multiple_resets_errno_before_joining, "cma_strjoin_multiple
     cma_free(joined_string);
     return (result);
 }
+
+FT_TEST(test_strjoin_multiple_retains_empty_segments, "cma_strjoin_multiple preserves empty strings")
+{
+    char *joined;
+    int result;
+
+    joined = cma_strjoin_multiple(4, "", "alpha", "", "beta");
+    if (joined == ft_nullptr)
+        return (0);
+    result = (ft_strcmp(joined, "alphabeta") == 0);
+    cma_free(joined);
+    return (result);
+}

--- a/Test/Test/test_strlcat.cpp
+++ b/Test/Test/test_strlcat.cpp
@@ -80,3 +80,22 @@ FT_TEST(test_strlcat_errno_resets_on_success, "ft_strlcat resets errno on succes
     return (1);
 }
 
+FT_TEST(test_strlcat_truncated_destination, "ft_strlcat handles unterminated destination within limit")
+{
+    char destination[7];
+
+    destination[0] = 'A';
+    destination[1] = 'B';
+    destination[2] = 'C';
+    destination[3] = 'D';
+    destination[4] = 'Y';
+    destination[5] = 'Z';
+    destination[6] = '\0';
+    FT_ASSERT_EQ(6u, ft_strlcat(destination, "pq", 4));
+    FT_ASSERT_EQ('A', destination[0]);
+    FT_ASSERT_EQ('D', destination[3]);
+    FT_ASSERT_EQ('Y', destination[4]);
+    FT_ASSERT_EQ('Z', destination[5]);
+    return (1);
+}
+

--- a/Test/Test/test_strlcpy.cpp
+++ b/Test/Test/test_strlcpy.cpp
@@ -1,4 +1,6 @@
 #include "../../Libft/libft.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strlcpy_basic, "ft_strlcpy basic")
@@ -32,5 +34,211 @@ FT_TEST(test_strlcpy_zero, "ft_strlcpy zero size")
     FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", 0));
     FT_ASSERT_EQ('a', destination[0]);
     FT_ASSERT_EQ('c', destination[2]);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_one_byte_buffer, "ft_strlcpy buffer size one")
+{
+    char destination[4];
+
+    destination[0] = 'x';
+    destination[1] = 'y';
+    destination[2] = 'z';
+    destination[3] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", 1));
+    FT_ASSERT_EQ('\0', destination[0]);
+    FT_ASSERT_EQ('y', destination[1]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_null_arguments, "ft_strlcpy null arguments set FT_EINVAL")
+{
+    char destination[4];
+
+    destination[0] = 'n';
+    destination[1] = '\0';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0u, ft_strlcpy(ft_nullptr, "abc", 4));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0u, ft_strlcpy(destination, ft_nullptr, 4));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_empty_source, "ft_strlcpy handles empty source")
+{
+    char destination[5];
+
+    destination[0] = 'x';
+    destination[1] = 'y';
+    destination[2] = 'z';
+    destination[3] = 'w';
+    destination[4] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(0u, ft_strlcpy(destination, "", sizeof(destination)));
+    FT_ASSERT_EQ('\0', destination[0]);
+    FT_ASSERT_EQ('y', destination[1]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_preserves_tail, "ft_strlcpy preserves bytes beyond terminator")
+{
+    char destination[8];
+
+    destination[0] = 'a';
+    destination[1] = 'b';
+    destination[2] = 'c';
+    destination[3] = 'd';
+    destination[4] = 'e';
+    destination[5] = 'x';
+    destination[6] = 'y';
+    destination[7] = 'z';
+    FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", sizeof(destination)));
+    FT_ASSERT_EQ(0, ft_strcmp(destination, "hello"));
+    FT_ASSERT_EQ('y', destination[6]);
+    FT_ASSERT_EQ('z', destination[7]);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_resets_errno, "ft_strlcpy resets errno on success")
+{
+    char destination[6];
+
+    destination[0] = '1';
+    destination[1] = '2';
+    destination[2] = '3';
+    destination[3] = '4';
+    destination[4] = '5';
+    destination[5] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", sizeof(destination)));
+    FT_ASSERT_EQ(0, ft_strcmp(destination, "hello"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_self_copy, "ft_strlcpy supports identical buffers")
+{
+    char buffer[6];
+
+    buffer[0] = 'h';
+    buffer[1] = 'e';
+    buffer[2] = 'l';
+    buffer[3] = 'l';
+    buffer[4] = 'o';
+    buffer[5] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(5u, ft_strlcpy(buffer, buffer, sizeof(buffer)));
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "hello"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_two_byte_buffer, "ft_strlcpy truncates with size two")
+{
+    char destination[4];
+
+    destination[0] = 'p';
+    destination[1] = 'q';
+    destination[2] = 'r';
+    destination[3] = '\0';
+    FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", 2));
+    FT_ASSERT_EQ('h', destination[0]);
+    FT_ASSERT_EQ('\0', destination[1]);
+    FT_ASSERT_EQ('r', destination[2]);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_zero_size_resets_errno, "ft_strlcpy zero size resets errno")
+{
+    char destination[3];
+
+    destination[0] = 'm';
+    destination[1] = 'n';
+    destination[2] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", 0));
+    FT_ASSERT_EQ('m', destination[0]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_buffer_matches_source_length, "ft_strlcpy buffer equals source length")
+{
+    char destination[5];
+
+    destination[0] = 'q';
+    destination[1] = 'q';
+    destination[2] = 'q';
+    destination[3] = 'q';
+    destination[4] = '\0';
+    FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", sizeof(destination)));
+    FT_ASSERT_EQ('h', destination[0]);
+    FT_ASSERT_EQ('e', destination[1]);
+    FT_ASSERT_EQ('l', destination[2]);
+    FT_ASSERT_EQ('l', destination[3]);
+    FT_ASSERT_EQ('\0', destination[4]);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_embedded_null_source, "ft_strlcpy stops at embedded null")
+{
+    char source[4];
+    char destination[3];
+
+    source[0] = 'a';
+    source[1] = '\0';
+    source[2] = 'b';
+    source[3] = '\0';
+    destination[0] = 'x';
+    destination[1] = 'y';
+    destination[2] = 'z';
+    FT_ASSERT_EQ(1u, ft_strlcpy(destination, source, sizeof(destination)));
+    FT_ASSERT_EQ('a', destination[0]);
+    FT_ASSERT_EQ('\0', destination[1]);
+    FT_ASSERT_EQ('z', destination[2]);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_long_source_counts_full_length, "ft_strlcpy counts full source length when truncated")
+{
+    const char *source;
+    char destination[5];
+
+    source = "abcdefghijklmnopqrstuvwxyz";
+    destination[0] = 'r';
+    destination[1] = 's';
+    destination[2] = 't';
+    destination[3] = 'u';
+    destination[4] = 'v';
+    FT_ASSERT_EQ(26u, ft_strlcpy(destination, source, sizeof(destination)));
+    FT_ASSERT_EQ('a', destination[0]);
+    FT_ASSERT_EQ('b', destination[1]);
+    FT_ASSERT_EQ('c', destination[2]);
+    FT_ASSERT_EQ('d', destination[3]);
+    FT_ASSERT_EQ('\0', destination[4]);
+    return (1);
+}
+
+FT_TEST(test_strlcpy_recovers_after_null_destination_failure, "ft_strlcpy resets errno after failure")
+{
+    char destination[6];
+
+    destination[0] = '0';
+    destination[1] = '0';
+    destination[2] = '0';
+    destination[3] = '0';
+    destination[4] = '0';
+    destination[5] = '\0';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0u, ft_strlcpy(ft_nullptr, "hello", sizeof(destination)));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", sizeof(destination)));
+    FT_ASSERT_EQ(0, ft_strcmp(destination, "hello"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strlen.cpp
+++ b/Test/Test/test_strlen.cpp
@@ -9,6 +9,14 @@ FT_TEST(test_strlen_nullptr, "ft_strlen nullptr")
     return (1);
 }
 
+FT_TEST(test_strlen_nullptr_sets_errno, "ft_strlen nullptr sets FT_EINVAL")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, ft_strlen(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_strlen_simple, "ft_strlen basic")
 {
     FT_ASSERT_EQ(4, ft_strlen("test"));
@@ -56,5 +64,44 @@ FT_TEST(test_strlen_resets_errno_on_success, "ft_strlen clears ft_errno before m
     ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(3, ft_strlen("abc"));
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlen_counts_non_ascii_bytes, "ft_strlen counts bytes beyond ascii")
+{
+    char string[3];
+
+    string[0] = static_cast<char>(0xFF);
+    string[1] = static_cast<char>(0x80);
+    string[2] = '\0';
+    ft_errno = FT_ERANGE;
+    FT_ASSERT_EQ(2, ft_strlen(string));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlen_size_t_large_buffer, "ft_strlen_size_t handles wide buffers")
+{
+    static char buffer[2049];
+    size_t index;
+
+    index = 0;
+    while (index < 2048)
+    {
+        buffer[index] = 'x';
+        index++;
+    }
+    buffer[2048] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(static_cast<size_t>(2048), ft_strlen_size_t(buffer));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strlen_size_t_nullptr_sets_errno, "ft_strlen_size_t nullptr sets FT_EINVAL")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(static_cast<size_t>(0), ft_strlen_size_t(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strmapi.cpp
+++ b/Test/Test/test_strmapi.cpp
@@ -1,5 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../CMA/CMA.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 static char to_upper_map(unsigned int index, char character)
@@ -8,6 +9,20 @@ static char to_upper_map(unsigned int index, char character)
     if (character >= 'a' && character <= 'z')
         return (character - 32);
     return (character);
+}
+
+static char g_strmapi_index_capture[8];
+static unsigned int g_strmapi_call_count = 0;
+
+static char index_to_digit_map(unsigned int index, char character)
+{
+    (void)character;
+    if (g_strmapi_call_count < 8)
+    {
+        g_strmapi_index_capture[g_strmapi_call_count] = static_cast<char>('0' + index);
+        g_strmapi_call_count++;
+    }
+    return (static_cast<char>('0' + index));
 }
 
 FT_TEST(test_strmapi_basic, "ft_strmapi basic")
@@ -28,5 +43,36 @@ FT_TEST(test_strmapi_basic, "ft_strmapi basic")
 
     FT_ASSERT_EQ(ft_nullptr, ft_strmapi(ft_nullptr, to_upper_map));
     FT_ASSERT_EQ(ft_nullptr, ft_strmapi("ab", ft_nullptr));
+    return (1);
+}
+
+FT_TEST(test_strmapi_uses_index_values, "ft_strmapi forwards index values to callback")
+{
+    char *result;
+
+    g_strmapi_call_count = 0;
+    g_strmapi_index_capture[0] = '\0';
+    g_strmapi_index_capture[1] = '\0';
+    g_strmapi_index_capture[2] = '\0';
+    g_strmapi_index_capture[3] = '\0';
+    result = ft_strmapi("qrst", index_to_digit_map);
+    if (result == ft_nullptr)
+        return (0);
+    g_strmapi_index_capture[g_strmapi_call_count] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp("0123", result));
+    FT_ASSERT_EQ(4u, g_strmapi_call_count);
+    FT_ASSERT_EQ(0, ft_strcmp("0123", g_strmapi_index_capture));
+    cma_free(result);
+    return (1);
+}
+
+FT_TEST(test_strmapi_null_arguments_set_errno, "ft_strmapi null inputs set FT_EINVAL")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_strmapi(ft_nullptr, to_upper_map));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_strmapi("sample", ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strncmp.cpp
+++ b/Test/Test/test_strncmp.cpp
@@ -44,3 +44,37 @@ FT_TEST(test_strncmp_null_arguments, "ft_strncmp null arguments return error")
     FT_ASSERT_EQ(-1, ft_strncmp("abc", ft_nullptr, 3));
     return (1);
 }
+
+FT_TEST(test_strncmp_high_bit_values, "ft_strncmp orders high-bit characters")
+{
+    char first[3];
+    char second[3];
+
+    first[0] = static_cast<char>(0x90);
+    first[1] = 'a';
+    first[2] = '\0';
+    second[0] = static_cast<char>(0x10);
+    second[1] = 'a';
+    second[2] = '\0';
+    FT_ASSERT(ft_strncmp(first, second, 2) > 0);
+    return (1);
+}
+
+FT_TEST(test_strncmp_embedded_nulls_stop_comparison, "ft_strncmp stops comparing after embedded null")
+{
+    char first[5];
+    char second[5];
+
+    first[0] = 'a';
+    first[1] = 'b';
+    first[2] = '\0';
+    first[3] = 'c';
+    first[4] = '\0';
+    second[0] = 'a';
+    second[1] = 'b';
+    second[2] = '\0';
+    second[3] = 'd';
+    second[4] = '\0';
+    FT_ASSERT_EQ(0, ft_strncmp(first, second, 4));
+    return (1);
+}

--- a/Test/Test/test_strncpy.cpp
+++ b/Test/Test/test_strncpy.cpp
@@ -1,5 +1,6 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strncpy_full_copy, "ft_strncpy full copy with padding")
@@ -74,5 +75,59 @@ FT_TEST(test_strncpy_null, "ft_strncpy with nullptr")
     buffer[3] = '\0';
     FT_ASSERT_EQ(ft_nullptr, ft_strncpy(ft_nullptr, buffer, 3));
     FT_ASSERT_EQ(ft_nullptr, ft_strncpy(buffer, ft_nullptr, 3));
+    return (1);
+}
+
+FT_TEST(test_strncpy_null_sets_errno, "ft_strncpy null arguments set FT_EINVAL")
+{
+    char buffer[4];
+
+    buffer[0] = 'z';
+    buffer[1] = '\0';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_strncpy(ft_nullptr, buffer, 2));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_strncpy(buffer, ft_nullptr, 2));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strncpy_zero_length_clears_errno, "ft_strncpy zero length clears errno")
+{
+    char destination[3];
+
+    destination[0] = 'x';
+    destination[1] = 'y';
+    destination[2] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(destination, ft_strncpy(destination, "hi", 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ('x', destination[0]);
+    FT_ASSERT_EQ('y', destination[1]);
+    return (1);
+}
+
+FT_TEST(test_strncpy_pads_with_null_bytes, "ft_strncpy pads destination when source shorter")
+{
+    char source[3];
+    char destination[5];
+
+    source[0] = 'o';
+    source[1] = 'k';
+    source[2] = '\0';
+    destination[0] = 'a';
+    destination[1] = 'a';
+    destination[2] = 'a';
+    destination[3] = 'a';
+    destination[4] = 'z';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(destination, ft_strncpy(destination, source, 4));
+    FT_ASSERT_EQ('o', destination[0]);
+    FT_ASSERT_EQ('k', destination[1]);
+    FT_ASSERT_EQ('\0', destination[2]);
+    FT_ASSERT_EQ('\0', destination[3]);
+    FT_ASSERT_EQ('z', destination[4]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strnstr.cpp
+++ b/Test/Test/test_strnstr.cpp
@@ -37,6 +37,14 @@ FT_TEST(test_strnstr_zero_size, "ft_strnstr zero size")
     return (1);
 }
 
+FT_TEST(test_strnstr_empty_needle_zero_size, "ft_strnstr empty needle ignores size limit")
+{
+    const char *haystack = "hello";
+
+    FT_ASSERT_EQ(haystack, ft_strnstr(haystack, "", 0));
+    return (1);
+}
+
 FT_TEST(test_strnstr_null_arguments, "ft_strnstr null arguments return nullptr")
 {
     FT_ASSERT_EQ(ft_nullptr, ft_strnstr(ft_nullptr, "abc", 3));
@@ -53,5 +61,13 @@ FT_TEST(test_strnstr_errno_resets_on_success, "ft_strnstr resets errno on succes
     ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(haystack + 3, ft_strnstr(haystack, "fix", 6));
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strnstr_restart_within_limit, "ft_strnstr restarts search within limit")
+{
+    const char *haystack = "abcabcd";
+
+    FT_ASSERT_EQ(haystack + 3, ft_strnstr(haystack, "abcd", 7));
     return (1);
 }

--- a/Test/Test/test_strrchr.cpp
+++ b/Test/Test/test_strrchr.cpp
@@ -34,3 +34,19 @@ FT_TEST(test_strrchr_terminator, "ft_strrchr terminator")
     FT_ASSERT_EQ(string + 5, ft_strrchr(string, '\0'));
     return (1);
 }
+
+FT_TEST(test_strrchr_high_bit, "ft_strrchr locates high-bit character")
+{
+    char string[6];
+
+    string[0] = 'n';
+    string[1] = static_cast<char>(0xFF);
+    string[2] = 'i';
+    string[3] = static_cast<char>(0xFF);
+    string[4] = 'l';
+    string[5] = '\0';
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(string + 3, ft_strrchr(string, 0xFF));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_strstr.cpp
+++ b/Test/Test/test_strstr.cpp
@@ -52,3 +52,12 @@ FT_TEST(test_strstr_null, "ft_strstr with nullptr")
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
+
+FT_TEST(test_strstr_overlapping_partial_match, "ft_strstr restarts after overlapping failure")
+{
+    const char *haystack = "ababac";
+    const char *needle = "abac";
+
+    FT_ASSERT_EQ(haystack + 2, ft_strstr(haystack, needle));
+    return (1);
+}

--- a/Test/Test/test_strtok.cpp
+++ b/Test/Test/test_strtok.cpp
@@ -62,6 +62,18 @@ FT_TEST(test_strtok_reinitialize, "ft_strtok resets when given a new string")
     return (1);
 }
 
+FT_TEST(test_strtok_skips_leading_delimiters, "ft_strtok skips leading separators")
+{
+    char buffer[16] = ",,token";
+    char *token;
+
+    token = ft_strtok(buffer, ",");
+    FT_ASSERT(token != ft_nullptr);
+    FT_ASSERT_EQ(0, ft_strcmp("token", token));
+    FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, ","));
+    return (1);
+}
+
 FT_TEST(test_strtok_thread_local_state, "ft_strtok maintains thread local state")
 {
     char first_thread_buffer[32] = "red blue";
@@ -98,5 +110,17 @@ FT_TEST(test_strtok_thread_local_state, "ft_strtok maintains thread local state"
     FT_ASSERT_EQ(0, ft_strcmp("blue", first_thread_token_two));
     FT_ASSERT_EQ(0, ft_strcmp("green", second_thread_token_one));
     FT_ASSERT_EQ(0, ft_strcmp("yellow", second_thread_token_two));
+    return (1);
+}
+
+FT_TEST(test_strtok_empty_delimiter_returns_full_string, "ft_strtok treats empty delimiters as whole token")
+{
+    char buffer[16] = "token";
+    char *token;
+
+    token = ft_strtok(buffer, "");
+    FT_ASSERT(token != ft_nullptr);
+    FT_ASSERT_EQ(0, ft_strcmp("token", token));
+    FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, ""));
     return (1);
 }

--- a/Test/Test/test_strtol.cpp
+++ b/Test/Test/test_strtol.cpp
@@ -109,6 +109,17 @@ FT_TEST(test_strtol_negative_overflow, "ft_strtol clamps negative overflow and r
     return (1);
 }
 
+FT_TEST(test_strtol_uppercase_hex_prefix, "ft_strtol accepts uppercase hex prefix")
+{
+    char *end_pointer;
+
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(255, ft_strtol("0Xff", &end_pointer, 0));
+    FT_ASSERT_EQ('\0', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_strtol_null_input, "ft_strtol null input sets errno and end pointer")
 {
     char *end_pointer = reinterpret_cast<char *>(0x1);

--- a/Test/Test/test_strtoul.cpp
+++ b/Test/Test/test_strtoul.cpp
@@ -95,6 +95,17 @@ FT_TEST(test_strtoul_overflow, "ft_strtoul clamps overflow and reports error")
     return (1);
 }
 
+FT_TEST(test_strtoul_skips_leading_whitespace, "ft_strtoul ignores leading whitespace")
+{
+    char *end_pointer;
+
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(static_cast<unsigned long>(987), ft_strtoul("\r\n\t 987", &end_pointer, 10));
+    FT_ASSERT_EQ('\0', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_strtoul_null_input, "ft_strtoul null input sets errno and end pointer")
 {
     char *end_pointer = reinterpret_cast<char *>(0x1);

--- a/Test/Test/test_tolower.cpp
+++ b/Test/Test/test_tolower.cpp
@@ -44,3 +44,20 @@ FT_TEST(test_tolower_nullptr, "ft_to_lower nullptr")
     FT_ASSERT_EQ(1, 1);
     return (1);
 }
+
+FT_TEST(test_tolower_non_ascii_preserved, "ft_to_lower leaves non-ASCII bytes unchanged")
+{
+    char string[5];
+
+    string[0] = static_cast<char>(0xC7);
+    string[1] = 'A';
+    string[2] = static_cast<char>(0x80);
+    string[3] = 'Z';
+    string[4] = '\0';
+    ft_to_lower(string);
+    FT_ASSERT_EQ(static_cast<char>(0xC7), string[0]);
+    FT_ASSERT_EQ('a', string[1]);
+    FT_ASSERT_EQ(static_cast<char>(0x80), string[2]);
+    FT_ASSERT_EQ('z', string[3]);
+    return (1);
+}

--- a/Test/Test/test_toupper.cpp
+++ b/Test/Test/test_toupper.cpp
@@ -47,3 +47,22 @@ FT_TEST(test_toupper_nullptr, "ft_to_upper nullptr")
     FT_ASSERT_EQ(1, 1);
     return (1);
 }
+
+FT_TEST(test_toupper_stops_at_terminator, "ft_to_upper stops at first null byte")
+{
+    char string[6];
+
+    string[0] = 'a';
+    string[1] = static_cast<char>(0xE1);
+    string[2] = '\0';
+    string[3] = 'x';
+    string[4] = 'y';
+    string[5] = '\0';
+    ft_to_upper(string);
+    FT_ASSERT_EQ('A', string[0]);
+    FT_ASSERT_EQ(static_cast<char>(0xE1), string[1]);
+    FT_ASSERT_EQ('\0', string[2]);
+    FT_ASSERT_EQ('x', string[3]);
+    FT_ASSERT_EQ('y', string[4]);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add ft_getenv and ft_setenv regressions to cover empty names, missing variables, and null values
- ensure ft_memchr and ft_memcpy recover ft_errno after misses and successful copies
- verify ft_strchr terminator searches and ft_strlen_size_t nullptr inputs leave errno consistent

## Testing
- make -C Test OPT_LEVEL=0

------
https://chatgpt.com/codex/tasks/task_e_68d818f07a98833180acaaedf211ec3e