### PR TITLE
Ensure ft_strrchr clears errno before checks

### DIFF
--- a/Libft/libft_strrchr.cpp
+++ b/Libft/libft_strrchr.cpp
@@ -4,6 +4,7 @@
 
 char    *ft_strrchr(const char *string, int char_to_find)
 {
+    ft_errno = ER_SUCCESS;
     if (!string)
     {
         ft_errno = FT_EINVAL;


### PR DESCRIPTION
## Summary
- reset ft_errno to ER_SUCCESS at the start of ft_strrchr so successful paths leave errno unchanged

## Testing
- make -C Test
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d8d8e0da708331a87695a42944ea09