### PR TITLE
Add errno coverage to ft_strtok tests

### DIFF
--- a/Libft/libft_strtok.cpp
+++ b/Libft/libft_strtok.cpp
@@ -1,5 +1,6 @@
 #include "libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 char    *ft_strtok(char *string, const char *delimiters)
 {
@@ -19,6 +20,7 @@ char    *ft_strtok(char *string, const char *delimiters)
     size_t          new_delimiters_hash;
     unsigned char   delimiter_character_value;
 
+    ft_errno = ER_SUCCESS;
     if (string != ft_nullptr)
     {
         saved_string = string;
@@ -28,7 +30,10 @@ char    *ft_strtok(char *string, const char *delimiters)
         cached_delimiters_hash = 0;
     }
     if (saved_string == ft_nullptr || delimiters == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     new_delimiters_hash = 5381;
     delimiter_index = 0;
     while (delimiters[delimiter_index] != '\0')
@@ -75,6 +80,7 @@ char    *ft_strtok(char *string, const char *delimiters)
     if (*current_pointer == '\0')
     {
         saved_string = ft_nullptr;
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
     }
     token_start = current_pointer;

--- a/Test/Test/test_strtok.cpp
+++ b/Test/Test/test_strtok.cpp
@@ -1,4 +1,5 @@
 #include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include <thread>
 
@@ -9,11 +10,15 @@ FT_TEST(test_strtok_basic, "ft_strtok basic")
 
     token = ft_strtok(buffer, " ");
     FT_ASSERT_EQ(0, ft_strcmp("one", token));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     token = ft_strtok(ft_nullptr, " ");
     FT_ASSERT_EQ(0, ft_strcmp("two", token));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     token = ft_strtok(ft_nullptr, " ");
     FT_ASSERT_EQ(0, ft_strcmp("three", token));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, " "));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
@@ -21,10 +26,13 @@ FT_TEST(test_strtok_edge, "ft_strtok edge")
 {
     char buffer[4] = ",,,";
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(buffer, ","));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, ","));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
 
     char second[4] = "abc";
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(second, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
@@ -54,11 +62,15 @@ FT_TEST(test_strtok_reinitialize, "ft_strtok resets when given a new string")
 
     token = ft_strtok(first_string, " ");
     FT_ASSERT_EQ(0, ft_strcmp("alpha", token));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     token = ft_strtok(second_string, " ");
     FT_ASSERT_EQ(0, ft_strcmp("gamma", token));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     token = ft_strtok(ft_nullptr, " ");
     FT_ASSERT_EQ(0, ft_strcmp("delta", token));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, " "));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
@@ -70,7 +82,9 @@ FT_TEST(test_strtok_skips_leading_delimiters, "ft_strtok skips leading separator
     token = ft_strtok(buffer, ",");
     FT_ASSERT(token != ft_nullptr);
     FT_ASSERT_EQ(0, ft_strcmp("token", token));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, ","));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
@@ -121,6 +135,8 @@ FT_TEST(test_strtok_empty_delimiter_returns_full_string, "ft_strtok treats empty
     token = ft_strtok(buffer, "");
     FT_ASSERT(token != ft_nullptr);
     FT_ASSERT_EQ(0, ft_strcmp("token", token));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, ""));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }


### PR DESCRIPTION
## Summary
- extend the ft_strtok unit tests to include Errno checks for both success and invalid input paths

## Testing
- make -C Test
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d8e088e8c08331882a8e5fafd755fb