### PR TITLE
Ensure containers reset ft_errno after successful operations

### DIFF
--- a/Template/set.hpp
+++ b/Template/set.hpp
@@ -207,6 +207,7 @@ void ft_set<ElementType>::insert(const ElementType& value)
     size_t position = lower_bound(value);
     if (position < this->_size && !(value < this->_data[position]) && !(this->_data[position] < value))
     {
+        this->set_error(ER_SUCCESS);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -224,6 +225,7 @@ void ft_set<ElementType>::insert(const ElementType& value)
     }
     construct_at(&this->_data[position], value);
     ++this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -239,6 +241,7 @@ void ft_set<ElementType>::insert(ElementType&& value)
     size_t position = lower_bound(value);
     if (position < this->_size && !(value < this->_data[position]) && !(this->_data[position] < value))
     {
+        this->set_error(ER_SUCCESS);
         this->_mutex.unlock(THREAD_ID);
         return ;
     }
@@ -256,6 +259,7 @@ void ft_set<ElementType>::insert(ElementType&& value)
     }
     construct_at(&this->_data[position], ft_move(value));
     ++this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -276,6 +280,7 @@ ElementType* ft_set<ElementType>::find(const ElementType& value)
         return (ft_nullptr);
     }
     ElementType* result = &this->_data[index];
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (result);
 }
@@ -296,6 +301,7 @@ const ElementType* ft_set<ElementType>::find(const ElementType& value) const
         return (ft_nullptr);
     }
     ElementType* result = &this->_data[index];
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (result);
 }
@@ -324,6 +330,7 @@ void ft_set<ElementType>::remove(const ElementType& value)
         ++current_index;
     }
     --this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -376,6 +383,7 @@ void ft_set<ElementType>::clear()
         ++index;
     }
     this->_size = 0;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }

--- a/Template/stack.hpp
+++ b/Template/stack.hpp
@@ -130,6 +130,7 @@ void ft_stack<ElementType>::push(const ElementType& value)
     new_node->_next = this->_top;
     this->_top = new_node;
     ++this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -153,6 +154,7 @@ void ft_stack<ElementType>::push(ElementType&& value)
     new_node->_next = this->_top;
     this->_top = new_node;
     ++this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -177,6 +179,7 @@ ElementType ft_stack<ElementType>::pop()
     destroy_at(&node->_data);
     cma_free(node);
     --this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (value);
 }
@@ -197,6 +200,7 @@ ElementType& ft_stack<ElementType>::top()
         return (error_element);
     }
     ElementType& value = this->_top->_data;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (value);
 }
@@ -217,6 +221,7 @@ const ElementType& ft_stack<ElementType>::top() const
         return (error_element);
     }
     const ElementType& value = this->_top->_data;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (value);
 }
@@ -274,6 +279,7 @@ void ft_stack<ElementType>::clear()
         cma_free(node);
     }
     this->_size = 0;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }

--- a/Template/vector.hpp
+++ b/Template/vector.hpp
@@ -208,7 +208,7 @@ void ft_vector<ElementType>::push_back(const ElementType &value)
         else
             newCapacity = 1;
         this->reserve_internal(newCapacity);
-        if (this->_error_code != ER_SUCCESS)
+        if (this->_capacity < newCapacity)
         {
             this->_mutex.unlock(THREAD_ID);
             return ;
@@ -216,6 +216,7 @@ void ft_vector<ElementType>::push_back(const ElementType &value)
     }
     construct_at(&this->_data[this->_size], value);
     this->_size++;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -236,7 +237,7 @@ void ft_vector<ElementType>::push_back(ElementType &&value)
         else
             newCapacity = 1;
         this->reserve_internal(newCapacity);
-        if (this->_error_code != ER_SUCCESS)
+        if (this->_capacity < newCapacity)
         {
             this->_mutex.unlock(THREAD_ID);
             return ;
@@ -244,6 +245,7 @@ void ft_vector<ElementType>::push_back(ElementType &&value)
     }
     construct_at(&this->_data[this->_size], std::forward<ElementType>(value));
     this->_size++;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -260,6 +262,7 @@ void ft_vector<ElementType>::pop_back()
     {
         destroy_at(&this->_data[this->_size - 1]);
         --this->_size;
+        this->set_error(ER_SUCCESS);
     }
     else
         this->set_error(VECTOR_INVALID_OPERATION);
@@ -283,6 +286,7 @@ ElementType& ft_vector<ElementType>::operator[](size_t index)
         return (default_instance);
     }
     ElementType& ref = this->_data[index];
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -303,6 +307,7 @@ const ElementType& ft_vector<ElementType>::operator[](size_t index) const
         return (default_instance);
     }
     const ElementType& ref = this->_data[index];
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (ref);
 }
@@ -317,6 +322,7 @@ void ft_vector<ElementType>::clear()
     }
     this->destroy_elements(0, this->_size);
     this->_size = 0;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -348,6 +354,8 @@ void ft_vector<ElementType>::reserve(size_t new_capacity)
         return ;
     }
     this->reserve_internal(new_capacity);
+    if (this->_capacity >= new_capacity)
+        this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -365,7 +373,7 @@ void ft_vector<ElementType>::resize(size_t new_size, const ElementType& value)
     else if (new_size > this->_size)
     {
         this->reserve_internal(new_size);
-        if (this->_error_code != ER_SUCCESS)
+        if (this->_capacity < new_size)
         {
             this->_mutex.unlock(THREAD_ID);
             return ;
@@ -378,6 +386,7 @@ void ft_vector<ElementType>::resize(size_t new_size, const ElementType& value)
         }
     }
     this->_size = new_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return ;
 }
@@ -405,7 +414,7 @@ typename ft_vector<ElementType>::iterator ft_vector<ElementType>::insert(iterato
         else
             new_capacity = 1;
         this->reserve_internal(new_capacity);
-        if (this->_error_code != ER_SUCCESS)
+        if (this->_capacity < new_capacity)
         {
             iterator endIt = this->_data + this->_size;
             this->_mutex.unlock(THREAD_ID);
@@ -423,6 +432,7 @@ typename ft_vector<ElementType>::iterator ft_vector<ElementType>::insert(iterato
     construct_at(&this->_data[index], value);
     this->_size++;
     iterator ret = &this->_data[index];
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (ret);
 }
@@ -457,6 +467,7 @@ typename ft_vector<ElementType>::iterator ft_vector<ElementType>::erase(iterator
         ret = this->_data + this->_size;
     else
         ret = &this->_data[index];
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (ret);
 }
@@ -483,6 +494,7 @@ ElementType ft_vector<ElementType>::release_at(size_t index)
         ++i2;
     }
     --this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (detached);
 }
@@ -493,6 +505,7 @@ typename ft_vector<ElementType>::iterator ft_vector<ElementType>::begin()
     if (this->_mutex.lock(THREAD_ID) != FT_SUCCESS)
         return (this->_data);
     iterator it = this->_data;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (it);
 }
@@ -503,6 +516,7 @@ typename ft_vector<ElementType>::const_iterator ft_vector<ElementType>::begin() 
     if (this->_mutex.lock(THREAD_ID) != FT_SUCCESS)
         return (this->_data);
     const_iterator it = this->_data;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (it);
 }
@@ -513,6 +527,7 @@ typename ft_vector<ElementType>::iterator ft_vector<ElementType>::end()
     if (this->_mutex.lock(THREAD_ID) != FT_SUCCESS)
         return (this->_data);
     iterator it = this->_data + this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (it);
 }
@@ -523,6 +538,7 @@ typename ft_vector<ElementType>::const_iterator ft_vector<ElementType>::end() co
     if (this->_mutex.lock(THREAD_ID) != FT_SUCCESS)
         return (this->_data);
     const_iterator it = this->_data + this->_size;
+    this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (it);
 }

--- a/Test/Test/test_template.cpp
+++ b/Test/Test/test_template.cpp
@@ -1,10 +1,14 @@
 #include "../../Template/vector.hpp"
 #include "../../Template/map.hpp"
+#include "../../Template/set.hpp"
+#include "../../Template/stack.hpp"
 #include "../../Template/shared_ptr.hpp"
 #include "../../Template/unique_ptr.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
 #include "../../Errno/errno.hpp"
 #include "../../JSon/document.hpp"
 #include "../../CMA/CMA.hpp"
+#include "../../System_utils/test_runner.hpp"
 #include <cstring>
 #include <cstdio>
 #include <vector>
@@ -275,6 +279,55 @@ int test_json_roundtrip_file(void)
     if (!item_two)
         return (0);
     return (std::strcmp(item_two->value, "value") == 0);
+}
+
+FT_TEST(test_ft_vector_resets_errno_after_successful_push, "ft_vector clears errno after successful push_back")
+{
+    ft_vector<int> vector_instance;
+
+    ft_errno = ER_SUCCESS;
+    vector_instance[0];
+    FT_ASSERT_EQ(VECTOR_OUT_OF_BOUNDS, vector_instance.get_error());
+    vector_instance.push_back(5);
+    FT_ASSERT_EQ(ER_SUCCESS, vector_instance.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(5, vector_instance[0]);
+    FT_ASSERT_EQ(ER_SUCCESS, vector_instance.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_set_resets_errno_after_successful_insert, "ft_set clears errno after successful insert")
+{
+    ft_set<int> set_instance;
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, set_instance.find(42));
+    FT_ASSERT_EQ(SET_NOT_FOUND, set_instance.get_error());
+    set_instance.insert(42);
+    FT_ASSERT_EQ(ER_SUCCESS, set_instance.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    int *found = set_instance.find(42);
+    FT_ASSERT(found != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, set_instance.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_stack_resets_errno_after_successful_push, "ft_stack clears errno after successful push")
+{
+    ft_stack<int> stack_instance;
+
+    ft_errno = ER_SUCCESS;
+    stack_instance.pop();
+    FT_ASSERT_EQ(STACK_EMPTY, stack_instance.get_error());
+    stack_instance.push(7);
+    FT_ASSERT_EQ(ER_SUCCESS, stack_instance.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(7, stack_instance.top());
+    FT_ASSERT_EQ(ER_SUCCESS, stack_instance.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
 }
 
 


### PR DESCRIPTION
## Summary
- reset ft_errno in vector push/pop/accessors and avoid interpreting stale errors as allocation failures
- ensure set and stack mutating and lookup methods clear ft_errno after successful operations
- add regression tests that reproduce the stale error scenario and confirm ft_errno resets to ER_SUCCESS

## Testing
- make -C Test OPT_LEVEL=0
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d8e6ea928c8331b7869bb6955a9b9b