### PR TITLE
Add loot table error handling tests

### DIFF
--- a/RNG/loot_table.hpp
+++ b/RNG/loot_table.hpp
@@ -53,7 +53,11 @@ ElementType *ft_loot_table<ElementType>::getRandomLoot() const
         if (effective < 1)
             effective = 1;
         if (INT_MAX - total_weight < effective)
+        {
+            ft_errno = FT_ERANGE;
+            const_cast<ft_loot_table<ElementType>*>(this)->set_error(FT_ERANGE);
             return (ft_nullptr);
+        }
         total_weight += effective;
         ++index;
     }
@@ -67,11 +71,18 @@ ElementType *ft_loot_table<ElementType>::getRandomLoot() const
             effective = 1;
         accumulated += effective;
         if (roll <= accumulated)
+        {
+            ft_errno = ER_SUCCESS;
+            const_cast<ft_loot_table<ElementType>*>(this)->set_error(ER_SUCCESS);
             return ((*this)[index].item);
+        }
         ++index;
     }
+    ft_errno = FT_ERANGE;
+    const_cast<ft_loot_table<ElementType>*>(this)->set_error(FT_ERANGE);
     return (ft_nullptr);
 }
+
 
 template<typename ElementType>
 ElementType *ft_loot_table<ElementType>::popRandomLoot()
@@ -90,7 +101,11 @@ ElementType *ft_loot_table<ElementType>::popRandomLoot()
         if (effective < 1)
             effective = 1;
         if (INT_MAX - total_weight < effective)
+        {
+            ft_errno = FT_ERANGE;
+            this->set_error(FT_ERANGE);
             return (ft_nullptr);
+        }
         total_weight += effective;
         ++index;
     }
@@ -107,10 +122,14 @@ ElementType *ft_loot_table<ElementType>::popRandomLoot()
         {
             ElementType *elem = (*this)[index].item;
             this->release_at(index);
+            ft_errno = ER_SUCCESS;
+            this->set_error(ER_SUCCESS);
             return (elem);
         }
         ++index;
     }
+    ft_errno = FT_ERANGE;
+    this->set_error(FT_ERANGE);
     return (ft_nullptr);
 }
 

--- a/Test/Test/test_loot_table.cpp
+++ b/Test/Test/test_loot_table.cpp
@@ -1,0 +1,79 @@
+#include "../../RNG/loot_table.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include <climits>
+
+FT_TEST(test_loot_table_get_random_success_sets_success, "ft_loot_table getRandomLoot success clears errors")
+{
+    ft_loot_table<int> table;
+    int treasure_value = 42;
+
+    FT_ASSERT_EQ(ft_nullptr, table.getRandomLoot());
+    FT_ASSERT_EQ(LOOT_TABLE_EMPTY, ft_errno);
+    FT_ASSERT_EQ(LOOT_TABLE_EMPTY, table.get_error());
+
+    table.addElement(&treasure_value, 10, 0);
+    ft_errno = FT_ERANGE;
+
+    int *result = table.getRandomLoot();
+    if (result == ft_nullptr)
+        return (0);
+    FT_ASSERT_EQ(&treasure_value, result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, table.get_error());
+    return (1);
+}
+
+FT_TEST(test_loot_table_get_random_overflow_sets_error, "ft_loot_table getRandomLoot overflow sets error state")
+{
+    ft_loot_table<int> table;
+    int rare_gem = 100;
+    int common_item = 50;
+
+    table.addElement(&rare_gem, INT_MAX, 0);
+    table.addElement(&common_item, 1, 0);
+
+    int *result = table.getRandomLoot();
+    FT_ASSERT_EQ(ft_nullptr, result);
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
+    FT_ASSERT_EQ(FT_ERANGE, table.get_error());
+    return (1);
+}
+
+FT_TEST(test_loot_table_pop_random_success_sets_success, "ft_loot_table popRandomLoot success clears errors")
+{
+    ft_loot_table<int> table;
+    int loot_piece = 7;
+
+    FT_ASSERT_EQ(ft_nullptr, table.popRandomLoot());
+    FT_ASSERT_EQ(LOOT_TABLE_EMPTY, ft_errno);
+    FT_ASSERT_EQ(LOOT_TABLE_EMPTY, table.get_error());
+
+    table.addElement(&loot_piece, 3, 0);
+    ft_errno = FT_ERANGE;
+
+    int *result = table.popRandomLoot();
+    if (result != &loot_piece)
+        return (0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, table.get_error());
+    FT_ASSERT_EQ(0u, table.size());
+    return (1);
+}
+
+FT_TEST(test_loot_table_pop_random_overflow_sets_error, "ft_loot_table popRandomLoot overflow sets error state")
+{
+    ft_loot_table<int> table;
+    int legendary_item = 5;
+    int mundane_item = 6;
+
+    table.addElement(&legendary_item, INT_MAX, 0);
+    table.addElement(&mundane_item, 1, 0);
+
+    int *result = table.popRandomLoot();
+    FT_ASSERT_EQ(ft_nullptr, result);
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
+    FT_ASSERT_EQ(FT_ERANGE, table.get_error());
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add regression coverage for loot table success paths to ensure ft_errno and container errors reset to ER_SUCCESS
- verify both getRandomLoot and popRandomLoot flag FT_ERANGE when their overflow guards trigger

## Testing
- `make -C Test`
- `./libft_tests`


------
https://chatgpt.com/codex/tasks/task_e_68d8f06e07088331b413e3957e738a08