### PR TITLE
Fix ft_memmove null pointer errno handling

### DIFF
--- a/Libft/libft_memmove.cpp
+++ b/Libft/libft_memmove.cpp
@@ -9,13 +9,17 @@ void *ft_memmove(void *destination, const void *source, size_t size)
     size_t index;
 
     ft_errno = ER_SUCCESS;
-    if (size == 0 || destination == source)
-        return (destination);
     if (destination == ft_nullptr || source == ft_nullptr)
     {
-        ft_errno = FT_EINVAL;
-        return (ft_nullptr);
+        if (size > 0)
+        {
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        return (destination);
     }
+    if (size == 0 || destination == source)
+        return (destination);
     if (destination_pointer < source_pointer)
     {
         index = 0;

--- a/Test/Test/test_memmove.cpp
+++ b/Test/Test/test_memmove.cpp
@@ -77,6 +77,14 @@ FT_TEST(test_memmove_null, "ft_memmove with nullptr")
     return (1);
 }
 
+FT_TEST(test_memmove_null_both_pointers, "ft_memmove with both pointers nullptr and size greater than zero")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_memmove(ft_nullptr, ft_nullptr, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_memmove_same_pointer, "ft_memmove same pointer")
 {
     char buffer[4];


### PR DESCRIPTION
## Summary
- move the null-pointer validation ahead of the self-copy early exit in ft_memmove so null inputs with a non-zero size set FT_EINVAL
- allow zero-length operations with null pointers to succeed without changing errno
- add a regression test that verifies ft_memmove(ft_nullptr, ft_nullptr, 1) returns ft_nullptr and sets FT_EINVAL

## Testing
- make test *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68d97140c4e883319c20708d489ee03b