### PR TITLE
Ensure math_pow clears errno on success path

### DIFF
--- a/Math/math_pow.cpp
+++ b/Math/math_pow.cpp
@@ -9,6 +9,7 @@ double math_pow(double base_value, int exponent)
 
     result = 1.0;
     exponent_value = exponent;
+    ft_errno = ER_SUCCESS;
     if (exponent_value < 0)
     {
         if (math_fabs(base_value) <= DBL_MIN)


### PR DESCRIPTION
## Summary
- reset ft_errno to ER_SUCCESS before branching in math_pow so successful calls clear stale errors

## Testing
- make


------
https://chatgpt.com/codex/tasks/task_e_68d98915a7908331a29a523f3d40dd64