### PR TITLE
Set math_roll errno on success

### DIFF
--- a/Math/math_roll.cpp
+++ b/Math/math_roll.cpp
@@ -76,6 +76,8 @@ int *math_roll(const char *expression)
     int     *value;
     int     parse_error;
 
+    ft_errno = ER_SUCCESS;
+
     if (!expression)
     {
         ft_errno = FT_EINVAL;
@@ -123,5 +125,6 @@ int *math_roll(const char *expression)
     }
     *value = ft_atoi(result);
     cma_free(result);
+    ft_errno = ER_SUCCESS;
     return (value);
 }


### PR DESCRIPTION
## Summary
- initialize `ft_errno` to `ER_SUCCESS` at the start of `math_roll`
- explicitly set `ft_errno` to `ER_SUCCESS` on the success return path after freeing the intermediate buffer

## Testing
- make -C Test libft_tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d98a3fe55c8331beb9524e68a85ddd