### PR TITLE
Handle errno when math_sqrt receives NaN

### DIFF
--- a/Math/math_sqrt.cpp
+++ b/Math/math_sqrt.cpp
@@ -10,7 +10,10 @@ double math_sqrt(double number)
     int    max_iterations;
 
     if (math_isnan(number))
+    {
+        ft_errno = FT_EINVAL;
         return (math_nan());
+    }
     if (number < 0)
     {
         ft_errno = FT_EINVAL;

--- a/Test/Test/test_math_sqrt.cpp
+++ b/Test/Test/test_math_sqrt.cpp
@@ -23,3 +23,14 @@ FT_TEST(test_math_sqrt_zero_clears_errno, "math_sqrt zero clears errno")
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
+
+FT_TEST(test_math_sqrt_nan_sets_errno, "math_sqrt sets errno for nan input")
+{
+    double result;
+
+    ft_errno = ER_SUCCESS;
+    result = math_sqrt(math_nan());
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- set `ft_errno` to `FT_EINVAL` before returning `math_nan()` when `math_sqrt` receives a NaN input
- add a unit test that covers the NaN input path and checks the errno behavior

## Testing
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68d99743e35c833196b9eea3390c706a