### PR TITLE
Handle errno for math_log domain errors

### DIFF
--- a/Math/math_log.cpp
+++ b/Math/math_log.cpp
@@ -1,4 +1,5 @@
 #include "math.hpp"
+#include "../Errno/errno.hpp"
 
 double math_log(double value)
 {
@@ -16,7 +17,10 @@ double math_log(double value)
     int    iteration;
 
     if (value <= 0.0)
-        return (-1.0);
+    {
+        ft_errno = FT_EINVAL;
+        return (math_nan());
+    }
     converter.double_value = value;
     exponent = static_cast<int>((converter.bit_pattern >> 52) & 0x7ff) - 1023;
     converter.bit_pattern = (converter.bit_pattern & 0x000fffffffffffffULL) | 0x3ff0000000000000ULL;

--- a/Test/Test/test_math_log.cpp
+++ b/Test/Test/test_math_log.cpp
@@ -1,0 +1,25 @@
+#include "../../Math/math.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_math_log_zero_sets_errno, "math_log returns nan and sets errno for zero")
+{
+    double result;
+
+    ft_errno = ER_SUCCESS;
+    result = math_log(0.0);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_log_negative_sets_errno, "math_log returns nan and sets errno for negative values")
+{
+    double result;
+
+    ft_errno = ER_SUCCESS;
+    result = math_log(-4.2);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- set `math_log` to report `FT_EINVAL` and return `math_nan()` for non-positive inputs while leaving successful paths unchanged
- add regression tests that confirm `math_log` returns `math_nan()` and sets `FT_EINVAL` for zero and negative arguments

## Testing
- `make -C Test`


------
https://chatgpt.com/codex/tasks/task_e_68d9a2fba2188331a02ca0e4f190bea9