### PR TITLE
Add errno handling for math acos and fmod

### DIFF
--- a/Math/math_acos.cpp
+++ b/Math/math_acos.cpp
@@ -1,4 +1,5 @@
 #include "math.hpp"
+#include "../Errno/errno.hpp"
 
 static int math_is_infinite_internal(double number)
 {
@@ -30,31 +31,52 @@ double math_acos(double dot)
     int    iteration_count;
 
     if (math_isnan(dot))
+    {
+        ft_errno = FT_EINVAL;
         return (math_nan());
+    }
     if (math_is_infinite_internal(dot) != 0)
+    {
+        ft_errno = FT_EINVAL;
         return (math_nan());
+    }
     tolerance = 0.0000000000001;
     if (dot > 1.0)
     {
         if (math_fabs(dot - 1.0) <= tolerance)
             dot = 1.0;
         else
+        {
+            ft_errno = FT_EINVAL;
             return (math_nan());
+        }
     }
     if (dot < -1.0)
     {
         if (math_fabs(dot + 1.0) <= tolerance)
             dot = -1.0;
         else
+        {
+            ft_errno = FT_EINVAL;
             return (math_nan());
+        }
     }
     pi_value = 3.14159265358979323846;
     if (math_fabs(dot - 1.0) <= tolerance)
+    {
+        ft_errno = ER_SUCCESS;
         return (0.0);
+    }
     if (math_fabs(dot + 1.0) <= tolerance)
+    {
+        ft_errno = ER_SUCCESS;
         return (pi_value);
+    }
     if (math_fabs(dot) <= tolerance)
+    {
+        ft_errno = ER_SUCCESS;
         return (pi_value * 0.5);
+    }
     lower_bound = 0.0;
     upper_bound = pi_value;
     iteration_count = 0;
@@ -63,13 +85,17 @@ double math_acos(double dot)
         middle_value = (lower_bound + upper_bound) * 0.5;
         cosine_middle = math_cos(middle_value);
         if (math_fabs(cosine_middle - dot) <= tolerance)
+        {
+            ft_errno = ER_SUCCESS;
             return (middle_value);
+        }
         if (cosine_middle > dot)
             lower_bound = middle_value;
         else
             upper_bound = middle_value;
         iteration_count = iteration_count + 1;
     }
+    ft_errno = ER_SUCCESS;
     return ((lower_bound + upper_bound) * 0.5);
 }
 

--- a/Math/math_fmod.cpp
+++ b/Math/math_fmod.cpp
@@ -1,4 +1,5 @@
 #include "math.hpp"
+#include "../Errno/errno.hpp"
 #include <cmath>
 #include <limits>
 
@@ -26,16 +27,26 @@ double math_fmod(double value, double modulus)
     double remainder_value;
 
     if (math_isnan(value) || math_isnan(modulus))
+    {
+        ft_errno = FT_EINVAL;
         return (math_nan());
+    }
     if (math_is_infinite_internal(value) != 0)
+    {
+        ft_errno = FT_EINVAL;
         return (math_nan());
+    }
     if (math_fabs(modulus) <= std::numeric_limits<double>::denorm_min())
+    {
+        ft_errno = FT_ERANGE;
         return (math_nan());
+    }
     if (math_is_infinite_internal(modulus) != 0)
         return (value);
     remainder_value = std::fmod(value, modulus);
     if (math_fabs(remainder_value) <= std::numeric_limits<double>::denorm_min())
         remainder_value = value * 0.0;
+    ft_errno = ER_SUCCESS;
     return (remainder_value);
 }
 

--- a/Test/Test/test_math_acos.cpp
+++ b/Test/Test/test_math_acos.cpp
@@ -1,0 +1,63 @@
+#include "../../Math/math.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <limits>
+
+FT_TEST(test_math_acos_nan_sets_errno, "math_acos returns nan and sets errno for nan input")
+{
+    double result;
+
+    ft_errno = ER_SUCCESS;
+    result = math_acos(math_nan());
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_acos_infinite_sets_errno, "math_acos returns nan and sets errno for infinite input")
+{
+    double result;
+    double infinite_value;
+
+    infinite_value = std::numeric_limits<double>::infinity();
+    ft_errno = ER_SUCCESS;
+    result = math_acos(infinite_value);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_acos_above_one_sets_errno, "math_acos rejects inputs greater than one")
+{
+    double result;
+
+    ft_errno = ER_SUCCESS;
+    result = math_acos(1.5);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_acos_below_negative_one_sets_errno, "math_acos rejects inputs less than negative one")
+{
+    double result;
+
+    ft_errno = ER_SUCCESS;
+    result = math_acos(-1.5);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_acos_success_clears_errno, "math_acos clears errno on success")
+{
+    double result;
+    double expected;
+
+    ft_errno = FT_EINVAL;
+    expected = 1.0471975511965979;
+    result = math_acos(0.5);
+    FT_ASSERT(math_fabs(result - expected) < 0.000001);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_math_fmod.cpp
+++ b/Test/Test/test_math_fmod.cpp
@@ -1,0 +1,63 @@
+#include "../../Math/math.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <limits>
+
+FT_TEST(test_math_fmod_nan_sets_errno, "math_fmod returns nan and sets errno for nan input")
+{
+    double result;
+
+    ft_errno = ER_SUCCESS;
+    result = math_fmod(math_nan(), 2.0);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_fmod_infinite_value_sets_errno, "math_fmod returns nan and sets errno for infinite value")
+{
+    double result;
+    double infinite_value;
+
+    infinite_value = std::numeric_limits<double>::infinity();
+    ft_errno = ER_SUCCESS;
+    result = math_fmod(infinite_value, 3.0);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_fmod_zero_modulus_sets_errno, "math_fmod returns nan and sets errno for zero modulus")
+{
+    double result;
+
+    ft_errno = ER_SUCCESS;
+    result = math_fmod(4.0, 0.0);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_fmod_infinite_modulus_preserves_errno, "math_fmod preserves errno when modulus is infinite")
+{
+    double result;
+    double infinite_value;
+
+    infinite_value = std::numeric_limits<double>::infinity();
+    ft_errno = FT_EINVAL;
+    result = math_fmod(7.0, infinite_value);
+    FT_ASSERT_EQ(7.0, result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_fmod_success_clears_errno, "math_fmod clears errno on success")
+{
+    double result;
+
+    ft_errno = FT_EINVAL;
+    result = math_fmod(5.5, 2.0);
+    FT_ASSERT(math_fabs(result - 1.5) < 0.000001);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- set `ft_errno` for invalid inputs in `math_acos` and clear it on successful results
- update `math_fmod` to report invalid arguments and preserve prior errno when returning the original value
- add targeted tests covering all error paths and success cases for `math_acos` and `math_fmod`

## Testing
- ⚠️ `make -C Test` *(interrupted because building the entire test suite exceeds the session limits)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a4fb01d4833181b5a3cfb272f1c9