### PR TITLE
Propagate ft_errno through compatibility file IO

### DIFF
--- a/Test/Test/test_system_utils_file_io.cpp
+++ b/Test/Test/test_system_utils_file_io.cpp
@@ -1,0 +1,116 @@
+#include "../../Compatebility/compatebility_internal.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cerrno>
+#include <cstdio>
+#include <fcntl.h>
+#include <unistd.h>
+
+static void create_system_io_test_file(void)
+{
+    FILE *file_handle;
+
+    file_handle = std::fopen("test_cmp_system_io.txt", "w");
+    if (file_handle != ft_nullptr)
+    {
+        std::fputs("data", file_handle);
+        std::fclose(file_handle);
+    }
+    return ;
+}
+
+FT_TEST(test_cmp_open_failure_sets_errno, "cmp_open failure reports ft_errno")
+{
+    ft_errno = ER_SUCCESS;
+    errno = 0;
+    std::remove("missing_cmp_file.txt");
+    FT_ASSERT_EQ(-1, cmp_open("missing_cmp_file.txt"));
+    FT_ASSERT_EQ(ENOENT + ERRNO_OFFSET, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cmp_read_invalid_fd_sets_ft_einval, "cmp_read invalid descriptor")
+{
+    char buffer[4];
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, cmp_read(-1, buffer, sizeof(buffer)));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cmp_write_invalid_fd_sets_ft_einval, "cmp_write invalid descriptor")
+{
+    char buffer[4] = {0, 0, 0, 0};
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, cmp_write(-1, buffer, sizeof(buffer)));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cmp_close_invalid_fd_sets_ft_einval, "cmp_close invalid descriptor")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, cmp_close(-1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cmp_read_translates_errno, "cmp_read propagates errno failures")
+{
+    int file_descriptor;
+    char buffer[4];
+
+    create_system_io_test_file();
+    ft_errno = ER_SUCCESS;
+    file_descriptor = cmp_open("test_cmp_system_io.txt", O_WRONLY);
+    FT_ASSERT(file_descriptor >= 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
+    errno = 0;
+    FT_ASSERT_EQ(-1, cmp_read(file_descriptor, buffer, sizeof(buffer)));
+    FT_ASSERT_EQ(EBADF + ERRNO_OFFSET, ft_errno);
+    FT_ASSERT_EQ(0, cmp_close(file_descriptor));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cmp_write_translates_errno, "cmp_write propagates errno failures")
+{
+    int file_descriptor;
+    const char buffer[4] = {'t', 'e', 's', 't'};
+
+    create_system_io_test_file();
+    ft_errno = ER_SUCCESS;
+    file_descriptor = cmp_open("test_cmp_system_io.txt", O_RDONLY);
+    FT_ASSERT(file_descriptor >= 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
+    errno = 0;
+    FT_ASSERT_EQ(-1, cmp_write(file_descriptor, buffer, sizeof(buffer)));
+    FT_ASSERT_EQ(EBADF + ERRNO_OFFSET, ft_errno);
+    FT_ASSERT_EQ(0, cmp_close(file_descriptor));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cmp_close_translates_errno, "cmp_close propagates errno failures")
+{
+    int file_descriptor;
+
+    create_system_io_test_file();
+    ft_errno = ER_SUCCESS;
+    file_descriptor = cmp_open("test_cmp_system_io.txt", O_RDONLY);
+    FT_ASSERT(file_descriptor >= 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, cmp_close(file_descriptor));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
+    errno = 0;
+    FT_ASSERT_EQ(-1, cmp_close(file_descriptor));
+    FT_ASSERT_EQ(EBADF + ERRNO_OFFSET, ft_errno);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- translate Windows and POSIX file I/O failures into ft_errno, including contract checks and success resets
- add regression coverage for cmp_open/read/write/close to ensure ft_errno is populated on error paths

## Testing
- make -C Test objs/Test/test_system_utils_file_io.o

------
https://chatgpt.com/codex/tasks/task_e_68da212debd88331a5a537765a185dc0