### PR TITLE
Ensure file stream wrappers update ft_errno and add tests

### DIFF
--- a/Test/Test/test_system_utils_file_stream.cpp
+++ b/Test/Test/test_system_utils_file_stream.cpp
@@ -1,0 +1,162 @@
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/system_utils.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+
+extern void su_force_file_stream_allocation_failure(bool should_fail);
+
+static void create_test_file_stream_file(void)
+{
+    FILE *file_handle;
+
+    file_handle = std::fopen("test_su_file_stream.txt", "w");
+    if (file_handle != ft_nullptr)
+    {
+        std::fputs("data", file_handle);
+        std::fclose(file_handle);
+    }
+    return ;
+}
+
+FT_TEST(test_su_fopen_null_path_sets_ft_einval, "su_fopen rejects null path")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, su_fopen(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_su_fopen_propagates_open_error, "su_fopen keeps su_open error")
+{
+    su_file *file_stream;
+
+    ft_errno = ER_SUCCESS;
+    errno = 0;
+    std::remove("missing_su_file_stream.txt");
+    file_stream = su_fopen("missing_su_file_stream.txt");
+    FT_ASSERT_EQ(ft_nullptr, file_stream);
+    FT_ASSERT_EQ(ENOENT + ERRNO_OFFSET, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_su_fopen_allocation_failure_sets_ft_ealloc, "su_fopen reports allocation failure")
+{
+    su_file *file_stream;
+
+    create_test_file_stream_file();
+    ft_errno = ER_SUCCESS;
+    su_force_file_stream_allocation_failure(true);
+    file_stream = su_fopen("test_su_file_stream.txt");
+    su_force_file_stream_allocation_failure(false);
+    FT_ASSERT_EQ(ft_nullptr, file_stream);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_su_fopen_success_clears_errno, "su_fopen clears ft_errno on success")
+{
+    su_file *file_stream;
+
+    create_test_file_stream_file();
+    ft_errno = FT_EINVAL;
+    file_stream = su_fopen("test_su_file_stream.txt");
+    if (file_stream == ft_nullptr)
+        return (0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, su_fclose(file_stream));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_su_fclose_null_stream_sets_ft_einval, "su_fclose rejects null stream")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, su_fclose(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_su_fclose_invalid_descriptor_propagates_error, "su_fclose preserves cmp_close error")
+{
+    su_file *file_stream;
+
+    file_stream = static_cast<su_file*>(std::malloc(sizeof(su_file)));
+    if (file_stream == ft_nullptr)
+        return (0);
+    file_stream->_descriptor = -1;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, su_fclose(file_stream));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    std::free(file_stream);
+    return (1);
+}
+
+FT_TEST(test_su_fread_null_buffer_sets_ft_einval, "su_fread rejects null buffer")
+{
+    su_file *file_stream;
+
+    file_stream = static_cast<su_file*>(std::malloc(sizeof(su_file)));
+    if (file_stream == ft_nullptr)
+        return (0);
+    file_stream->_descriptor = 0;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, su_fread(ft_nullptr, 1, 1, file_stream));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    std::free(file_stream);
+    return (1);
+}
+
+FT_TEST(test_su_fread_null_stream_sets_ft_einval, "su_fread rejects null stream")
+{
+    char buffer[4];
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, su_fread(buffer, 1, 1, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_su_fwrite_null_buffer_sets_ft_einval, "su_fwrite rejects null buffer")
+{
+    su_file *file_stream;
+
+    file_stream = static_cast<su_file*>(std::malloc(sizeof(su_file)));
+    if (file_stream == ft_nullptr)
+        return (0);
+    file_stream->_descriptor = 0;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, su_fwrite(ft_nullptr, 1, 1, file_stream));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    std::free(file_stream);
+    return (1);
+}
+
+FT_TEST(test_su_fwrite_null_stream_sets_ft_einval, "su_fwrite rejects null stream")
+{
+    char buffer[4] = {'t', 'e', 's', 't'};
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(0, su_fwrite(buffer, 1, 4, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_su_fseek_null_stream_sets_ft_einval, "su_fseek rejects null stream")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, su_fseek(ft_nullptr, 0, SEEK_SET));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_su_ftell_null_stream_sets_ft_einval, "su_ftell rejects null stream")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1L, su_ftell(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- propagate `ft_errno` for file stream wrappers, including a test-only toggle for simulating allocation failures
- keep errors from `su_open`/`cmp_close`, clear successes, and validate null arguments
- add unit tests covering all file stream failure paths and the resulting error codes

## Testing
- make -C Test
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68da240e14cc8331b96c0191caec15c1