### PR TITLE
Ensure base64 errno handling and add regression tests

### DIFF
--- a/Compression/compression_base64.cpp
+++ b/Compression/compression_base64.cpp
@@ -1,6 +1,7 @@
 #include "../CMA/CMA.hpp"
 #include "../Libft/libft.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include "compression.hpp"
 
 static int base64_char_value(unsigned char character)
@@ -49,12 +50,19 @@ unsigned char    *ft_base64_encode(const unsigned char *input_buffer, std::size_
     int             has_byte_three;
 
     if (!input_buffer || !encoded_size)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     base64_table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     output_length = ((input_size + 2) / 3) * 4;
     output_buffer = static_cast<unsigned char *>(cma_malloc(output_length + 1));
     if (!output_buffer)
+    {
+        ft_errno = FT_EALLOC;
+        *encoded_size = 0;
         return (ft_nullptr);
+    }
     input_index = 0;
     output_index = 0;
     while (input_index < input_size)
@@ -104,6 +112,7 @@ unsigned char    *ft_base64_encode(const unsigned char *input_buffer, std::size_
     }
     output_buffer[output_index] = '\0';
     *encoded_size = output_index;
+    ft_errno = ER_SUCCESS;
     return (output_buffer);
 }
 
@@ -128,7 +137,10 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
     int             has_char_four;
 
     if (!input_buffer || !decoded_size)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     *decoded_size = 0;
     sanitized_length = 0;
     input_index = 0;
@@ -142,15 +154,28 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
     {
         output_buffer = static_cast<unsigned char *>(cma_malloc(1));
         if (!output_buffer)
+        {
+            ft_errno = FT_EALLOC;
+            *decoded_size = 0;
             return (ft_nullptr);
+        }
+        output_buffer[0] = '\0';
+        ft_errno = ER_SUCCESS;
         return (output_buffer);
     }
     if (sanitized_length % 4 == 1)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     output_length = ((sanitized_length + 3) / 4) * 3;
     output_buffer = static_cast<unsigned char *>(cma_malloc(output_length));
     if (!output_buffer)
+    {
+        ft_errno = FT_EALLOC;
+        *decoded_size = 0;
         return (ft_nullptr);
+    }
     input_index = 0;
     sanitized_index = 0;
     output_index = 0;
@@ -172,18 +197,24 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
         if (chunk_count < 2)
         {
             cma_free(output_buffer);
+            *decoded_size = 0;
+            ft_errno = FT_EINVAL;
             return (ft_nullptr);
         }
         value_one = base64_char_value(chunk[0]);
         if (value_one == -1)
         {
             cma_free(output_buffer);
+            *decoded_size = 0;
+            ft_errno = FT_EINVAL;
             return (ft_nullptr);
         }
         value_two = base64_char_value(chunk[1]);
         if (value_two == -1)
         {
             cma_free(output_buffer);
+            *decoded_size = 0;
+            ft_errno = FT_EINVAL;
             return (ft_nullptr);
         }
         has_char_three = 0;
@@ -214,6 +245,8 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
             if (value_three == -1)
             {
                 cma_free(output_buffer);
+                *decoded_size = 0;
+                ft_errno = FT_EINVAL;
                 return (ft_nullptr);
             }
         }
@@ -225,12 +258,16 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
             if (value_four == -1)
             {
                 cma_free(output_buffer);
+                *decoded_size = 0;
+                ft_errno = FT_EINVAL;
                 return (ft_nullptr);
             }
         }
         if (has_char_three && char_three == '=' && has_char_four && char_four != '=')
         {
             cma_free(output_buffer);
+            *decoded_size = 0;
+            ft_errno = FT_EINVAL;
             return (ft_nullptr);
         }
         if ((has_char_three && char_three == '=') || (has_char_four && char_four == '='))
@@ -238,6 +275,8 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
             if (sanitized_index < sanitized_length)
             {
                 cma_free(output_buffer);
+                *decoded_size = 0;
+                ft_errno = FT_EINVAL;
                 return (ft_nullptr);
             }
         }
@@ -255,5 +294,6 @@ unsigned char    *ft_base64_decode(const unsigned char *input_buffer, std::size_
         }
     }
     *decoded_size = output_index;
+    ft_errno = ER_SUCCESS;
     return (output_buffer);
 }

--- a/Test/Test/test_compression_base64.cpp
+++ b/Test/Test/test_compression_base64.cpp
@@ -1,0 +1,254 @@
+#include "../../Compression/compression.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_base64_encode_null_input_sets_errno, "ft_base64_encode null input sets FT_EINVAL")
+{
+    std::size_t encoded_length;
+
+    encoded_length = 123;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_base64_encode(ft_nullptr, 4, &encoded_length));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(static_cast<std::size_t>(123), encoded_length);
+    return (1);
+}
+
+FT_TEST(test_base64_encode_null_size_sets_errno, "ft_base64_encode null encoded_size sets FT_EINVAL")
+{
+    unsigned char input_buffer[3];
+
+    input_buffer[0] = 'a';
+    input_buffer[1] = 'b';
+    input_buffer[2] = 'c';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_base64_encode(input_buffer, 3, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_encode_allocation_failure_sets_errno, "ft_base64_encode allocation failure sets FT_EALLOC")
+{
+    unsigned char   input_buffer[3];
+    unsigned char   *result_buffer;
+    std::size_t     encoded_length;
+
+    input_buffer[0] = 'A';
+    input_buffer[1] = 'B';
+    input_buffer[2] = 'C';
+    encoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    cma_set_alloc_limit(2);
+    result_buffer = ft_base64_encode(input_buffer, 3, &encoded_length);
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, result_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), encoded_length);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_encode_success_resets_errno, "ft_base64_encode success resets errno")
+{
+    unsigned char   input_buffer[1];
+    unsigned char   *encoded_buffer;
+    std::size_t     encoded_length;
+
+    input_buffer[0] = '\0';
+    encoded_length = 0;
+    ft_errno = FT_EINVAL;
+    encoded_buffer = ft_base64_encode(input_buffer, 0, &encoded_length);
+    FT_ASSERT(encoded_buffer != ft_nullptr);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), encoded_length);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(encoded_buffer);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_null_input_sets_errno, "ft_base64_decode null input sets FT_EINVAL")
+{
+    std::size_t decoded_length;
+
+    decoded_length = 77;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_base64_decode(ft_nullptr, 4, &decoded_length));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(static_cast<std::size_t>(77), decoded_length);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_null_size_sets_errno, "ft_base64_decode null decoded_size sets FT_EINVAL")
+{
+    const unsigned char *input_buffer;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("AAAA");
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_base64_decode(input_buffer, 4, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_empty_input_resets_errno, "ft_base64_decode empty input resets errno")
+{
+    unsigned char   *decoded_buffer;
+    std::size_t     decoded_length;
+
+    decoded_length = 99;
+    ft_errno = FT_EINVAL;
+    decoded_buffer = ft_base64_decode(reinterpret_cast<const unsigned char *>(""), 0, &decoded_length);
+    FT_ASSERT(decoded_buffer != ft_nullptr);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(decoded_buffer);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_short_block_sets_errno, "ft_base64_decode short input sets FT_EINVAL")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("A");
+    decoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    decoded_buffer = ft_base64_decode(input_buffer, 1, &decoded_length);
+    FT_ASSERT_EQ(ft_nullptr, decoded_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_allocation_failure_sets_errno, "ft_base64_decode allocation failure sets FT_EALLOC")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("AAAA");
+    decoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    cma_set_alloc_limit(2);
+    decoded_buffer = ft_base64_decode(input_buffer, 4, &decoded_length);
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, decoded_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_invalid_first_character_sets_errno, "ft_base64_decode invalid first char sets FT_EINVAL")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("!AAA");
+    decoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    decoded_buffer = ft_base64_decode(input_buffer, 4, &decoded_length);
+    FT_ASSERT_EQ(ft_nullptr, decoded_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_invalid_second_character_sets_errno, "ft_base64_decode invalid second char sets FT_EINVAL")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("A!AA");
+    decoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    decoded_buffer = ft_base64_decode(input_buffer, 4, &decoded_length);
+    FT_ASSERT_EQ(ft_nullptr, decoded_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_invalid_third_character_sets_errno, "ft_base64_decode invalid third char sets FT_EINVAL")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("AA!A");
+    decoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    decoded_buffer = ft_base64_decode(input_buffer, 4, &decoded_length);
+    FT_ASSERT_EQ(ft_nullptr, decoded_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_invalid_fourth_character_sets_errno, "ft_base64_decode invalid fourth char sets FT_EINVAL")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("AAA!");
+    decoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    decoded_buffer = ft_base64_decode(input_buffer, 4, &decoded_length);
+    FT_ASSERT_EQ(ft_nullptr, decoded_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_invalid_padding_mismatch_sets_errno, "ft_base64_decode padding mismatch sets FT_EINVAL")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("AA=A");
+    decoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    decoded_buffer = ft_base64_decode(input_buffer, 4, &decoded_length);
+    FT_ASSERT_EQ(ft_nullptr, decoded_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_trailing_data_after_padding_sets_errno, "ft_base64_decode trailing data after padding sets FT_EINVAL")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("AAA=AAAA");
+    decoded_length = 0;
+    ft_errno = ER_SUCCESS;
+    decoded_buffer = ft_base64_decode(input_buffer, 8, &decoded_length);
+    FT_ASSERT_EQ(ft_nullptr, decoded_buffer);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), decoded_length);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_base64_decode_success_resets_errno, "ft_base64_decode success resets errno")
+{
+    const unsigned char   *input_buffer;
+    unsigned char         *decoded_buffer;
+    std::size_t           decoded_length;
+
+    input_buffer = reinterpret_cast<const unsigned char *>("TQ==");
+    decoded_length = 0;
+    ft_errno = FT_EINVAL;
+    decoded_buffer = ft_base64_decode(input_buffer, 4, &decoded_length);
+    FT_ASSERT(decoded_buffer != ft_nullptr);
+    FT_ASSERT_EQ(static_cast<std::size_t>(1), decoded_length);
+    FT_ASSERT_EQ('M', decoded_buffer[0]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(decoded_buffer);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- update the base64 encoder/decoder to report FT_EINVAL and FT_EALLOC on failure and clear ft_errno after successful calls
- ensure decoded-size bookkeeping stays consistent when returning early and add an Errno include
- add regression tests that exercise each failure path and confirm both the sentinel return values and ft_errno updates

## Testing
- make tests *(fails: System_utils_file_stream.cpp lacks a previous declaration when built with -Werror)*

------
https://chatgpt.com/codex/tasks/task_e_68da28250de08331b3a9d4078acee48b