### PR TITLE
Improve rng secure bytes error handling

### DIFF
--- a/Compatebility/Compatebility_rng.cpp
+++ b/Compatebility/Compatebility_rng.cpp
@@ -1,4 +1,5 @@
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include "compatebility_internal.hpp"
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -9,36 +10,127 @@ int cmp_rng_secure_bytes(unsigned char *buffer, size_t length)
     HCRYPTPROV crypt_provider = 0;
     if (CryptAcquireContext(&crypt_provider, ft_nullptr, ft_nullptr,
             PROV_RSA_FULL, CRYPT_VERIFYCONTEXT) == 0)
-        return (-1);
-    if (CryptGenRandom(crypt_provider, static_cast<DWORD>(length), buffer) == 0)
     {
-        CryptReleaseContext(crypt_provider, 0);
+        DWORD last_error = GetLastError();
+        if (last_error != 0)
+            ft_errno = static_cast<int>(last_error) + ERRNO_OFFSET;
+        else
+            ft_errno = FT_EINVAL;
         return (-1);
     }
-    CryptReleaseContext(crypt_provider, 0);
+    if (CryptGenRandom(crypt_provider, static_cast<DWORD>(length), buffer) == 0)
+    {
+        DWORD last_error = GetLastError();
+        CryptReleaseContext(crypt_provider, 0);
+        if (last_error != 0)
+            ft_errno = static_cast<int>(last_error) + ERRNO_OFFSET;
+        else
+            ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    if (CryptReleaseContext(crypt_provider, 0) == 0)
+    {
+        DWORD last_error = GetLastError();
+        if (last_error != 0)
+            ft_errno = static_cast<int>(last_error) + ERRNO_OFFSET;
+        else
+            ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    ft_errno = ER_SUCCESS;
     return (0);
 }
 #else
 # include <unistd.h>
 # include <fcntl.h>
+# include <cerrno>
+
+static int g_force_rng_open_errno = 0;
+static int g_force_rng_read_errno = 0;
+static int g_force_rng_close_errno = 0;
+
+void cmp_force_rng_open_failure(int error_code)
+{
+    g_force_rng_open_errno = error_code;
+    return ;
+}
+
+void cmp_force_rng_read_failure(int error_code)
+{
+    g_force_rng_read_errno = error_code;
+    return ;
+}
+
+void cmp_force_rng_close_failure(int error_code)
+{
+    g_force_rng_close_errno = error_code;
+    return ;
+}
+
+void cmp_clear_force_rng_failures(void)
+{
+    g_force_rng_open_errno = 0;
+    g_force_rng_read_errno = 0;
+    g_force_rng_close_errno = 0;
+    return ;
+}
 int cmp_rng_secure_bytes(unsigned char *buffer, size_t length)
 {
+    int forced_open_errno = g_force_rng_open_errno;
+    g_force_rng_open_errno = 0;
+    if (forced_open_errno != 0)
+    {
+        errno = forced_open_errno;
+        ft_errno = errno + ERRNO_OFFSET;
+        return (-1);
+    }
     int file_descriptor = open("/dev/urandom", O_RDONLY);
     if (file_descriptor < 0)
+    {
+        ft_errno = errno + ERRNO_OFFSET;
         return (-1);
+    }
     size_t offset = 0;
     while (offset < length)
     {
+        int forced_read_errno = g_force_rng_read_errno;
+        if (forced_read_errno != 0)
+        {
+            g_force_rng_read_errno = 0;
+            errno = forced_read_errno;
+            ft_errno = errno + ERRNO_OFFSET;
+            int stored_errno = errno;
+            close(file_descriptor);
+            errno = stored_errno;
+            return (-1);
+        }
         ssize_t bytes_read = read(file_descriptor, buffer + offset,
             length - offset);
         if (bytes_read < 0)
         {
+            ft_errno = errno + ERRNO_OFFSET;
+            int stored_errno = errno;
             close(file_descriptor);
+            errno = stored_errno;
             return (-1);
         }
         offset += static_cast<size_t>(bytes_read);
     }
-    close(file_descriptor);
+    int close_result = close(file_descriptor);
+    if (close_result < 0)
+    {
+        ft_errno = errno + ERRNO_OFFSET;
+        return (-1);
+    }
+    int forced_close_errno = g_force_rng_close_errno;
+    g_force_rng_close_errno = 0;
+    if (forced_close_errno != 0)
+    {
+        errno = forced_close_errno;
+        ft_errno = errno + ERRNO_OFFSET;
+        return (-1);
+    }
+    ft_errno = ER_SUCCESS;
     return (0);
 }
 #endif

--- a/Compatebility/compatebility_internal.hpp
+++ b/Compatebility/compatebility_internal.hpp
@@ -78,6 +78,12 @@ void cmp_readline_disable_raw_mode(void);
 int cmp_readline_terminal_width(void);
 
 int cmp_rng_secure_bytes(unsigned char *buffer, size_t length);
+#if !defined(_WIN32) && !defined(_WIN64)
+void cmp_force_rng_open_failure(int error_code);
+void cmp_force_rng_read_failure(int error_code);
+void cmp_force_rng_close_failure(int error_code);
+void cmp_clear_force_rng_failures(void);
+#endif
 
 int cmp_setenv(const char *name, const char *value, int overwrite);
 int cmp_unsetenv(const char *name);

--- a/RNG/rng_secure_bytes.cpp
+++ b/RNG/rng_secure_bytes.cpp
@@ -1,11 +1,21 @@
 #include "rng.hpp"
 #include "../Compatebility/compatebility_internal.hpp"
+#include "../Errno/errno.hpp"
 
 int rng_secure_bytes(unsigned char *buffer, size_t length)
 {
     if (buffer == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (-1);
-    return (cmp_rng_secure_bytes(buffer, length));
+    }
+    int result = cmp_rng_secure_bytes(buffer, length);
+    if (result == 0)
+    {
+        ft_errno = ER_SUCCESS;
+        return (0);
+    }
+    return (result);
 }
 
 uint32_t ft_random_uint32(void)

--- a/Test/Test/test_rng_secure_bytes.cpp
+++ b/Test/Test/test_rng_secure_bytes.cpp
@@ -1,0 +1,74 @@
+#include "../../RNG/rng.hpp"
+#include "../../Compatebility/compatebility_internal.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+#include <cerrno>
+
+FT_TEST(test_rng_secure_bytes_null_buffer_sets_ft_einval, "rng_secure_bytes null buffer sets FT_EINVAL")
+{
+    ft_errno = ER_SUCCESS;
+    if (rng_secure_bytes(ft_nullptr, 16) != -1)
+        return (0);
+    if (ft_errno != FT_EINVAL)
+        return (0);
+    return (1);
+}
+
+FT_TEST(test_rng_secure_bytes_success_clears_errno, "rng_secure_bytes success clears ft_errno")
+{
+    unsigned char buffer[8];
+    ft_errno = FT_EINVAL;
+    if (rng_secure_bytes(buffer, 8) != 0)
+        return (0);
+    if (ft_errno != ER_SUCCESS)
+        return (0);
+    return (1);
+}
+
+#if !defined(_WIN32) && !defined(_WIN64)
+FT_TEST(test_rng_secure_bytes_open_failure_propagates_errno, "rng_secure_bytes propagates open failures")
+{
+    unsigned char buffer[4];
+    cmp_clear_force_rng_failures();
+    ft_errno = ER_SUCCESS;
+    cmp_force_rng_open_failure(EACCES);
+    int result = rng_secure_bytes(buffer, 4);
+    cmp_clear_force_rng_failures();
+    if (result != -1)
+        return (0);
+    if (ft_errno != EACCES + ERRNO_OFFSET)
+        return (0);
+    return (1);
+}
+
+FT_TEST(test_rng_secure_bytes_read_failure_propagates_errno, "rng_secure_bytes propagates read failures")
+{
+    unsigned char buffer[4];
+    cmp_clear_force_rng_failures();
+    ft_errno = ER_SUCCESS;
+    cmp_force_rng_read_failure(EIO);
+    int result = rng_secure_bytes(buffer, 4);
+    cmp_clear_force_rng_failures();
+    if (result != -1)
+        return (0);
+    if (ft_errno != EIO + ERRNO_OFFSET)
+        return (0);
+    return (1);
+}
+
+FT_TEST(test_rng_secure_bytes_close_failure_propagates_errno, "rng_secure_bytes propagates close failures")
+{
+    unsigned char buffer[4];
+    cmp_clear_force_rng_failures();
+    ft_errno = ER_SUCCESS;
+    cmp_force_rng_close_failure(EBADF);
+    int result = rng_secure_bytes(buffer, 4);
+    cmp_clear_force_rng_failures();
+    if (result != -1)
+        return (0);
+    if (ft_errno != EBADF + ERRNO_OFFSET)
+        return (0);
+    return (1);
+}
+#endif


### PR DESCRIPTION
## Summary
- translate operating system errors in `cmp_rng_secure_bytes` and clear `ft_errno` on success
- ensure `rng_secure_bytes` reports `FT_EINVAL` for null buffers and preserves compatibility errors
- add regression tests that cover success, null input, and forced open/read/close failures

## Testing
- g++ -Wall -Wextra -Werror -std=c++17 -c Compatebility/Compatebility_rng.cpp -o /tmp/Compatebility_rng.o
- g++ -Wall -Wextra -Werror -std=c++17 -c RNG/rng_secure_bytes.cpp -o /tmp/rng_secure_bytes.o
- make -C Test objs/Test/test_rng_secure_bytes.o


------
https://chatgpt.com/codex/tasks/task_e_68da3dbe39b48331b69cdde81a6fe9ea