### PR TITLE
Handle time_strftime error conditions

### DIFF
--- a/Test/Test/test_time_strftime.cpp
+++ b/Test/Test/test_time_strftime.cpp
@@ -1,0 +1,84 @@
+#include "../../System_utils/test_runner.hpp"
+#include "../../Time/time.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+
+static t_time_info create_sample_time_info(void)
+{
+    t_time_info sample_time_info;
+
+    sample_time_info.seconds = 0;
+    sample_time_info.minutes = 0;
+    sample_time_info.hours = 0;
+    sample_time_info.month_day = 1;
+    sample_time_info.month = 0;
+    sample_time_info.year = 0;
+    sample_time_info.week_day = 0;
+    sample_time_info.year_day = 0;
+    sample_time_info.is_daylight_saving = 0;
+    return (sample_time_info);
+}
+
+FT_TEST(test_time_strftime_null_buffer_sets_errno, "time_strftime null buffer sets FT_EINVAL")
+{
+    t_time_info sample_time_info;
+
+    sample_time_info = create_sample_time_info();
+    ft_errno = ER_SUCCESS;
+    size_t format_result = time_strftime(static_cast<char *>(ft_nullptr), 16, "%Y", &sample_time_info);
+    FT_ASSERT_EQ(static_cast<size_t>(0), format_result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_strftime_zero_size_sets_errno, "time_strftime zero size sets FT_EINVAL")
+{
+    char buffer[8];
+    t_time_info sample_time_info;
+
+    buffer[0] = 'X';
+    sample_time_info = create_sample_time_info();
+    ft_errno = ER_SUCCESS;
+    size_t format_result = time_strftime(buffer, 0, "%Y", &sample_time_info);
+    FT_ASSERT_EQ(static_cast<size_t>(0), format_result);
+    FT_ASSERT_EQ('X', buffer[0]);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_strftime_null_format_sets_errno, "time_strftime null format sets FT_EINVAL")
+{
+    char buffer[8];
+    t_time_info sample_time_info;
+
+    buffer[0] = 'X';
+    sample_time_info = create_sample_time_info();
+    ft_errno = ER_SUCCESS;
+    size_t format_result = time_strftime(buffer, sizeof(buffer), static_cast<const char *>(ft_nullptr), &sample_time_info);
+    FT_ASSERT_EQ(static_cast<size_t>(0), format_result);
+    FT_ASSERT_EQ('X', buffer[0]);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_strftime_success_resets_errno, "time_strftime success resets errno")
+{
+    char buffer[32];
+    t_time_info sample_time_info;
+    const char  *expected_string;
+    size_t  expected_length;
+
+    sample_time_info = create_sample_time_info();
+    sample_time_info.year = 124;
+    sample_time_info.month = 10;
+    sample_time_info.month_day = 5;
+    ft_errno = FT_EINVAL;
+    size_t format_result = time_strftime(buffer, sizeof(buffer), "%Y-%m-%d", &sample_time_info);
+    expected_string = "2024-11-05";
+    expected_length = ft_strlen(expected_string);
+    FT_ASSERT_EQ(expected_length, format_result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, ft_strcmp(expected_string, buffer));
+    return (1);
+}

--- a/Time/time_strftime.cpp
+++ b/Time/time_strftime.cpp
@@ -1,6 +1,7 @@
 #include "time.hpp"
 #include "../Libft/libft.hpp"
 #include "../Printf/printf.hpp"
+#include "../Errno/errno.hpp"
 
 size_t  time_strftime(char *buffer, size_t size, const char *format, const t_time_info *time_info)
 {
@@ -11,7 +12,10 @@ size_t  time_strftime(char *buffer, size_t size, const char *format, const t_tim
     int     value;
 
     if (!buffer || size == 0 || !format || !time_info)
+    {
+        ft_errno = FT_EINVAL;
         return (0);
+    }
     format_index = 0;
     output_index = 0;
     while (format[format_index] && output_index + 1 < size)
@@ -43,10 +47,20 @@ size_t  time_strftime(char *buffer, size_t size, const char *format, const t_tim
                     format_index++;
                     continue;
                 }
+                int snprintf_result;
+
                 if (format[format_index + 1] == 'Y')
-                    pf_snprintf(number_buffer, sizeof(number_buffer), "%04d", value);
+                    snprintf_result = pf_snprintf(number_buffer, sizeof(number_buffer), "%04d", value);
                 else
-                    pf_snprintf(number_buffer, sizeof(number_buffer), "%02d", value);
+                    snprintf_result = pf_snprintf(number_buffer, sizeof(number_buffer), "%02d", value);
+                if (snprintf_result < 0 || ft_errno != ER_SUCCESS)
+                {
+                    if (output_index < size)
+                        buffer[output_index] = '\0';
+                    else if (size > 0)
+                        buffer[size - 1] = '\0';
+                    return (0);
+                }
                 length = ft_strlen(number_buffer);
                 size_t number_index;
 
@@ -68,6 +82,7 @@ size_t  time_strftime(char *buffer, size_t size, const char *format, const t_tim
         }
     }
     buffer[output_index] = '\0';
+    ft_errno = ER_SUCCESS;
     return (output_index);
 }
 


### PR DESCRIPTION
## Summary
- set `ft_errno` to `FT_EINVAL` when `time_strftime` receives invalid pointers or buffer sizes
- stop formatting when `pf_snprintf` reports an error and reset `ft_errno` on successful completion
- add targeted tests that cover invalid arguments and successful formatting behaviour

## Testing
- `make -C Test objs/Test/test_time_strftime.o`


------
https://chatgpt.com/codex/tasks/task_e_68da812ad68883319bc3827e13dd9415