### PR TITLE
Handle encryption error propagation

### DIFF
--- a/Encryption/basic_encryption.hpp
+++ b/Encryption/basic_encryption.hpp
@@ -1,14 +1,21 @@
 #ifndef BASIC_ENCRYPTION_HPP
 #define BASIC_ENCRYPTION_HPP
 
+#include <cstddef>
+#include <sys/types.h>
 #include "aes.hpp"
 #include "rsa.hpp"
 #include "encryption_sha256.hpp"
 #include "encryption_hmac_sha256.hpp"
 
+typedef int (*t_be_open_function)(const char *path_name, int flags, mode_t mode);
+typedef ssize_t (*t_be_write_function)(int file_descriptor, const void *buffer, size_t count);
+
 int            be_saveGame(const char *filename, const char *data, const char *key);
 char        **be_DecryptData(char **data, const char *key);
 const char    *be_getEncryptionKey();
+void            be_set_save_game_hooks(t_be_open_function open_function,
+                    t_be_write_function write_function);
 
 
 

--- a/Encryption/encryption_basic_encryption.cpp
+++ b/Encryption/encryption_basic_encryption.cpp
@@ -7,7 +7,34 @@
 #include "../System_utils/system_utils.hpp"
 #include "../Compatebility/compatebility_internal.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include "basic_encryption.hpp"
+
+static int be_default_open(const char *path_name, int flags, mode_t mode)
+{
+    return (su_open(path_name, flags, mode));
+}
+
+static ssize_t be_default_write(int file_descriptor, const void *buffer, size_t count)
+{
+    return (su_write(file_descriptor, buffer, count));
+}
+
+static t_be_open_function g_be_open_function = be_default_open;
+static t_be_write_function g_be_write_function = be_default_write;
+
+void be_set_save_game_hooks(t_be_open_function open_function, t_be_write_function write_function)
+{
+    if (open_function != ft_nullptr)
+        g_be_open_function = open_function;
+    else
+        g_be_open_function = be_default_open;
+    if (write_function != ft_nullptr)
+        g_be_write_function = write_function;
+    else
+        g_be_write_function = be_default_write;
+    return ;
+}
 
 static void be_encrypt(char *data, size_t data_length, const char *key)
 {
@@ -32,29 +59,41 @@ int be_saveGame(const char *filename, const char *data, const char *key)
 {
     size_t data_length = ft_strlen(data);
     char *encrypted_data = static_cast<char *>(cma_malloc(data_length));
-    if (!encrypted_data)
+    if (encrypted_data == ft_nullptr)
+    {
+        ft_errno = FT_EALLOC;
         return (1);
+    }
     ft_memcpy(encrypted_data, data, data_length);
     be_encrypt(encrypted_data, data_length, key);
-    int file_descriptor = su_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    int file_descriptor = g_be_open_function(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (file_descriptor < 0)
     {
         cma_free(encrypted_data);
         return (1);
     }
-    ssize_t bytes_written = su_write(file_descriptor, encrypted_data, static_cast<int>(data_length));
+    ssize_t bytes_written = g_be_write_function(file_descriptor, encrypted_data, static_cast<int>(data_length));
+    int write_errno = ft_errno;
     cmp_close(file_descriptor);
     cma_free(encrypted_data);
     if (bytes_written == static_cast<ssize_t>(data_length))
+    {
+        ft_errno = ER_SUCCESS;
         return (0);
+    }
+    ft_errno = write_errno;
     return (1);
 }
 
 char **be_DecryptData(char **data, const char *key)
 {
-    if (!data || !*data)
+    if (data == ft_nullptr || *data == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     size_t data_length = ft_strlen(*data);
     be_encrypt(*data, data_length, key);
+    ft_errno = ER_SUCCESS;
     return (data);
 }

--- a/Encryption/encryption_key.cpp
+++ b/Encryption/encryption_key.cpp
@@ -4,6 +4,7 @@
 #include "../RNG/rng.hpp"
 #include "../CMA/CMA.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include "basic_encryption.hpp"
 #include "../Compatebility/compatebility_internal.hpp"
 
@@ -11,8 +12,11 @@ const char *be_getEncryptionKey(void)
 {
     size_t key_length = 32;
     char *key = static_cast<char *>(cma_malloc(key_length + 1));
-    if (!key)
+    if (key == ft_nullptr)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     if (cmp_rng_secure_bytes(reinterpret_cast<unsigned char *>(key), key_length) == 0)
     {
         size_t index = 0;
@@ -23,8 +27,10 @@ const char *be_getEncryptionKey(void)
             index++;
         }
         key[key_length] = '\0';
+        ft_errno = ER_SUCCESS;
         return (key);
     }
+    int secure_error = ft_errno;
     uint32_t seed_value = ft_random_seed(ft_nullptr);
     size_t index = 0;
     while (index < key_length)
@@ -34,5 +40,7 @@ const char *be_getEncryptionKey(void)
         index++;
     }
     key[key_length] = '\0';
+    ft_errno = secure_error;
+    ft_errno = ER_SUCCESS;
     return (key);
 }

--- a/Test/Test/test_encryption_basic.cpp
+++ b/Test/Test/test_encryption_basic.cpp
@@ -1,0 +1,96 @@
+#include "../../Encryption/basic_encryption.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cstdio>
+
+static int mock_open_failure(const char *path_name, int flags, mode_t mode)
+{
+    (void)path_name;
+    (void)flags;
+    (void)mode;
+    ft_errno = FT_EIO;
+    return (-1);
+}
+
+static ssize_t mock_write_failure(int file_descriptor, const void *buffer, size_t count)
+{
+    (void)file_descriptor;
+    (void)buffer;
+    (void)count;
+    ft_errno = FT_EIO;
+    return (-1);
+}
+
+FT_TEST(test_be_get_encryption_key_allocation_failure_sets_errno,
+    "be_getEncryptionKey reports allocator failure")
+{
+    const char *key;
+
+    ft_errno = ER_SUCCESS;
+    cma_set_alloc_limit(1);
+    key = be_getEncryptionKey();
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, key);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_be_save_game_allocation_failure_sets_errno,
+    "be_saveGame reports allocator failure")
+{
+    int save_result;
+
+    ft_errno = ER_SUCCESS;
+    cma_set_alloc_limit(1);
+    save_result = be_saveGame("be_save_game_alloc.txt", "data", "key");
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(1, save_result);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_be_save_game_open_failure_preserves_errno,
+    "be_saveGame keeps su_open error code")
+{
+    int save_result;
+
+    ft_errno = ER_SUCCESS;
+    be_set_save_game_hooks(mock_open_failure, ft_nullptr);
+    save_result = be_saveGame("be_save_game_open.txt", "data", "key");
+    be_set_save_game_hooks(ft_nullptr, ft_nullptr);
+    FT_ASSERT_EQ(1, save_result);
+    FT_ASSERT_EQ(FT_EIO, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_be_save_game_write_failure_preserves_errno,
+    "be_saveGame keeps su_write error code")
+{
+    int save_result;
+
+    ft_errno = ER_SUCCESS;
+    be_set_save_game_hooks(ft_nullptr, mock_write_failure);
+    save_result = be_saveGame("be_save_game_write.txt", "data", "key");
+    be_set_save_game_hooks(ft_nullptr, ft_nullptr);
+    std::remove("be_save_game_write.txt");
+    FT_ASSERT_EQ(1, save_result);
+    FT_ASSERT_EQ(FT_EIO, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_be_decrypt_data_null_input_sets_errno,
+    "be_DecryptData rejects null buffers")
+{
+    char *missing_buffer = ft_nullptr;
+    char **wrapper = &missing_buffer;
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, be_DecryptData(ft_nullptr, "key"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, be_DecryptData(wrapper, "key"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- set `ft_errno` on allocation, I/O, and validation failures in the basic encryption helpers while exposing hooks so tests can stub file operations
- ensure the key generator reports allocator errors and clears success when returning a generated buffer
- add regression tests that force allocator, open/write, and null-input failures to verify both return values and `ft_errno`

## Testing
- `make -C Test`
- `Test/libft_tests` *(fails: existing suite has several KO cases unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68da8e008e188331b9d2a68e4a61ea60