### PR TITLE
Handle errno propagation in JSON writer

### DIFF
--- a/JSon/json_writer.cpp
+++ b/JSon/json_writer.cpp
@@ -11,6 +11,14 @@
 #include "../CPP_class/class_nullptr.hpp"
 #include "../CPP_class/class_big_number.hpp"
 #include "../CMA/CMA.hpp"
+#include "../Errno/errno.hpp"
+
+static char *json_writer_return_failure(void)
+{
+    if (ft_errno == ER_SUCCESS)
+        ft_errno = FT_EALLOC;
+    return (ft_nullptr);
+}
 
 int json_write_to_file(const char *file_path, json_group *groups)
 {
@@ -67,7 +75,7 @@ char *json_write_to_string(json_group *groups)
 {
     char *result = cma_strdup("{\n");
     if (!result)
-        return (ft_nullptr);
+        return (json_writer_return_failure());
     json_group *group_iterator = groups;
     while (group_iterator)
     {
@@ -75,13 +83,13 @@ char *json_write_to_string(json_group *groups)
         if (!line)
         {
             cma_free(result);
-            return (ft_nullptr);
+            return (json_writer_return_failure());
         }
         char *temporary = cma_strjoin(result, line);
         cma_free(result);
         cma_free(line);
         if (!temporary)
-            return (ft_nullptr);
+            return (json_writer_return_failure());
         result = temporary;
         json_item *item_iterator = group_iterator->items;
         while (item_iterator)
@@ -110,13 +118,13 @@ char *json_write_to_string(json_group *groups)
             if (!line)
             {
                 cma_free(result);
-                return (ft_nullptr);
+                return (json_writer_return_failure());
             }
             temporary = cma_strjoin(result, line);
             cma_free(result);
             cma_free(line);
             if (!temporary)
-                return (ft_nullptr);
+                return (json_writer_return_failure());
             result = temporary;
             item_iterator = item_iterator->next;
         }
@@ -127,13 +135,13 @@ char *json_write_to_string(json_group *groups)
         if (!line)
         {
             cma_free(result);
-            return (ft_nullptr);
+            return (json_writer_return_failure());
         }
         temporary = cma_strjoin(result, line);
         cma_free(result);
         cma_free(line);
         if (!temporary)
-            return (ft_nullptr);
+            return (json_writer_return_failure());
         result = temporary;
         group_iterator = group_iterator->next;
     }
@@ -141,14 +149,15 @@ char *json_write_to_string(json_group *groups)
     if (!end_line)
     {
         cma_free(result);
-        return (ft_nullptr);
+        return (json_writer_return_failure());
     }
     char *temporary = cma_strjoin(result, end_line);
     cma_free(result);
     cma_free(end_line);
     if (!temporary)
-        return (ft_nullptr);
+        return (json_writer_return_failure());
     result = temporary;
+    ft_errno = ER_SUCCESS;
     return (result);
 }
 

--- a/Test/Test/test_json_writer.cpp
+++ b/Test/Test/test_json_writer.cpp
@@ -1,0 +1,61 @@
+#include "../../JSon/json.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+static json_group *create_sample_group(void)
+{
+    json_group *group = json_create_json_group("sample");
+    if (!group)
+        return (ft_nullptr);
+    json_item *item = json_create_item("key", "value");
+    if (!item)
+    {
+        json_free_groups(group);
+        return (ft_nullptr);
+    }
+    json_add_item_to_group(group, item);
+    return (group);
+}
+
+FT_TEST(test_json_write_to_string_initial_alloc_failure_sets_errno, "json_write_to_string reports errno when the initial buffer allocation fails")
+{
+    ft_errno = ER_SUCCESS;
+    cma_set_alloc_limit(1);
+    char *result = json_write_to_string(ft_nullptr);
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, result);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_json_write_to_string_midway_failure_preserves_errno, "json_write_to_string keeps the allocator errno on intermediate failures")
+{
+    json_group *group = create_sample_group();
+    FT_ASSERT(group != ft_nullptr);
+    ft_errno = ER_SUCCESS;
+    cma_set_alloc_limit(16);
+    char *result = json_write_to_string(group);
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, result);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    json_free_groups(group);
+    return (1);
+}
+
+FT_TEST(test_json_write_to_string_success_resets_errno, "json_write_to_string clears errno after a successful serialization")
+{
+    json_group *group = create_sample_group();
+    FT_ASSERT(group != ft_nullptr);
+    ft_errno = FT_EINVAL;
+    char *result = json_write_to_string(group);
+    FT_ASSERT(result != ft_nullptr);
+    const char *expected = "{\n  \"sample\": {\n    \"key\": \"value\"\n  }\n}\n";
+    FT_ASSERT_EQ(0, ft_strcmp(expected, result));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(result);
+    json_free_groups(group);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- ensure `json_write_to_string` propagates allocation errors via `ft_errno` and clears it on success
- add unit tests that cover allocator failures and the success path for the JSON writer

## Testing
- `make -C Test`


------
https://chatgpt.com/codex/tasks/task_e_68da9121697c83318a484745339c965b