### PR TITLE
Improve XML write error handling and tests

### DIFF
--- a/Test/Test/test_xml_document.cpp
+++ b/Test/Test/test_xml_document.cpp
@@ -1,0 +1,91 @@
+#include "../../XML/xml.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cerrno>
+
+FT_TEST(test_xml_document_write_to_string_empty_document_sets_error, "xml_document::write_to_string reports FT_EINVAL when empty")
+{
+    xml_document document;
+    char *result;
+
+    ft_errno = ER_SUCCESS;
+    result = document.write_to_string();
+    FT_ASSERT(result == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, document.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_xml_document_write_to_file_empty_document_sets_error, "xml_document::write_to_file reports FT_EINVAL when empty")
+{
+    xml_document document;
+    int result;
+
+    ft_errno = ER_SUCCESS;
+    result = document.write_to_file("Test");
+    FT_ASSERT_EQ(FT_EINVAL, result);
+    FT_ASSERT_EQ(FT_EINVAL, document.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_xml_document_write_to_string_allocation_failure_sets_error, "xml_document::write_to_string reports FT_EALLOC when allocation fails")
+{
+    xml_document document;
+    char *result;
+
+    FT_ASSERT_EQ(ER_SUCCESS, document.load_from_string("<root/>"));
+    ft_errno = ER_SUCCESS;
+    cma_set_alloc_limit(1);
+    result = document.write_to_string();
+    cma_set_alloc_limit(0);
+    FT_ASSERT(result == ft_nullptr);
+    FT_ASSERT_EQ(FT_EALLOC, document.get_error());
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_xml_document_write_to_file_fopen_failure_sets_errno_offset, "xml_document::write_to_file reports errno on fopen failure")
+{
+    xml_document document;
+    int result;
+    int open_errno;
+
+    FT_ASSERT_EQ(ER_SUCCESS, document.load_from_string("<root/>"));
+    ft_errno = ER_SUCCESS;
+    errno = 0;
+    result = document.write_to_file("Test");
+    open_errno = errno;
+    FT_ASSERT(result != ER_SUCCESS);
+    FT_ASSERT_EQ(result, document.get_error());
+    FT_ASSERT_EQ(result, ft_errno);
+    if (open_errno != 0)
+        FT_ASSERT_EQ(open_errno + ERRNO_OFFSET, result);
+    else
+        FT_ASSERT_EQ(FT_EINVAL, result);
+    return (1);
+}
+
+FT_TEST(test_xml_document_write_to_file_fwrite_failure_sets_errno_offset, "xml_document::write_to_file reports errno on fwrite failure")
+{
+    xml_document document;
+    int result;
+    int write_errno;
+
+    FT_ASSERT_EQ(ER_SUCCESS, document.load_from_string("<root/>"));
+    ft_errno = ER_SUCCESS;
+    errno = 0;
+    result = document.write_to_file("/dev/full");
+    write_errno = errno;
+    FT_ASSERT(result != ER_SUCCESS);
+    FT_ASSERT_EQ(result, document.get_error());
+    FT_ASSERT_EQ(result, ft_errno);
+    if (write_errno != 0)
+        FT_ASSERT_EQ(write_errno + ERRNO_OFFSET, result);
+    else
+        FT_ASSERT_EQ(FT_EINVAL, result);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- ensure `xml_document::write_to_string` and `xml_document::write_to_file` use `set_error` to report failures and success
- add regression tests for empty documents, allocation failure, and `fopen`/`fwrite` error paths

## Testing
- `make -C XML`


------
https://chatgpt.com/codex/tasks/task_e_68da95d440f88331adc9d1715ff059f9