### PR TITLE
Fix errno handling in game serialization helpers

### DIFF
--- a/Game/game_save.cpp
+++ b/Game/game_save.cpp
@@ -92,85 +92,98 @@ json_group *serialize_inventory(const ft_inventory &inventory)
         ft_errno = JSON_MALLOC_FAIL;
         return (ft_nullptr);
     }
-    json_item *capacity_item = json_create_item("capacity", static_cast<int>(inventory.get_capacity()));
-    if (!capacity_item)
+    bool has_error = false;
+    int error_code = ER_SUCCESS;
+    do
     {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, capacity_item);
-    json_item *weight_limit_item = json_create_item("weight_limit", inventory.get_weight_limit());
-    if (!weight_limit_item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, weight_limit_item);
-    json_item *current_weight_item = json_create_item("current_weight", inventory.get_current_weight());
-    if (!current_weight_item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, current_weight_item);
-    json_item *used_slots_item = json_create_item("used_slots", static_cast<int>(inventory.get_used()));
-    if (!used_slots_item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, used_slots_item);
-    size_t item_count = inventory.get_items().size();
-    json_item *count_item = json_create_item("item_count", static_cast<int>(item_count));
-    if (!count_item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, count_item);
-    size_t item_index = 0;
-    const Pair<int, ft_sharedptr<ft_item> > *items_end = inventory.get_items().end();
-    const Pair<int, ft_sharedptr<ft_item> > *item_start = items_end;
-    if (item_count > 0)
-    {
-        if (!items_end)
+        json_item *capacity_item = json_create_item("capacity", static_cast<int>(inventory.get_capacity()));
+        if (!capacity_item)
         {
-            json_free_groups(group);
-            ft_errno = GAME_GENERAL_ERROR;
-            return (ft_nullptr);
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
         }
-        item_start = items_end - item_count;
-    }
-    while (item_index < item_count)
+        json_add_item_to_group(group, capacity_item);
+        json_item *weight_limit_item = json_create_item("weight_limit", inventory.get_weight_limit());
+        if (!weight_limit_item)
+        {
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
+        }
+        json_add_item_to_group(group, weight_limit_item);
+        json_item *current_weight_item = json_create_item("current_weight", inventory.get_current_weight());
+        if (!current_weight_item)
+        {
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
+        }
+        json_add_item_to_group(group, current_weight_item);
+        json_item *used_slots_item = json_create_item("used_slots", static_cast<int>(inventory.get_used()));
+        if (!used_slots_item)
+        {
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
+        }
+        json_add_item_to_group(group, used_slots_item);
+        size_t item_count = inventory.get_items().size();
+        json_item *count_item = json_create_item("item_count", static_cast<int>(item_count));
+        if (!count_item)
+        {
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
+        }
+        json_add_item_to_group(group, count_item);
+        const Pair<int, ft_sharedptr<ft_item> > *items_end = inventory.get_items().end();
+        const Pair<int, ft_sharedptr<ft_item> > *item_start = items_end;
+        if (item_count > 0)
+        {
+            if (!items_end)
+            {
+                error_code = GAME_GENERAL_ERROR;
+                has_error = true;
+                break;
+            }
+            item_start = items_end - item_count;
+        }
+        size_t item_index = 0;
+        while (item_index < item_count)
+        {
+            char *item_index_string = cma_itoa(static_cast<int>(item_index));
+            if (!item_index_string)
+            {
+                error_code = JSON_MALLOC_FAIL;
+                has_error = true;
+                break;
+            }
+            ft_string item_prefix = "item_";
+            item_prefix += item_index_string;
+            cma_free(item_index_string);
+            if (!item_start[item_index].value)
+            {
+                error_code = GAME_GENERAL_ERROR;
+                has_error = true;
+                break;
+            }
+            if (serialize_item_fields(group, *item_start[item_index].value, item_prefix) != ER_SUCCESS)
+            {
+                error_code = JSON_MALLOC_FAIL;
+                has_error = true;
+                break;
+            }
+            item_index++;
+        }
+        if (has_error)
+            break;
+    } while (0);
+    if (has_error)
     {
-        char *item_index_string = cma_itoa(static_cast<int>(item_index));
-        if (!item_index_string)
-        {
-            json_free_groups(group);
-            ft_errno = JSON_MALLOC_FAIL;
-            return (ft_nullptr);
-        }
-        ft_string item_prefix = "item_";
-        item_prefix += item_index_string;
-        cma_free(item_index_string);
-        if (!item_start[item_index].value)
-        {
-            json_free_groups(group);
-            ft_errno = GAME_GENERAL_ERROR;
-            return (ft_nullptr);
-        }
-        if (serialize_item_fields(group, *item_start[item_index].value, item_prefix) != ER_SUCCESS)
-        {
-            json_free_groups(group);
-            ft_errno = JSON_MALLOC_FAIL;
-            return (ft_nullptr);
-        }
-        item_index++;
+        json_free_groups(group);
+        ft_errno = error_code;
+        return (ft_nullptr);
     }
     ft_errno = ER_SUCCESS;
     return (group);
@@ -241,97 +254,110 @@ json_group *serialize_quest(const ft_quest &quest)
         ft_errno = JSON_MALLOC_FAIL;
         return (ft_nullptr);
     }
-    json_item *item = json_create_item("id", quest.get_id());
-    if (!item)
+    bool has_error = false;
+    int error_code = ER_SUCCESS;
+    do
     {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, item);
-    item = json_create_item("phases", quest.get_phases());
-    if (!item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, item);
-    item = json_create_item("current_phase", quest.get_current_phase());
-    if (!item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, item);
-    item = json_create_item("description", quest.get_description().c_str());
-    if (!item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, item);
-    item = json_create_item("objective", quest.get_objective().c_str());
-    if (!item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, item);
-    item = json_create_item("reward_experience", quest.get_reward_experience());
-    if (!item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, item);
-    size_t item_count = quest.get_reward_items().size();
-    item = json_create_item("reward_item_count", static_cast<int>(item_count));
-    if (!item)
-    {
-        json_free_groups(group);
-        ft_errno = JSON_MALLOC_FAIL;
-        return (ft_nullptr);
-    }
-    json_add_item_to_group(group, item);
-    size_t item_index = 0;
-    const ft_vector<ft_sharedptr<ft_item> > &reward_items = quest.get_reward_items();
-    const ft_sharedptr<ft_item> *item_start = reward_items.begin();
-    if (item_count > 0 && !item_start)
-    {
-        json_free_groups(group);
-        ft_errno = GAME_GENERAL_ERROR;
-        return (ft_nullptr);
-    }
-    while (item_index < item_count)
-    {
-        char *item_index_string = cma_itoa(static_cast<int>(item_index));
-        if (!item_index_string)
+        json_item *item = json_create_item("id", quest.get_id());
+        if (!item)
         {
-            json_free_groups(group);
-            ft_errno = JSON_MALLOC_FAIL;
-            return (ft_nullptr);
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
         }
-        ft_string item_prefix = "reward_item_";
-        item_prefix += item_index_string;
-        cma_free(item_index_string);
-        if (!item_start[item_index])
+        json_add_item_to_group(group, item);
+        item = json_create_item("phases", quest.get_phases());
+        if (!item)
         {
-            json_free_groups(group);
-            ft_errno = GAME_GENERAL_ERROR;
-            return (ft_nullptr);
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
         }
-        if (serialize_item_fields(group, *item_start[item_index], item_prefix) != ER_SUCCESS)
+        json_add_item_to_group(group, item);
+        item = json_create_item("current_phase", quest.get_current_phase());
+        if (!item)
         {
-            json_free_groups(group);
-            ft_errno = JSON_MALLOC_FAIL;
-            return (ft_nullptr);
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
         }
-        item_index++;
+        json_add_item_to_group(group, item);
+        item = json_create_item("description", quest.get_description().c_str());
+        if (!item)
+        {
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
+        }
+        json_add_item_to_group(group, item);
+        item = json_create_item("objective", quest.get_objective().c_str());
+        if (!item)
+        {
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
+        }
+        json_add_item_to_group(group, item);
+        item = json_create_item("reward_experience", quest.get_reward_experience());
+        if (!item)
+        {
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
+        }
+        json_add_item_to_group(group, item);
+        size_t item_count = quest.get_reward_items().size();
+        item = json_create_item("reward_item_count", static_cast<int>(item_count));
+        if (!item)
+        {
+            error_code = JSON_MALLOC_FAIL;
+            has_error = true;
+            break;
+        }
+        json_add_item_to_group(group, item);
+        const ft_vector<ft_sharedptr<ft_item> > &reward_items = quest.get_reward_items();
+        const ft_sharedptr<ft_item> *item_start = reward_items.begin();
+        if (item_count > 0 && !item_start)
+        {
+            error_code = GAME_GENERAL_ERROR;
+            has_error = true;
+            break;
+        }
+        size_t item_index = 0;
+        while (item_index < item_count)
+        {
+            char *item_index_string = cma_itoa(static_cast<int>(item_index));
+            if (!item_index_string)
+            {
+                error_code = JSON_MALLOC_FAIL;
+                has_error = true;
+                break;
+            }
+            ft_string item_prefix = "reward_item_";
+            item_prefix += item_index_string;
+            cma_free(item_index_string);
+            if (!item_start[item_index])
+            {
+                error_code = GAME_GENERAL_ERROR;
+                has_error = true;
+                break;
+            }
+            if (serialize_item_fields(group, *item_start[item_index], item_prefix) != ER_SUCCESS)
+            {
+                error_code = JSON_MALLOC_FAIL;
+                has_error = true;
+                break;
+            }
+            item_index++;
+        }
+        if (has_error)
+            break;
+    } while (0);
+    if (has_error)
+    {
+        json_free_groups(group);
+        ft_errno = error_code;
+        return (ft_nullptr);
     }
     ft_errno = ER_SUCCESS;
     return (group);

--- a/HTML/html_string_writer.cpp
+++ b/HTML/html_string_writer.cpp
@@ -1,29 +1,38 @@
 #include "parser.hpp"
 #include "../CMA/CMA.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include "../Libft/libft.hpp"
 
 static char *html_attrs_to_string(html_attr *attribute)
 {
     char *result = cma_strdup("");
     if (!result)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     while (attribute)
     {
         char *attr = cma_strjoin_multiple(5, " ", attribute->key, "=\"", attribute->value, "\"");
         if (!attr)
         {
             cma_free(result);
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
         }
         char *tmp = cma_strjoin(result, attr);
         cma_free(result);
         cma_free(attr);
         if (!tmp)
+        {
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
+        }
         result = tmp;
         attribute = attribute->next;
     }
+    ft_errno = ER_SUCCESS;
     return (result);
 }
 
@@ -32,13 +41,17 @@ static char *html_indent(int indent)
     int spaces = indent * 2;
     char *result = static_cast<char*>(cma_calloc(spaces + 1, sizeof(char)));
     if (!result)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     int index = 0;
     while (index < spaces)
     {
         result[index] = ' ';
         ++index;
     }
+    ft_errno = ER_SUCCESS;
     return (result);
 }
 
@@ -46,23 +59,31 @@ static char *html_node_to_string(html_node *node, int indent)
 {
     char *result = cma_strdup("");
     if (!result)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     char *pad = html_indent(indent);
     if (!pad)
     {
         cma_free(result);
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
     }
     char *tmp = cma_strjoin(result, pad);
     cma_free(result);
     cma_free(pad);
     if (!tmp)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     result = tmp;
     char *attrs = html_attrs_to_string(node->attributes);
     if (!attrs)
     {
         cma_free(result);
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
     }
     char *open = cma_strjoin_multiple(3, "<", node->tag, attrs);
@@ -70,6 +91,7 @@ static char *html_node_to_string(html_node *node, int indent)
     if (!open)
     {
         cma_free(result);
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
     }
     if (!node->text && !node->children)
@@ -79,14 +101,19 @@ static char *html_node_to_string(html_node *node, int indent)
         if (!line)
         {
             cma_free(result);
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
         }
         tmp = cma_strjoin(result, line);
         cma_free(result);
         cma_free(line);
         if (!tmp)
+        {
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
+        }
         result = tmp;
+        ft_errno = ER_SUCCESS;
         return (result);
     }
     tmp = cma_strjoin_multiple(2, open, ">");
@@ -94,20 +121,27 @@ static char *html_node_to_string(html_node *node, int indent)
     if (!tmp)
     {
         cma_free(result);
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
     }
     char *joined = cma_strjoin(result, tmp);
     cma_free(result);
     cma_free(tmp);
     if (!joined)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     result = joined;
     if (node->text)
     {
         tmp = cma_strjoin(result, node->text);
         cma_free(result);
         if (!tmp)
+        {
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
+        }
         result = tmp;
     }
     if (node->children)
@@ -115,7 +149,10 @@ static char *html_node_to_string(html_node *node, int indent)
         tmp = cma_strjoin(result, "\n");
         cma_free(result);
         if (!tmp)
+        {
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
+        }
         result = tmp;
         html_node *child = node->children;
         while (child)
@@ -124,13 +161,17 @@ static char *html_node_to_string(html_node *node, int indent)
             if (!child_str)
             {
                 cma_free(result);
+                ft_errno = FT_EALLOC;
                 return (ft_nullptr);
             }
             tmp = cma_strjoin(result, child_str);
             cma_free(result);
             cma_free(child_str);
             if (!tmp)
+            {
+                ft_errno = FT_EALLOC;
                 return (ft_nullptr);
+            }
             result = tmp;
             child = child->next;
         }
@@ -138,19 +179,24 @@ static char *html_node_to_string(html_node *node, int indent)
         if (!pad)
         {
             cma_free(result);
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
         }
         tmp = cma_strjoin(result, pad);
         cma_free(result);
         cma_free(pad);
         if (!tmp)
+        {
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
+        }
         result = tmp;
     }
     char *close_start = cma_strjoin_multiple(2, "</", node->tag);
     if (!close_start)
     {
         cma_free(result);
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
     }
     char *close = cma_strjoin_multiple(3, close_start, ">", "\n");
@@ -158,14 +204,19 @@ static char *html_node_to_string(html_node *node, int indent)
     if (!close)
     {
         cma_free(result);
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
     }
     tmp = cma_strjoin(result, close);
     cma_free(result);
     cma_free(close);
     if (!tmp)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     result = tmp;
+    ft_errno = ER_SUCCESS;
     return (result);
 }
 
@@ -173,7 +224,10 @@ char *html_write_to_string(html_node *nodeList)
 {
     char *result = cma_strdup("");
     if (!result)
+    {
+        ft_errno = FT_EALLOC;
         return (ft_nullptr);
+    }
     html_node *current = nodeList;
     while (current)
     {
@@ -181,16 +235,21 @@ char *html_write_to_string(html_node *nodeList)
         if (!node_str)
         {
             cma_free(result);
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
         }
         char *tmp = cma_strjoin(result, node_str);
         cma_free(result);
         cma_free(node_str);
         if (!tmp)
+        {
+            ft_errno = FT_EALLOC;
             return (ft_nullptr);
+        }
         result = tmp;
         current = current->next;
     }
+    ft_errno = ER_SUCCESS;
     return (result);
 }
 


### PR DESCRIPTION
## Summary
- refactor `serialize_inventory` to centralize cleanup while preserving `GAME_GENERAL_ERROR` on null item slots and clearing errno on success
- refactor `serialize_quest` to mirror the same error tracking so null reward entries surface `GAME_GENERAL_ERROR`

## Testing
- make -C Test OPT_LEVEL=0
- ./Test/libft_tests


------
https://chatgpt.com/codex/tasks/task_e_68dae43471f88331838941b21cd2b397