### PR TITLE
Improve JSON reader error reporting and tests

### DIFF
--- a/JSon/json_create_item.cpp
+++ b/JSon/json_create_item.cpp
@@ -40,6 +40,7 @@ json_item* json_create_item(const char *key, const char *value)
         return (ft_nullptr);
     }
     json_item_refresh_numeric_state(item);
+    ft_errno = ER_SUCCESS;
     return (item);
 }
 
@@ -75,6 +76,7 @@ json_item* json_create_item(const char *key, const bool value)
         return (ft_nullptr);
     }
     json_item_refresh_numeric_state(item);
+    ft_errno = ER_SUCCESS;
     return (item);
 }
 
@@ -107,6 +109,7 @@ json_item* json_create_item(const char *key, const int value)
         return (ft_nullptr);
     }
     json_item_refresh_numeric_state(item);
+    ft_errno = ER_SUCCESS;
     return (item);
 }
 

--- a/JSon/json_parsing.cpp
+++ b/JSon/json_parsing.cpp
@@ -108,7 +108,10 @@ json_group* json_create_json_group(const char *name)
 {
     json_group *group = new(std::nothrow) json_group;
     if (!group)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
         return (ft_nullptr);
+    }
     group->name = cma_strdup(name);
     if (!group->name)
     {
@@ -118,6 +121,7 @@ json_group* json_create_json_group(const char *name)
     }
     group->items = ft_nullptr;
     group->next = ft_nullptr;
+    ft_errno = ER_SUCCESS;
     return (group);
 }
 

--- a/JSon/json_reader.cpp
+++ b/JSon/json_reader.cpp
@@ -3,6 +3,7 @@
 #include "../GetNextLine/get_next_line.hpp"
 #include "../CMA/CMA.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 
 static void skip_whitespace(const char *json_string, size_t &index)
 {
@@ -16,16 +17,29 @@ static char *parse_string(const char *json_string, size_t &index)
 {
     size_t length = ft_strlen_size_t(json_string);
     if (index >= length || json_string[index] != '"')
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     index++;
     size_t start_index = index;
     while (index < length && json_string[index] != '"')
         index++;
+    if (index >= length || json_string[index] != '"')
+    {
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
     char *result = cma_substr(json_string,
                                static_cast<unsigned int>(start_index),
                                index - start_index);
-    if (index < length && json_string[index] == '"')
-        index++;
+    if (!result)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    index++;
+    ft_errno = ER_SUCCESS;
     return (result);
 }
 
@@ -59,9 +73,20 @@ static char *parse_number(const char *json_string, size_t &index)
             index++;
     }
     if (!has_digits)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
-    return (cma_substr(json_string, static_cast<unsigned int>(start_index),
-                       index - start_index));
+    }
+    char *number = cma_substr(json_string,
+                               static_cast<unsigned int>(start_index),
+                               index - start_index);
+    if (!number)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    ft_errno = ER_SUCCESS;
+    return (number);
 }
 
 static char *parse_value(const char *json_string, size_t &index)
@@ -69,22 +94,40 @@ static char *parse_value(const char *json_string, size_t &index)
     skip_whitespace(json_string, index);
     size_t length = ft_strlen_size_t(json_string);
     if (index >= length)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     if (json_string[index] == '"')
         return (parse_string(json_string, index));
     if (length - index >= 4 && ft_strncmp(json_string + index, "true", 4) == 0)
     {
         index += 4;
-        return (cma_strdup("true"));
+        char *value = cma_strdup("true");
+        if (!value)
+        {
+            ft_errno = JSON_MALLOC_FAIL;
+            return (ft_nullptr);
+        }
+        ft_errno = ER_SUCCESS;
+        return (value);
     }
     if (length - index >= 5 && ft_strncmp(json_string + index, "false", 5) == 0)
     {
         index += 5;
-        return (cma_strdup("false"));
+        char *value = cma_strdup("false");
+        if (!value)
+        {
+            ft_errno = JSON_MALLOC_FAIL;
+            return (ft_nullptr);
+        }
+        ft_errno = ER_SUCCESS;
+        return (value);
     }
     if (ft_isdigit(static_cast<unsigned char>(json_string[index]))
         || json_string[index] == '-' || json_string[index] == '+')
         return (parse_number(json_string, index));
+    ft_errno = FT_EINVAL;
     return (ft_nullptr);
 }
 
@@ -95,14 +138,19 @@ static json_item *parse_items(const char *json_string, size_t &index)
     json_item *tail = ft_nullptr;
     skip_whitespace(json_string, index);
     if (index >= length || json_string[index] != '{')
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     index++;
+    bool object_closed = false;
     while (index < length)
     {
         skip_whitespace(json_string, index);
         if (index < length && json_string[index] == '}')
         {
             index++;
+            object_closed = true;
             break;
         }
         char *key = parse_string(json_string, index);
@@ -115,7 +163,9 @@ static json_item *parse_items(const char *json_string, size_t &index)
         if (index >= length || json_string[index] != ':')
         {
             cma_free(key);
-            break;
+            json_free_items(head);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
         }
         index++;
         skip_whitespace(json_string, index);
@@ -127,7 +177,13 @@ static json_item *parse_items(const char *json_string, size_t &index)
             return (ft_nullptr);
         }
         json_item *item = json_create_item(key, value);
+        cma_free(value);
         cma_free(key);
+        if (!item)
+        {
+            json_free_items(head);
+            return (ft_nullptr);
+        }
         if (!head)
             head = tail = item;
         else
@@ -142,6 +198,13 @@ static json_item *parse_items(const char *json_string, size_t &index)
             continue;
         }
     }
+    if (!object_closed)
+    {
+        json_free_items(head);
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    ft_errno = ER_SUCCESS;
     return (head);
 }
 
@@ -149,7 +212,10 @@ json_group *json_read_from_file(const char *filename)
 {
     char **lines = ft_open_and_read_file(filename, 512);
     if (!lines)
+    {
+        ft_errno = FT_EIO;
         return (ft_nullptr);
+    }
     char *content = cma_strdup("");
     if (!content)
     {
@@ -160,6 +226,7 @@ json_group *json_read_from_file(const char *filename)
             ++line_index;
         }
         cma_free(lines);
+        ft_errno = JSON_MALLOC_FAIL;
         return (ft_nullptr);
     }
     int line_index = 0;
@@ -177,6 +244,7 @@ json_group *json_read_from_file(const char *filename)
                 ++remaining_index;
             }
             cma_free(lines);
+            ft_errno = JSON_MALLOC_FAIL;
             return (ft_nullptr);
         }
         content = tmp;
@@ -189,17 +257,20 @@ json_group *json_read_from_file(const char *filename)
     if (index >= length || content[index] != '{')
     {
         cma_free(content);
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
     }
     index++;
     json_group *head = ft_nullptr;
     json_group *tail = ft_nullptr;
+    bool object_closed = false;
     while (index < length)
     {
         skip_whitespace(content, index);
         if (index < length && content[index] == '}')
         {
             index++;
+            object_closed = true;
             break;
         }
         char *group_name = parse_string(content, index);
@@ -213,7 +284,10 @@ json_group *json_read_from_file(const char *filename)
         if (index >= length || content[index] != ':')
         {
             cma_free(group_name);
-            break;
+            json_free_groups(head);
+            cma_free(content);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
         }
         index++;
         json_item *items = parse_items(content, index);
@@ -248,28 +322,44 @@ json_group *json_read_from_file(const char *filename)
             continue;
         }
     }
+    if (!object_closed)
+    {
+        json_free_groups(head);
+        cma_free(content);
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
     cma_free(content);
+    ft_errno = ER_SUCCESS;
     return (head);
 }
 
 json_group *json_read_from_string(const char *content)
 {
     if (!content)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     size_t index = 0;
     skip_whitespace(content, index);
     size_t length = ft_strlen_size_t(content);
     if (index >= length || content[index] != '{')
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
+    }
     index++;
     json_group *head = ft_nullptr;
     json_group *tail = ft_nullptr;
+    bool object_closed = false;
     while (index < length)
     {
         skip_whitespace(content, index);
         if (index < length && content[index] == '}')
         {
             index++;
+            object_closed = true;
             break;
         }
         char *group_name = parse_string(content, index);
@@ -282,7 +372,9 @@ json_group *json_read_from_string(const char *content)
         if (index >= length || content[index] != ':')
         {
             cma_free(group_name);
-            break;
+            json_free_groups(head);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
         }
         index++;
         json_item *items = parse_items(content, index);
@@ -315,6 +407,13 @@ json_group *json_read_from_string(const char *content)
             continue;
         }
     }
+    if (!object_closed)
+    {
+        json_free_groups(head);
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    ft_errno = ER_SUCCESS;
     return (head);
 }
 

--- a/Test/Test/test_json_reader.cpp
+++ b/Test/Test/test_json_reader.cpp
@@ -1,0 +1,63 @@
+#include "../../JSon/json.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_json_read_from_string_null_input_sets_errno, "json reader rejects null input")
+{
+    ft_errno = ER_SUCCESS;
+    json_group *groups = json_read_from_string(ft_nullptr);
+    FT_ASSERT(groups == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_json_read_from_string_missing_quote_sets_errno, "json reader detects unterminated strings")
+{
+    const char *content = "{ \"config\": { \"name\": \"value } }";
+    ft_errno = ER_SUCCESS;
+    json_group *groups = json_read_from_string(content);
+    FT_ASSERT(groups == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_json_read_from_string_missing_colon_sets_errno, "json reader detects missing delimiters")
+{
+    const char *content = "{ \"config\" { \"name\": \"value\" } }";
+    ft_errno = ER_SUCCESS;
+    json_group *groups = json_read_from_string(content);
+    FT_ASSERT(groups == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_json_read_from_string_missing_closing_sets_errno, "json reader requires closing braces")
+{
+    const char *content = "{ \"config\": { \"name\": \"value\" }";
+    ft_errno = ER_SUCCESS;
+    json_group *groups = json_read_from_string(content);
+    FT_ASSERT(groups == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_json_read_from_string_success_resets_errno, "json reader clears errno on success")
+{
+    const char *content = "{ \"config\": { \"name\": \"value\" } }";
+    ft_errno = FT_EINVAL;
+    json_group *groups = json_read_from_string(content);
+    FT_ASSERT(groups != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    json_free_groups(groups);
+    return (1);
+}
+
+FT_TEST(test_json_read_from_file_missing_file_sets_errno, "json reader reports io errors")
+{
+    ft_errno = ER_SUCCESS;
+    json_group *groups = json_read_from_file("Test/nonexistent_json_reader.json");
+    FT_ASSERT(groups == ft_nullptr);
+    FT_ASSERT_EQ(FT_EIO, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- ensure the JSON reader propagates `ft_errno` for malformed input and resets it on success
- have JSON helper constructors leave `ft_errno` in a success state when they return a valid object
- add regression tests that cover malformed JSON documents and verify the reported error codes

## Testing
- make -C Test

------
https://chatgpt.com/codex/tasks/task_e_68daf81e80448331a1ba229140ef6fb4