### PR TITLE
Fix compression stream tests and JSON reader errno

### DIFF
--- a/Compression/compression_stream.cpp
+++ b/Compression/compression_stream.cpp
@@ -3,7 +3,87 @@
 #include "../CMA/CMA.hpp"
 #include "../CPP_class/class_nullptr.hpp"
 #include "../System_utils/system_utils.hpp"
+#include "../Errno/errno.hpp"
 #include "compression.hpp"
+#include "compression_stream_test_hooks.hpp"
+
+static int map_zlib_error(int zlib_status)
+{
+    if (zlib_status == Z_MEM_ERROR)
+        return (FT_EALLOC);
+    if (zlib_status == Z_BUF_ERROR)
+        return (FT_EIO);
+    if (zlib_status == Z_NEED_DICT)
+        return (FT_EINVAL);
+    if (zlib_status == Z_DATA_ERROR)
+        return (FT_EINVAL);
+    if (zlib_status == Z_STREAM_ERROR)
+        return (FT_EINVAL);
+    if (zlib_status == Z_VERSION_ERROR)
+        return (FT_EINVAL);
+    return (FT_EINVAL);
+}
+
+static int compress_stream_default_deflate_init(z_stream *stream, int compression_level)
+{
+    return (deflateInit(stream, compression_level));
+}
+
+static int compress_stream_default_deflate(z_stream *stream, int flush_mode)
+{
+    return (deflate(stream, flush_mode));
+}
+
+static int decompress_stream_default_inflate_init(z_stream *stream)
+{
+    return (inflateInit(stream));
+}
+
+static int decompress_stream_default_inflate(z_stream *stream, int flush_mode)
+{
+    return (inflate(stream, flush_mode));
+}
+
+static t_compress_stream_deflate_init_hook    g_compress_stream_deflate_init_hook = compress_stream_default_deflate_init;
+static t_compress_stream_deflate_hook         g_compress_stream_deflate_hook = compress_stream_default_deflate;
+static t_decompress_stream_inflate_init_hook  g_decompress_stream_inflate_init_hook = decompress_stream_default_inflate_init;
+static t_decompress_stream_inflate_hook       g_decompress_stream_inflate_hook = decompress_stream_default_inflate;
+
+void ft_compress_stream_set_deflate_init_hook(t_compress_stream_deflate_init_hook hook)
+{
+    if (hook)
+        g_compress_stream_deflate_init_hook = hook;
+    else
+        g_compress_stream_deflate_init_hook = compress_stream_default_deflate_init;
+    return ;
+}
+
+void ft_compress_stream_set_deflate_hook(t_compress_stream_deflate_hook hook)
+{
+    if (hook)
+        g_compress_stream_deflate_hook = hook;
+    else
+        g_compress_stream_deflate_hook = compress_stream_default_deflate;
+    return ;
+}
+
+void ft_decompress_stream_set_inflate_init_hook(t_decompress_stream_inflate_init_hook hook)
+{
+    if (hook)
+        g_decompress_stream_inflate_init_hook = hook;
+    else
+        g_decompress_stream_inflate_init_hook = decompress_stream_default_inflate_init;
+    return ;
+}
+
+void ft_decompress_stream_set_inflate_hook(t_decompress_stream_inflate_hook hook)
+{
+    if (hook)
+        g_decompress_stream_inflate_hook = hook;
+    else
+        g_decompress_stream_inflate_hook = decompress_stream_default_inflate;
+    return ;
+}
 
 int ft_compress_stream(int input_fd, int output_fd)
 {
@@ -15,10 +95,17 @@ int ft_compress_stream(int input_fd, int output_fd)
     ssize_t         read_bytes;
 
     if (input_fd < 0 || output_fd < 0)
+    {
+        ft_errno = FT_EINVAL;
         return (1);
+    }
     ft_bzero(&stream, sizeof(stream));
-    if (deflateInit(&stream, Z_BEST_COMPRESSION) != Z_OK)
+    deflate_status = g_compress_stream_deflate_init_hook(&stream, Z_BEST_COMPRESSION);
+    if (deflate_status != Z_OK)
+    {
+        ft_errno = map_zlib_error(deflate_status);
         return (1);
+    }
     flush_mode = Z_NO_FLUSH;
     while (flush_mode != Z_FINISH)
     {
@@ -26,6 +113,7 @@ int ft_compress_stream(int input_fd, int output_fd)
         if (read_bytes < 0)
         {
             deflateEnd(&stream);
+            ft_errno = FT_EIO;
             return (1);
         }
         stream.next_in = input_buffer;
@@ -38,22 +126,25 @@ int ft_compress_stream(int input_fd, int output_fd)
         {
             stream.next_out = output_buffer;
             stream.avail_out = sizeof(output_buffer);
-            deflate_status = deflate(&stream, flush_mode);
-            if (deflate_status == Z_STREAM_ERROR)
+            deflate_status = g_compress_stream_deflate_hook(&stream, flush_mode);
+            if (deflate_status == Z_STREAM_ERROR || deflate_status == Z_BUF_ERROR)
             {
                 deflateEnd(&stream);
+                ft_errno = map_zlib_error(deflate_status);
                 return (1);
             }
             std::size_t produced_bytes = sizeof(output_buffer) - stream.avail_out;
             if (su_write(output_fd, output_buffer, produced_bytes) != static_cast<ssize_t>(produced_bytes))
             {
                 deflateEnd(&stream);
+                ft_errno = FT_EIO;
                 return (1);
             }
         }
         while (stream.avail_out == 0);
     }
     deflateEnd(&stream);
+    ft_errno = ER_SUCCESS;
     return (0);
 }
 
@@ -67,10 +158,17 @@ int ft_decompress_stream(int input_fd, int output_fd)
     int             flush_mode;
 
     if (input_fd < 0 || output_fd < 0)
+    {
+        ft_errno = FT_EINVAL;
         return (1);
+    }
     ft_bzero(&stream, sizeof(stream));
-    if (inflateInit(&stream) != Z_OK)
+    inflate_status = g_decompress_stream_inflate_init_hook(&stream);
+    if (inflate_status != Z_OK)
+    {
+        ft_errno = map_zlib_error(inflate_status);
         return (1);
+    }
     flush_mode = Z_NO_FLUSH;
     while (flush_mode != Z_FINISH)
     {
@@ -78,6 +176,7 @@ int ft_decompress_stream(int input_fd, int output_fd)
         if (read_bytes < 0)
         {
             inflateEnd(&stream);
+            ft_errno = FT_EIO;
             return (1);
         }
         stream.next_in = input_buffer;
@@ -90,21 +189,24 @@ int ft_decompress_stream(int input_fd, int output_fd)
         {
             stream.next_out = output_buffer;
             stream.avail_out = sizeof(output_buffer);
-            inflate_status = inflate(&stream, flush_mode);
+            inflate_status = g_decompress_stream_inflate_hook(&stream, flush_mode);
             if (inflate_status == Z_NEED_DICT || inflate_status == Z_DATA_ERROR || inflate_status == Z_MEM_ERROR)
             {
                 inflateEnd(&stream);
+                ft_errno = map_zlib_error(inflate_status);
                 return (1);
             }
             std::size_t produced_bytes = sizeof(output_buffer) - stream.avail_out;
             if (su_write(output_fd, output_buffer, produced_bytes) != static_cast<ssize_t>(produced_bytes))
             {
                 inflateEnd(&stream);
+                ft_errno = FT_EIO;
                 return (1);
             }
         }
         while (stream.avail_out == 0);
     }
     inflateEnd(&stream);
+    ft_errno = ER_SUCCESS;
     return (0);
 }

--- a/Compression/compression_stream_test_hooks.hpp
+++ b/Compression/compression_stream_test_hooks.hpp
@@ -1,0 +1,16 @@
+#ifndef COMPRESSION_STREAM_TEST_HOOKS_HPP
+# define COMPRESSION_STREAM_TEST_HOOKS_HPP
+
+#include <zlib.h>
+
+typedef int (*t_compress_stream_deflate_init_hook)(z_stream *stream, int compression_level);
+typedef int (*t_compress_stream_deflate_hook)(z_stream *stream, int flush_mode);
+typedef int (*t_decompress_stream_inflate_init_hook)(z_stream *stream);
+typedef int (*t_decompress_stream_inflate_hook)(z_stream *stream, int flush_mode);
+
+void    ft_compress_stream_set_deflate_init_hook(t_compress_stream_deflate_init_hook hook);
+void    ft_compress_stream_set_deflate_hook(t_compress_stream_deflate_hook hook);
+void    ft_decompress_stream_set_inflate_init_hook(t_decompress_stream_inflate_init_hook hook);
+void    ft_decompress_stream_set_inflate_hook(t_decompress_stream_inflate_hook hook);
+
+#endif

--- a/JSon/json_reader.cpp
+++ b/JSon/json_reader.cpp
@@ -365,7 +365,14 @@ json_group *json_read_from_string(const char *content)
         char *group_name = parse_string(content, index);
         if (!group_name)
         {
+            int error_code;
+
+            error_code = ft_errno;
             json_free_groups(head);
+            if (error_code == ER_SUCCESS)
+                ft_errno = FT_EINVAL;
+            else
+                ft_errno = error_code;
             return (ft_nullptr);
         }
         skip_whitespace(content, index);
@@ -380,8 +387,15 @@ json_group *json_read_from_string(const char *content)
         json_item *items = parse_items(content, index);
         if (!items)
         {
+            int error_code;
+
+            error_code = ft_errno;
             cma_free(group_name);
             json_free_groups(head);
+            if (error_code == ER_SUCCESS)
+                ft_errno = FT_EINVAL;
+            else
+                ft_errno = error_code;
             return (ft_nullptr);
         }
         json_group *group = json_create_json_group(group_name);
@@ -409,8 +423,14 @@ json_group *json_read_from_string(const char *content)
     }
     if (!object_closed)
     {
+        int error_code;
+
+        error_code = ft_errno;
         json_free_groups(head);
-        ft_errno = FT_EINVAL;
+        if (error_code == ER_SUCCESS)
+            ft_errno = FT_EINVAL;
+        else
+            ft_errno = error_code;
         return (ft_nullptr);
     }
     ft_errno = ER_SUCCESS;

--- a/Test/Test/test_compression_stream.cpp
+++ b/Test/Test/test_compression_stream.cpp
@@ -1,0 +1,304 @@
+#include "../../Compression/compression.hpp"
+#include "../../Compression/compression_stream_test_hooks.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/system_utils.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <unistd.h>
+#include <cstdint>
+
+static int compression_stream_fail_deflate_init(z_stream *stream, int compression_level)
+{
+    (void)stream;
+    (void)compression_level;
+    return (Z_MEM_ERROR);
+}
+
+static int compression_stream_fail_deflate(z_stream *stream, int flush_mode)
+{
+    (void)stream;
+    (void)flush_mode;
+    return (Z_STREAM_ERROR);
+}
+
+static int compression_stream_fail_inflate_init(z_stream *stream)
+{
+    (void)stream;
+    return (Z_MEM_ERROR);
+}
+
+static int compression_stream_fail_inflate(z_stream *stream, int flush_mode)
+{
+    (void)stream;
+    (void)flush_mode;
+    return (Z_DATA_ERROR);
+}
+
+FT_TEST(test_ft_compress_stream_rejects_invalid_descriptors, "ft_compress_stream rejects invalid descriptors")
+{
+    int result;
+
+    ft_errno = ER_SUCCESS;
+    result = ft_compress_stream(-1, -1);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_compress_stream_reports_deflate_init_failure, "ft_compress_stream reports deflateInit failures")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    int result;
+
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    ft_compress_stream_set_deflate_init_hook(compression_stream_fail_deflate_init);
+    ft_errno = ER_SUCCESS;
+    result = ft_compress_stream(input_pipe[0], output_pipe[1]);
+    ft_compress_stream_set_deflate_init_hook(ft_nullptr);
+    close(input_pipe[0]);
+    close(input_pipe[1]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_compress_stream_reports_read_failure, "ft_compress_stream reports su_read failures")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    int result;
+
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    close(input_pipe[0]);
+    ft_errno = ER_SUCCESS;
+    result = ft_compress_stream(input_pipe[1], output_pipe[1]);
+    close(input_pipe[1]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EIO, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_compress_stream_reports_deflate_failure, "ft_compress_stream reports deflate failures")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    const char *payload;
+    ssize_t written;
+    int result;
+
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    payload = "stream failure";
+    written = su_write(input_pipe[1], payload, ft_strlen_size_t(payload));
+    FT_ASSERT_EQ(static_cast<ssize_t>(ft_strlen_size_t(payload)), written);
+    close(input_pipe[1]);
+    ft_compress_stream_set_deflate_hook(compression_stream_fail_deflate);
+    ft_errno = ER_SUCCESS;
+    result = ft_compress_stream(input_pipe[0], output_pipe[1]);
+    ft_compress_stream_set_deflate_hook(ft_nullptr);
+    close(input_pipe[0]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_compress_stream_reports_write_failure, "ft_compress_stream reports su_write failures")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    const char *payload;
+    ssize_t written;
+    int result;
+
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    payload = "stream write";
+    written = su_write(input_pipe[1], payload, ft_strlen_size_t(payload));
+    FT_ASSERT_EQ(static_cast<ssize_t>(ft_strlen_size_t(payload)), written);
+    close(input_pipe[1]);
+    ft_errno = ER_SUCCESS;
+    result = ft_compress_stream(input_pipe[0], output_pipe[0]);
+    close(input_pipe[0]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EIO, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_compress_stream_success_sets_errno_success, "ft_compress_stream success sets ft_errno")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    const char *payload;
+    ssize_t written;
+    int result;
+
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    payload = "compress success";
+    written = su_write(input_pipe[1], payload, ft_strlen_size_t(payload));
+    FT_ASSERT_EQ(static_cast<ssize_t>(ft_strlen_size_t(payload)), written);
+    close(input_pipe[1]);
+    ft_errno = ER_SUCCESS;
+    result = ft_compress_stream(input_pipe[0], output_pipe[1]);
+    close(input_pipe[0]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(0, result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_decompress_stream_rejects_invalid_descriptors, "ft_decompress_stream rejects invalid descriptors")
+{
+    int result;
+
+    ft_errno = ER_SUCCESS;
+    result = ft_decompress_stream(-1, -1);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_decompress_stream_reports_inflate_init_failure, "ft_decompress_stream reports inflateInit failures")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    int result;
+
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    ft_decompress_stream_set_inflate_init_hook(compression_stream_fail_inflate_init);
+    ft_errno = ER_SUCCESS;
+    result = ft_decompress_stream(input_pipe[0], output_pipe[1]);
+    ft_decompress_stream_set_inflate_init_hook(ft_nullptr);
+    close(input_pipe[0]);
+    close(input_pipe[1]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_decompress_stream_reports_read_failure, "ft_decompress_stream reports su_read failures")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    int result;
+
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    close(input_pipe[0]);
+    ft_errno = ER_SUCCESS;
+    result = ft_decompress_stream(input_pipe[1], output_pipe[1]);
+    close(input_pipe[1]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EIO, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_decompress_stream_reports_inflate_failure, "ft_decompress_stream reports inflate failures")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    int result;
+
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    close(input_pipe[1]);
+    ft_decompress_stream_set_inflate_hook(compression_stream_fail_inflate);
+    ft_errno = ER_SUCCESS;
+    result = ft_decompress_stream(input_pipe[0], output_pipe[1]);
+    ft_decompress_stream_set_inflate_hook(ft_nullptr);
+    close(input_pipe[0]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_decompress_stream_reports_write_failure, "ft_decompress_stream reports su_write failures")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    const unsigned char *payload;
+    unsigned char *compressed_buffer;
+    std::size_t compressed_size;
+    ssize_t payload_written;
+    int result;
+
+    payload = reinterpret_cast<const unsigned char *>("decompress write");
+    compressed_size = 0;
+    compressed_buffer = ft_compress(payload, ft_strlen_size_t("decompress write"), &compressed_size);
+    FT_ASSERT(compressed_buffer != ft_nullptr);
+    FT_ASSERT(compressed_size > 0);
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    FT_ASSERT(compressed_size > sizeof(uint32_t));
+    payload_written = su_write(input_pipe[1],
+            compressed_buffer + sizeof(uint32_t),
+            compressed_size - sizeof(uint32_t));
+    FT_ASSERT_EQ(static_cast<ssize_t>(compressed_size - sizeof(uint32_t)),
+        payload_written);
+    close(input_pipe[1]);
+    cma_free(compressed_buffer);
+    ft_errno = ER_SUCCESS;
+    result = ft_decompress_stream(input_pipe[0], output_pipe[0]);
+    close(input_pipe[0]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(1, result);
+    FT_ASSERT_EQ(FT_EIO, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_decompress_stream_success_sets_errno_success, "ft_decompress_stream success sets ft_errno")
+{
+    int input_pipe[2];
+    int output_pipe[2];
+    const unsigned char *payload;
+    unsigned char *compressed_buffer;
+    std::size_t compressed_size;
+    ssize_t payload_written;
+    int result;
+
+    payload = reinterpret_cast<const unsigned char *>("decompress success");
+    compressed_size = 0;
+    compressed_buffer = ft_compress(payload, ft_strlen_size_t("decompress success"), &compressed_size);
+    FT_ASSERT(compressed_buffer != ft_nullptr);
+    FT_ASSERT(compressed_size > 0);
+    FT_ASSERT_EQ(0, pipe(input_pipe));
+    FT_ASSERT_EQ(0, pipe(output_pipe));
+    FT_ASSERT(compressed_size > sizeof(uint32_t));
+    payload_written = su_write(input_pipe[1],
+            compressed_buffer + sizeof(uint32_t),
+            compressed_size - sizeof(uint32_t));
+    FT_ASSERT_EQ(static_cast<ssize_t>(compressed_size - sizeof(uint32_t)),
+        payload_written);
+    close(input_pipe[1]);
+    cma_free(compressed_buffer);
+    ft_errno = ER_SUCCESS;
+    result = ft_decompress_stream(input_pipe[0], output_pipe[1]);
+    close(input_pipe[0]);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    FT_ASSERT_EQ(0, result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- ensure the compression stream regression tests feed raw deflate data by skipping the ft_compress size prefix
- preserve ft_errno when json_read_from_string aborts early so syntax errors are reported as FT_EINVAL

## Testing
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68db72508c288331a0b518f0dcaf3c1c