### PR TITLE
Ensure zlib compression clears errno on success

### DIFF
--- a/Compression/compression_zlib.cpp
+++ b/Compression/compression_zlib.cpp
@@ -51,6 +51,7 @@ unsigned char    *compress_buffer(const unsigned char *input_buffer, std::size_t
     resized_buffer = static_cast<unsigned char *>(cma_realloc(result_buffer, *compressed_size));
     if (resized_buffer)
         result_buffer = resized_buffer;
+    ft_errno = ER_SUCCESS;
     return (result_buffer);
 }
 
@@ -98,6 +99,7 @@ unsigned char    *decompress_buffer(const unsigned char *input_buffer, std::size
         return (ft_nullptr);
     }
     *decompressed_size = actual_size;
+    ft_errno = ER_SUCCESS;
     return (result_buffer);
 }
 

--- a/Test/Test/test_compression.cpp
+++ b/Test/Test/test_compression.cpp
@@ -73,14 +73,26 @@ FT_TEST(test_ft_compress_round_trip, "ft_compress round trip")
     input_string = "The quick brown fox jumps over the lazy dog";
     input_length = ft_strlen_size_t(input_string);
     compressed_length = 0;
+    ft_errno = FT_EINVAL;
     compressed_buffer = ft_compress(reinterpret_cast<const unsigned char *>(input_string), input_length, &compressed_length);
     if (!compressed_buffer)
         return (0);
+    if (ft_errno != ER_SUCCESS)
+    {
+        cma_free(compressed_buffer);
+        return (0);
+    }
     decompressed_length = 0;
+    ft_errno = FT_EINVAL;
     decompressed_buffer = ft_decompress(compressed_buffer, compressed_length, &decompressed_length);
     cma_free(compressed_buffer);
     if (!decompressed_buffer)
         return (0);
+    if (ft_errno != ER_SUCCESS)
+    {
+        cma_free(decompressed_buffer);
+        return (0);
+    }
     comparison_result = ft_memcmp(decompressed_buffer, input_string, decompressed_length);
     if (comparison_result == 0 && decompressed_length == input_length)
     {


### PR DESCRIPTION
## Summary
- ensure `compress_buffer` and `decompress_buffer` set `ft_errno` to `ER_SUCCESS` when they complete successfully
- update the `ft_compress` round-trip unit test to assert `ft_errno` is cleared after successful compression and decompression

## Testing
- make -C Test
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68db7c812e2c833180234bc08317ca75