### PR TITLE
Fix C++ file stream error handling

### DIFF
--- a/CPP_class/cpp_class_file.cpp
+++ b/CPP_class/cpp_class_file.cpp
@@ -111,6 +111,7 @@ int ft_file::open(const char* filename, int flags, mode_t mode) noexcept
         }
     }
     this->_fd = new_fd;
+    this->set_error(ER_SUCCESS);
     return (0);
 }
 
@@ -133,6 +134,7 @@ int ft_file::open(const char* filename, int flags) noexcept
         }
     }
     this->_fd = new_fd;
+    this->set_error(ER_SUCCESS);
     return (0);
 }
 
@@ -172,7 +174,11 @@ ssize_t ft_file::read(char *buffer, int count) noexcept
     }
     ssize_t bytes_read = su_read(this->_fd, buffer, static_cast<size_t>(count));
     if (bytes_read == -1)
+    {
         this->set_error(errno + ERRNO_OFFSET);
+        return (-1);
+    }
+    this->set_error(ER_SUCCESS);
     return (bytes_read);
 }
 
@@ -189,7 +195,7 @@ ssize_t ft_file::write(const char *string) noexcept
         this->set_error(errno + ERRNO_OFFSET);
         return (-1);
     }
-
+    this->set_error(ER_SUCCESS);
     return (result);
 }
 
@@ -201,6 +207,7 @@ int ft_file::seek(off_t offset, int whence) noexcept
         this->set_error(errno + ERRNO_OFFSET);
         return (-1);
     }
+    this->set_error(ER_SUCCESS);
     return (0);
 }
 
@@ -208,8 +215,11 @@ int ft_file::printf(const char *format, ...)
 {
     va_list args;
 
-    if (!format)
+    if (format == ft_nullptr)
+    {
+        this->set_error(FT_EINVAL);
         return (0);
+    }
     if (this->_fd == -1)
     {
         this->set_error(FILE_INVALID_FD);
@@ -218,6 +228,9 @@ int ft_file::printf(const char *format, ...)
     va_start(args, format);
     int printed_chars = pf_printf_fd_v(this->_fd, format, args);
     va_end(args);
+    if (printed_chars < 0)
+        return (printed_chars);
+    this->set_error(ER_SUCCESS);
     return (printed_chars);
 }
 

--- a/CPP_class/cpp_class_ofstream.cpp
+++ b/CPP_class/cpp_class_ofstream.cpp
@@ -28,9 +28,10 @@ int ft_ofstream::open(const char *filename) noexcept
     }
     if (this->_file.open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644) != 0)
     {
-        this->set_error(this->_file.get_error());
+        this->_error_code = this->_file.get_error();
         return (1);
     }
+    this->set_error(ER_SUCCESS);
     return (0);
 }
 
@@ -43,13 +44,26 @@ ssize_t ft_ofstream::write(const char *string) noexcept
     }
     ssize_t result = this->_file.write(string);
     if (result < 0)
-        this->set_error(this->_file.get_error());
+    {
+        this->_error_code = this->_file.get_error();
+        return (-1);
+    }
+    this->set_error(ER_SUCCESS);
     return (result);
 }
 
 void ft_ofstream::close() noexcept
 {
+    int previous_fd = this->_file.get_fd();
+
     this->_file.close();
+    if (previous_fd >= 0 && this->_file.get_fd() == previous_fd &&
+        this->_file.get_error() != ER_SUCCESS)
+    {
+        this->_error_code = this->_file.get_error();
+        return ;
+    }
+    this->set_error(ER_SUCCESS);
     return ;
 }
 

--- a/Test/Test/test_cpp_class_errors.cpp
+++ b/Test/Test/test_cpp_class_errors.cpp
@@ -1,0 +1,46 @@
+#include "../../CPP_class/class_file.hpp"
+#include "../../CPP_class/class_ofstream.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <fcntl.h>
+#include <unistd.h>
+
+FT_TEST(test_ft_file_error_resets, "ft_file resets error state after success")
+{
+    const char *filename = "test_ft_file_error_resets.txt";
+    ft_file file;
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, file.read(ft_nullptr, 1));
+    FT_ASSERT_EQ(FT_EINVAL, file.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(0, file.open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644));
+    FT_ASSERT_EQ(ER_SUCCESS, file.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    file.close();
+    ::unlink(filename);
+    return (1);
+}
+
+FT_TEST(test_ft_ofstream_error_resets, "ft_ofstream resets error state after success")
+{
+    const char *filename = "test_ft_ofstream_error_resets.txt";
+    ft_ofstream stream;
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(1, stream.open(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, stream.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(0, stream.open(filename));
+    FT_ASSERT_EQ(ER_SUCCESS, stream.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(5, stream.write("reset"));
+    FT_ASSERT_EQ(ER_SUCCESS, stream.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    stream.close();
+    FT_ASSERT_EQ(ER_SUCCESS, stream.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ::unlink(filename);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- reset ft_file success paths to clear ft_errno and the cached error code after open, read, write, seek, and printf
- ensure ft_ofstream propagates helper failures while clearing its error state on successful open, write, and close calls
- add cpp_class tests covering failure followed by success to confirm error codes reset to ER_SUCCESS

## Testing
- make -C Test

------
https://chatgpt.com/codex/tasks/task_e_68db7dc6990c8331931a8fe5920487c4