### PR TITLE
Fix cmp_timegm errno handling

### DIFF
--- a/Compatebility/Compatebility_system.cpp
+++ b/Compatebility/Compatebility_system.cpp
@@ -510,11 +510,19 @@ unsigned long long cmp_get_total_memory(void)
 
 std::time_t cmp_timegm(std::tm *time_pointer)
 {
+    std::time_t conversion_result;
+
     if (time_pointer == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (static_cast<std::time_t>(-1));
+    }
 #if defined(_WIN32) || defined(_WIN64)
-    return (_mkgmtime(time_pointer));
+    conversion_result = _mkgmtime(time_pointer);
 #else
-    return (::timegm(time_pointer));
+    conversion_result = ::timegm(time_pointer);
 #endif
+    if (conversion_result != static_cast<std::time_t>(-1))
+        ft_errno = ER_SUCCESS;
+    return (conversion_result);
 }

--- a/Test/Test/test_time.cpp
+++ b/Test/Test/test_time.cpp
@@ -162,6 +162,17 @@ FT_TEST(test_time_format_errors, "ft_time_format edge cases")
     return (1);
 }
 
+FT_TEST(test_cmp_timegm_null_pointer_sets_errno, "cmp_timegm validates null pointers")
+{
+    std::time_t conversion_result;
+
+    ft_errno = ER_SUCCESS;
+    conversion_result = cmp_timegm(ft_nullptr);
+    FT_ASSERT_EQ(static_cast<std::time_t>(-1), conversion_result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_time_format_small_buffer, "ft_time_format detects insufficient space")
 {
     char buffer[1];

--- a/Time/time_parse.cpp
+++ b/Time/time_parse.cpp
@@ -196,7 +196,8 @@ bool    time_parse_iso8601(const char *string_input, std::tm *time_output, t_tim
         epoch_time = cmp_timegm(&parsed_time);
         if (epoch_time == static_cast<std::time_t>(-1))
         {
-            ft_errno = FT_ERANGE;
+            if (ft_errno == ER_SUCCESS)
+                ft_errno = FT_ERANGE;
             return (false);
         }
         adjusted_epoch = epoch_time - static_cast<std::time_t>(offset_seconds);
@@ -207,7 +208,8 @@ bool    time_parse_iso8601(const char *string_input, std::tm *time_output, t_tim
         epoch_time = cmp_timegm(&parsed_time);
         if (epoch_time == static_cast<std::time_t>(-1))
         {
-            ft_errno = FT_ERANGE;
+            if (ft_errno == ER_SUCCESS)
+                ft_errno = FT_ERANGE;
             return (false);
         }
         adjusted_epoch = epoch_time - static_cast<std::time_t>(offset_seconds);
@@ -254,7 +256,8 @@ bool    time_parse_custom(const char *string_input, const char *format, std::tm 
         epoch_time = cmp_timegm(&parsed_time);
         if (epoch_time == static_cast<std::time_t>(-1))
         {
-            ft_errno = FT_ERANGE;
+            if (ft_errno == ER_SUCCESS)
+                ft_errno = FT_ERANGE;
             return (false);
         }
     }


### PR DESCRIPTION
## Summary
- set cmp_timegm to report FT_EINVAL for null input and clear errno when conversion succeeds
- preserve cmp_timegm error reporting in time_parse helpers
- extend the time test suite with coverage for cmp_timegm null-pointer handling

## Testing
- make -C Test
- ./Test/libft_tests --gtest_filter=test_cmp_timegm_null_pointer_sets_errno

------
https://chatgpt.com/codex/tasks/task_e_68db89c4b8f483318615a0a719267223