### PR TITLE
Fix pthread errno propagation and add regression tests

### DIFF
--- a/PThread/pthread_thread_create.cpp
+++ b/PThread/pthread_thread_create.cpp
@@ -1,4 +1,3 @@
-#include <cerrno>
 #include <pthread.h>
 #include "pthread.hpp"
 #include "../Errno/errno.hpp"
@@ -8,8 +7,14 @@ thread_local pt_thread_id_type pt_thread_id = THREAD_ID;
 int pt_thread_create(pthread_t *thread, const pthread_attr_t *attr,
                 void *(*start_routine)(void *), void *arg)
 {
-    int return_value = pthread_create(thread, attr, start_routine, arg);
+    int return_value;
+
+    return_value = pthread_create(thread, attr, start_routine, arg);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }

--- a/PThread/pthread_thread_detach.cpp
+++ b/PThread/pthread_thread_detach.cpp
@@ -1,12 +1,17 @@
-#include <cerrno>
 #include <pthread.h>
 #include "pthread.hpp"
 #include "../Errno/errno.hpp"
 
 int pt_thread_detach(pthread_t thread)
 {
-        int return_value = pthread_detach(thread);
-        if (return_value != 0)
-                ft_errno = errno + ERRNO_OFFSET;
+    int return_value;
+
+    return_value = pthread_detach(thread);
+    if (return_value != 0)
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
         return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
+    return (return_value);
 }

--- a/PThread/pthread_thread_join.cpp
+++ b/PThread/pthread_thread_join.cpp
@@ -1,12 +1,17 @@
-#include <cerrno>
 #include <pthread.h>
 #include "../Errno/errno.hpp"
 #include "pthread.hpp"
 
 int pt_thread_join(pthread_t thread, void **retval)
 {
-    int return_value = pthread_join(thread, retval);
+    int return_value;
+
+    return_value = pthread_join(thread, retval);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -57,6 +57,7 @@ $(OBJDIR)/%.o: %.cpp
 
 $(OBJDIR)/Test/test_promise.o: CFLAGS := $(COMPILE_FLAGS) -DTEST_MODULE=\"Template\"
 $(OBJDIR)/Test/test_task_scheduler.o: CFLAGS := $(COMPILE_FLAGS) -DTEST_MODULE=\"PThread\"
+$(OBJDIR)/Test/test_pthread_thread.o: CFLAGS := $(COMPILE_FLAGS) -DTEST_MODULE=\"PThread\"
 $(OBJDIR)/Test/test_networking.o $(OBJDIR)/Test/test_http_server.o $(OBJDIR)/Test/test_websocket.o: CFLAGS := $(COMPILE_FLAGS) -DTEST_MODULE=\"Networking\"
 $(OBJDIR)/Test/test_logger.o $(OBJDIR)/Test/test_logger_async.o $(OBJDIR)/Test/test_logger_network.o: CFLAGS := $(COMPILE_FLAGS) -DTEST_MODULE=\"Logger\"
 $(OBJDIR)/Test/test_json_validate.o: CFLAGS := $(COMPILE_FLAGS) -DTEST_MODULE=\"JSon\"

--- a/Test/Test/test_pthread_thread.cpp
+++ b/Test/Test/test_pthread_thread.cpp
@@ -1,0 +1,82 @@
+#include "../../PThread/pthread.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+static void *pthread_test_routine(void *argument)
+{
+    int *started_flag;
+
+    started_flag = static_cast<int*>(argument);
+    if (started_flag != ft_nullptr)
+        *started_flag = 1;
+    return (ft_nullptr);
+}
+
+FT_TEST(test_pt_thread_create_updates_errno, "pt_thread_create updates ft_errno on failure and success")
+{
+    pthread_t thread;
+    int failure_result;
+    int success_result;
+    int routine_started;
+    pthread_attr_t attributes;
+    size_t huge_stack_size;
+    int set_stack_result;
+
+    routine_started = 0;
+    pthread_attr_init(&attributes);
+    huge_stack_size = static_cast<size_t>(1ULL) << 40;
+    set_stack_result = pthread_attr_setstacksize(&attributes, huge_stack_size);
+    FT_ASSERT_EQ(0, set_stack_result);
+    failure_result = pt_thread_create(&thread, &attributes, pthread_test_routine, &routine_started);
+    FT_ASSERT(failure_result != 0);
+    FT_ASSERT_EQ(failure_result + ERRNO_OFFSET, ft_errno);
+    pthread_attr_destroy(&attributes);
+    success_result = pt_thread_create(&thread, ft_nullptr, pthread_test_routine, &routine_started);
+    FT_ASSERT_EQ(0, success_result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, pt_thread_join(thread, ft_nullptr));
+    FT_ASSERT_EQ(1, routine_started);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_pt_thread_join_updates_errno, "pt_thread_join updates ft_errno on failure and success")
+{
+    pthread_t invalid_thread;
+    pthread_t thread;
+    int failure_result;
+    int routine_started;
+
+    invalid_thread = 0;
+    failure_result = pt_thread_join(invalid_thread, ft_nullptr);
+    FT_ASSERT(failure_result != 0);
+    FT_ASSERT_EQ(failure_result + ERRNO_OFFSET, ft_errno);
+    routine_started = 0;
+    FT_ASSERT_EQ(0, pt_thread_create(&thread, ft_nullptr, pthread_test_routine, &routine_started));
+    FT_ASSERT_EQ(0, pt_thread_join(thread, ft_nullptr));
+    FT_ASSERT_EQ(1, routine_started);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_pt_thread_detach_updates_errno, "pt_thread_detach updates ft_errno on failure and success")
+{
+    pthread_t invalid_thread;
+    pthread_t thread;
+    int failure_result;
+    int detach_result;
+    int routine_started;
+
+    invalid_thread = 0;
+    failure_result = pt_thread_detach(invalid_thread);
+    FT_ASSERT(failure_result != 0);
+    FT_ASSERT_EQ(failure_result + ERRNO_OFFSET, ft_errno);
+    routine_started = 0;
+    FT_ASSERT_EQ(0, pt_thread_create(&thread, ft_nullptr, pthread_test_routine, &routine_started));
+    detach_result = pt_thread_detach(thread);
+    FT_ASSERT_EQ(0, detach_result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    while (routine_started == 0)
+        pt_thread_sleep(10);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- ensure the pthread create/join/detach wrappers translate pthread_* return codes into ft_errno and clear ft_errno on success
- add a pthread test suite that covers failure-then-success scenarios for thread create/join/detach and register it with the PThread module

## Testing
- make tests COMPILE_FLAGS="-Wall -Wextra -Werror -std=c++17 -O0 -g"
- Test/libft_tests


------
https://chatgpt.com/codex/tasks/task_e_68db8c7f47208331ab25550c24ae511a