### PR TITLE
Fix pthread condition and rwlock errno handling

### DIFF
--- a/PThread/pthread_condition.cpp
+++ b/PThread/pthread_condition.cpp
@@ -1,4 +1,3 @@
-#include <cerrno>
 #include <pthread.h>
 #include "condition.hpp"
 #include "../Errno/errno.hpp"
@@ -7,7 +6,11 @@ int pt_cond_init(pthread_cond_t *condition, const pthread_condattr_t *attributes
 {
     int return_value = pthread_cond_init(condition, attributes);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 
@@ -15,7 +18,11 @@ int pt_cond_destroy(pthread_cond_t *condition)
 {
     int return_value = pthread_cond_destroy(condition);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 
@@ -23,7 +30,11 @@ int pt_cond_wait(pthread_cond_t *condition, pthread_mutex_t *mutex)
 {
     int return_value = pthread_cond_wait(condition, mutex);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 
@@ -31,7 +42,11 @@ int pt_cond_signal(pthread_cond_t *condition)
 {
     int return_value = pthread_cond_signal(condition);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 
@@ -39,7 +54,11 @@ int pt_cond_broadcast(pthread_cond_t *condition)
 {
     int return_value = pthread_cond_broadcast(condition);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 

--- a/PThread/pthread_rwlock.cpp
+++ b/PThread/pthread_rwlock.cpp
@@ -1,4 +1,3 @@
-#include <cerrno>
 #include <pthread.h>
 #include "pthread.hpp"
 #include "../Errno/errno.hpp"
@@ -7,7 +6,11 @@ int pt_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attribu
 {
     int return_value = pthread_rwlock_init(rwlock, attributes);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 
@@ -15,7 +18,11 @@ int pt_rwlock_rdlock(pthread_rwlock_t *rwlock)
 {
     int return_value = pthread_rwlock_rdlock(rwlock);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 
@@ -23,7 +30,11 @@ int pt_rwlock_wrlock(pthread_rwlock_t *rwlock)
 {
     int return_value = pthread_rwlock_wrlock(rwlock);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 
@@ -31,7 +42,11 @@ int pt_rwlock_unlock(pthread_rwlock_t *rwlock)
 {
     int return_value = pthread_rwlock_unlock(rwlock);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 
@@ -39,7 +54,11 @@ int pt_rwlock_destroy(pthread_rwlock_t *rwlock)
 {
     int return_value = pthread_rwlock_destroy(rwlock);
     if (return_value != 0)
-        ft_errno = errno + ERRNO_OFFSET;
+    {
+        ft_errno = return_value + ERRNO_OFFSET;
+        return (return_value);
+    }
+    ft_errno = ER_SUCCESS;
     return (return_value);
 }
 

--- a/Test/Test/test_pthread_condition.cpp
+++ b/Test/Test/test_pthread_condition.cpp
@@ -1,0 +1,57 @@
+#include "../../PThread/pthread.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+struct pt_condition_signal_data
+{
+    pthread_cond_t *condition;
+    pthread_mutex_t *mutex;
+    int *ready;
+};
+
+static void *pt_condition_signal_thread(void *argument)
+{
+    pt_condition_signal_data *data;
+
+    data = static_cast<pt_condition_signal_data*>(argument);
+    pthread_mutex_lock(data->mutex);
+    *(data->ready) = 1;
+    pthread_cond_signal(data->condition);
+    pthread_mutex_unlock(data->mutex);
+    return (ft_nullptr);
+}
+
+FT_TEST(test_pt_cond_wait_updates_errno, "pt_cond_wait updates ft_errno on failure and success")
+{
+    pthread_cond_t condition;
+    pthread_mutex_t mutex;
+    pt_condition_signal_data data;
+    pthread_t thread_identifier;
+    int failure_result;
+    int wait_result;
+    int ready;
+
+    FT_ASSERT_EQ(0, pt_cond_init(&condition, ft_nullptr));
+    FT_ASSERT_EQ(0, pthread_mutex_init(&mutex, ft_nullptr));
+    failure_result = pt_cond_wait(&condition, &mutex);
+    FT_ASSERT(failure_result != 0);
+    FT_ASSERT_EQ(failure_result + ERRNO_OFFSET, ft_errno);
+    ready = 0;
+    data.condition = &condition;
+    data.mutex = &mutex;
+    data.ready = &ready;
+    FT_ASSERT_EQ(0, pthread_mutex_lock(&mutex));
+    FT_ASSERT_EQ(0, pthread_create(&thread_identifier, ft_nullptr, pt_condition_signal_thread, &data));
+    while (ready == 0)
+    {
+        wait_result = pt_cond_wait(&condition, &mutex);
+        FT_ASSERT_EQ(0, wait_result);
+        FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    }
+    FT_ASSERT_EQ(0, pthread_mutex_unlock(&mutex));
+    FT_ASSERT_EQ(0, pthread_join(thread_identifier, ft_nullptr));
+    FT_ASSERT_EQ(0, pt_cond_destroy(&condition));
+    FT_ASSERT_EQ(0, pthread_mutex_destroy(&mutex));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_pthread_rwlock.cpp
+++ b/Test/Test/test_pthread_rwlock.cpp
@@ -1,5 +1,6 @@
 #include "../../PThread/pthread.hpp"
 #include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
 
 struct reader_data
 {
@@ -76,5 +77,22 @@ int test_pt_rwlock_readers_writers(void)
     pt_thread_join(writer_thread, ft_nullptr);
     pt_rwlock_destroy(&rwlock);
     return (writer_acquired == 1 && writer_acquired_early == 0 && shared_value == 1);
+}
+
+FT_TEST(test_pt_rwlock_unlock_updates_errno, "pt_rwlock_unlock updates ft_errno on failure and success")
+{
+    pthread_rwlock_t rwlock;
+    int failure_result;
+
+    FT_ASSERT_EQ(0, pt_rwlock_init(&rwlock, ft_nullptr));
+    failure_result = pt_rwlock_unlock(&rwlock);
+    FT_ASSERT(failure_result != 0);
+    FT_ASSERT_EQ(failure_result + ERRNO_OFFSET, ft_errno);
+    FT_ASSERT_EQ(0, pthread_rwlock_wrlock(&rwlock));
+    FT_ASSERT_EQ(0, pt_rwlock_unlock(&rwlock));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, pt_rwlock_destroy(&rwlock));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
 }
 


### PR DESCRIPTION
## Summary
- update pthread condition and rwlock helpers to translate pthread return codes and clear ft_errno on success
- add regression tests that fail then succeed to ensure condition variables and rwlocks update ft_errno

## Testing
- make -C Test

------
https://chatgpt.com/codex/tasks/task_e_68dbf5bd5d988331b711d43f5cfd2456