### PR TITLE
Fix fd_istream errno handling

### DIFF
--- a/CPP_class/cpp_class_fd_istream.cpp
+++ b/CPP_class/cpp_class_fd_istream.cpp
@@ -18,8 +18,14 @@ std::size_t ft_fd_istream::do_read(char *buffer, std::size_t count)
     result = su_read(this->_fd, buffer, count);
     if (result < 0)
     {
-        this->set_error(FILE_INVALID_FD);
+        int read_error;
+
+        read_error = ft_errno;
+        if (read_error == ER_SUCCESS)
+            read_error = FILE_INVALID_FD;
+        this->set_error(read_error);
         return (0);
     }
+    this->set_error(ER_SUCCESS);
     return (static_cast<std::size_t>(result));
 }

--- a/Test/Test/test_cpp_class_errors.cpp
+++ b/Test/Test/test_cpp_class_errors.cpp
@@ -1,4 +1,5 @@
 #include "../../CPP_class/class_file.hpp"
+#include "../../CPP_class/class_fd_istream.hpp"
 #include "../../CPP_class/class_ofstream.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
 #include "../../Errno/errno.hpp"
@@ -42,5 +43,51 @@ FT_TEST(test_ft_ofstream_error_resets, "ft_ofstream resets error state after suc
     FT_ASSERT_EQ(ER_SUCCESS, stream.get_error());
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     ::unlink(filename);
+    return (1);
+}
+
+FT_TEST(test_ft_fd_istream_error_resets, "ft_fd_istream preserves su_read errno and clears after success")
+{
+    int pipe_descriptors[2];
+    int target_descriptor;
+    int write_descriptor;
+    int new_read_descriptor;
+    ssize_t write_result;
+    char read_buffer[3];
+    int failure_error;
+    const char message[] = "go";
+
+    FT_ASSERT_EQ(0, ::pipe(pipe_descriptors));
+    target_descriptor = pipe_descriptors[0];
+    write_descriptor = pipe_descriptors[1];
+    ft_fd_istream stream(target_descriptor);
+
+    FT_ASSERT_EQ(0, ::close(target_descriptor));
+    FT_ASSERT_EQ(0, ::close(write_descriptor));
+    stream.read(read_buffer, sizeof(read_buffer));
+    failure_error = ft_errno;
+    FT_ASSERT(failure_error != ER_SUCCESS);
+    FT_ASSERT_EQ(failure_error, stream.get_error());
+
+    FT_ASSERT_EQ(0, ::pipe(pipe_descriptors));
+    new_read_descriptor = pipe_descriptors[0];
+    write_descriptor = pipe_descriptors[1];
+    if (new_read_descriptor != target_descriptor)
+    {
+        FT_ASSERT_EQ(target_descriptor, ::dup2(new_read_descriptor, target_descriptor));
+        FT_ASSERT_EQ(0, ::close(new_read_descriptor));
+    }
+
+    write_result = ::write(write_descriptor, message, sizeof(message) - 1);
+    FT_ASSERT_EQ(static_cast<ssize_t>(sizeof(message) - 1), write_result);
+    FT_ASSERT_EQ(0, ::close(write_descriptor));
+
+    stream.read(read_buffer, sizeof(message) - 1);
+    FT_ASSERT_EQ(ER_SUCCESS, stream.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(static_cast<std::size_t>(sizeof(message) - 1), stream.gcount());
+    FT_ASSERT_EQ('g', read_buffer[0]);
+    FT_ASSERT_EQ('o', read_buffer[1]);
+    FT_ASSERT_EQ(0, ::close(target_descriptor));
     return (1);
 }


### PR DESCRIPTION
## Summary
- propagate the su_read error code through ft_fd_istream::do_read and clear stale errors on successful reads
- add a regression test that exercises a failed read followed by a successful one to verify the error state resets

## Testing
- make -C Test
- /tmp/fd_istream_test

------
https://chatgpt.com/codex/tasks/task_e_68dc10d737f08331bcbb8b83faf71773