### PR TITLE
Reset stringbuf error state after successful reads

### DIFF
--- a/CPP_class/cpp_class_stringbuf.cpp
+++ b/CPP_class/cpp_class_stringbuf.cpp
@@ -23,6 +23,7 @@ void ft_stringbuf::set_error(int error_code) const
 std::size_t ft_stringbuf::read(char *buffer, std::size_t count)
 {
     std::size_t index = 0;
+    bool failure_occurred = false;
 
     if (!buffer)
     {
@@ -35,12 +36,15 @@ std::size_t ft_stringbuf::read(char *buffer, std::size_t count)
         if (!current)
         {
             this->set_error(FT_EINVAL);
+            failure_occurred = true;
             break ;
         }
         buffer[index] = *current;
         index++;
         this->_position++;
     }
+    if (!failure_occurred && index > 0)
+        this->set_error(ER_SUCCESS);
     return (index);
 }
 
@@ -65,5 +69,7 @@ ft_string ft_stringbuf::str() const
     ft_string result(start + this->_position);
     if (result.get_error() != ER_SUCCESS)
         this->set_error(result.get_error());
+    else
+        this->set_error(ER_SUCCESS);
     return (result);
 }

--- a/Test/Test/test_cpp_class_errors.cpp
+++ b/Test/Test/test_cpp_class_errors.cpp
@@ -1,5 +1,6 @@
 #include "../../CPP_class/class_file.hpp"
 #include "../../CPP_class/class_fd_istream.hpp"
+#include "../../CPP_class/class_istringstream.hpp"
 #include "../../CPP_class/class_ofstream.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
 #include "../../Errno/errno.hpp"
@@ -89,5 +90,30 @@ FT_TEST(test_ft_fd_istream_error_resets, "ft_fd_istream preserves su_read errno 
     FT_ASSERT_EQ('g', read_buffer[0]);
     FT_ASSERT_EQ('o', read_buffer[1]);
     FT_ASSERT_EQ(0, ::close(target_descriptor));
+    return (1);
+}
+
+FT_TEST(test_ft_istringstream_error_resets, "ft_istringstream resets error state after invalid read")
+{
+    ft_istringstream stream("reset");
+    char read_buffer[6] = {0};
+
+    ft_errno = ER_SUCCESS;
+    stream.read(ft_nullptr, 1);
+    FT_ASSERT_EQ(FT_EINVAL, stream.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT(stream.bad());
+
+    stream.read(read_buffer, 5);
+    FT_ASSERT_EQ(ER_SUCCESS, stream.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(false, stream.bad());
+    FT_ASSERT_EQ(static_cast<std::size_t>(5), stream.gcount());
+    FT_ASSERT_EQ('r', read_buffer[0]);
+    FT_ASSERT_EQ('e', read_buffer[1]);
+    FT_ASSERT_EQ('s', read_buffer[2]);
+    FT_ASSERT_EQ('e', read_buffer[3]);
+    FT_ASSERT_EQ('t', read_buffer[4]);
+    FT_ASSERT_EQ(0, read_buffer[5]);
     return (1);
 }


### PR DESCRIPTION
## Summary
- ensure `ft_stringbuf::read` restores `ER_SUCCESS` when characters are copied and preserves failure states
- clear stale errors from `ft_stringbuf::str` on successful string extraction
- add a regression test that exercises a failed `ft_istringstream` read followed by a successful one

## Testing
- `make libft_tests` *(aborted because the full suite rebuild is extremely large in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc15cab1148331a474867fc32863db