### PR TITLE
Handle null pointer checks for pthread condition helpers

### DIFF
--- a/PThread/pthread_condition.cpp
+++ b/PThread/pthread_condition.cpp
@@ -1,6 +1,7 @@
 #include <pthread.h>
 #include "condition.hpp"
 #include "../Errno/errno.hpp"
+#include "../CPP_class/class_nullptr.hpp"
 
 int pt_cond_init(pthread_cond_t *condition, const pthread_condattr_t *attributes)
 {
@@ -28,7 +29,14 @@ int pt_cond_destroy(pthread_cond_t *condition)
 
 int pt_cond_wait(pthread_cond_t *condition, pthread_mutex_t *mutex)
 {
-    int return_value = pthread_cond_wait(condition, mutex);
+    int return_value;
+
+    if (condition == ft_nullptr || mutex == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    return_value = pthread_cond_wait(condition, mutex);
     if (return_value != 0)
     {
         ft_errno = return_value + ERRNO_OFFSET;

--- a/PThread/pthread_rwlock.cpp
+++ b/PThread/pthread_rwlock.cpp
@@ -1,6 +1,7 @@
 #include <pthread.h>
 #include "pthread.hpp"
 #include "../Errno/errno.hpp"
+#include "../CPP_class/class_nullptr.hpp"
 
 int pt_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attributes)
 {
@@ -40,7 +41,14 @@ int pt_rwlock_wrlock(pthread_rwlock_t *rwlock)
 
 int pt_rwlock_unlock(pthread_rwlock_t *rwlock)
 {
-    int return_value = pthread_rwlock_unlock(rwlock);
+    int return_value;
+
+    if (rwlock == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    return_value = pthread_rwlock_unlock(rwlock);
     if (return_value != 0)
     {
         ft_errno = return_value + ERRNO_OFFSET;

--- a/RNG/rng_uuid.cpp
+++ b/RNG/rng_uuid.cpp
@@ -1,9 +1,13 @@
 #include "rng.hpp"
+#include "../Errno/errno.hpp"
 
 void ft_generate_uuid(char out[37])
 {
     if (out == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return ;
+    }
     unsigned char uuid_bytes[16];
     if (rng_secure_bytes(uuid_bytes, 16) != 0)
     {
@@ -29,6 +33,7 @@ void ft_generate_uuid(char out[37])
         byte_index++;
     }
     out[output_index] = '\0';
+    ft_errno = ER_SUCCESS;
     return ;
 }
 

--- a/Test/Test/test_pthread_condition.cpp
+++ b/Test/Test/test_pthread_condition.cpp
@@ -31,11 +31,14 @@ FT_TEST(test_pt_cond_wait_updates_errno, "pt_cond_wait updates ft_errno on failu
     int wait_result;
     int ready;
 
-    FT_ASSERT_EQ(0, pt_cond_init(&condition, ft_nullptr));
     FT_ASSERT_EQ(0, pthread_mutex_init(&mutex, ft_nullptr));
-    failure_result = pt_cond_wait(&condition, &mutex);
-    FT_ASSERT(failure_result != 0);
-    FT_ASSERT_EQ(failure_result + ERRNO_OFFSET, ft_errno);
+    failure_result = pt_cond_wait(ft_nullptr, &mutex);
+    FT_ASSERT_EQ(-1, failure_result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(0, pt_cond_init(&condition, ft_nullptr));
+    failure_result = pt_cond_wait(&condition, ft_nullptr);
+    FT_ASSERT_EQ(-1, failure_result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     ready = 0;
     data.condition = &condition;
     data.mutex = &mutex;

--- a/Test/Test/test_pthread_rwlock.cpp
+++ b/Test/Test/test_pthread_rwlock.cpp
@@ -85,9 +85,9 @@ FT_TEST(test_pt_rwlock_unlock_updates_errno, "pt_rwlock_unlock updates ft_errno 
     int failure_result;
 
     FT_ASSERT_EQ(0, pt_rwlock_init(&rwlock, ft_nullptr));
-    failure_result = pt_rwlock_unlock(&rwlock);
-    FT_ASSERT(failure_result != 0);
-    FT_ASSERT_EQ(failure_result + ERRNO_OFFSET, ft_errno);
+    failure_result = pt_rwlock_unlock(ft_nullptr);
+    FT_ASSERT_EQ(-1, failure_result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     FT_ASSERT_EQ(0, pthread_rwlock_wrlock(&rwlock));
     FT_ASSERT_EQ(0, pt_rwlock_unlock(&rwlock));
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);

--- a/Test/Test/test_rng_uuid.cpp
+++ b/Test/Test/test_rng_uuid.cpp
@@ -1,0 +1,42 @@
+#include "../../RNG/rng.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+static int is_lower_hexadecimal_character(char value)
+{
+    if (value >= '0' && value <= '9')
+        return (1);
+    if (value >= 'a' && value <= 'f')
+        return (1);
+    return (0);
+}
+
+FT_TEST(test_ft_generate_uuid_null_out_sets_errno, "ft_generate_uuid null output sets errno")
+{
+    ft_errno = ER_SUCCESS;
+    ft_generate_uuid(ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_generate_uuid_success_sets_errno_success, "ft_generate_uuid success sets errno success")
+{
+    char output[37];
+    size_t index;
+
+    ft_errno = FT_EINVAL;
+    ft_generate_uuid(output);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    index = 0;
+    while (index < 36)
+    {
+        if (index == 8 || index == 13 || index == 18 || index == 23)
+            FT_ASSERT_EQ('-', output[index]);
+        else
+            FT_ASSERT(is_lower_hexadecimal_character(output[index]) != 0);
+        index++;
+    }
+    FT_ASSERT_EQ('\0', output[36]);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- guard pt_cond_wait and pt_rwlock_unlock against null arguments while keeping errno translation for underlying pthread failures
- update the pthread condition and rwlock tests to cover the new null argument behavior and verify errno resets on success

## Testing
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68dc18706af88331af25ce2419960c30