### PR TITLE
Ensure game deserializers refresh ft_errno state

### DIFF
--- a/Game/game_character_save_load.cpp
+++ b/Game/game_character_save_load.cpp
@@ -337,7 +337,10 @@ int deserialize_character(ft_character &character, json_group *group)
         {
             char *skill_index_string = cma_itoa(skill_index);
             if (!skill_index_string)
+            {
+                ft_errno = JSON_MALLOC_FAIL;
                 return (JSON_MALLOC_FAIL);
+            }
             ft_string prefix = "skill_";
             prefix += skill_index_string;
             cma_free(skill_index_string);
@@ -380,6 +383,7 @@ int deserialize_character(ft_character &character, json_group *group)
             skill_index++;
         }
     }
+    ft_errno = ER_SUCCESS;
     return (ER_SUCCESS);
 }
 

--- a/Game/game_load.cpp
+++ b/Game/game_load.cpp
@@ -22,6 +22,7 @@ static int parse_item_field(json_group *group, const ft_string &key, int &out_va
         return (GAME_GENERAL_ERROR);
     }
     out_value = ft_atoi(json_item_ptr->value);
+    ft_errno = ER_SUCCESS;
     return (ER_SUCCESS);
 }
 
@@ -93,6 +94,7 @@ static int build_item_from_group(ft_item &item, json_group *group, const ft_stri
     if (parse_item_field(group, key_mod4_value, value) != ER_SUCCESS)
         return (GAME_GENERAL_ERROR);
     item.set_modifier4_value(value);
+    ft_errno = ER_SUCCESS;
     return (ER_SUCCESS);
 }
 
@@ -141,7 +143,10 @@ int deserialize_inventory(ft_inventory &inventory, json_group *group)
     {
         char *item_index_string = cma_itoa(item_index);
         if (!item_index_string)
+        {
+            ft_errno = JSON_MALLOC_FAIL;
             return (JSON_MALLOC_FAIL);
+        }
         ft_string item_prefix = "item_";
         item_prefix += item_index_string;
         cma_free(item_index_string);
@@ -150,13 +155,17 @@ int deserialize_inventory(ft_inventory &inventory, json_group *group)
             return (GAME_GENERAL_ERROR);
         ft_sharedptr<ft_item> item(new ft_item(item_temp));
         if (!item)
+        {
+            ft_errno = JSON_MALLOC_FAIL;
             return (JSON_MALLOC_FAIL);
+        }
         if (inventory.add_item(item) != ER_SUCCESS)
             return (inventory.get_error());
         item_index++;
     }
     inventory.set_current_weight(serialized_weight);
     inventory.set_used_slots(serialized_slots);
+    ft_errno = ER_SUCCESS;
     return (ER_SUCCESS);
 }
 
@@ -198,6 +207,7 @@ int deserialize_equipment(ft_character &character, json_group *group)
     }
     else
         character.unequip_item(EQUIP_WEAPON);
+    ft_errno = ER_SUCCESS;
     return (ER_SUCCESS);
 }
 
@@ -237,7 +247,10 @@ int deserialize_quest(ft_quest &quest, json_group *group)
         {
             char *index_string = cma_itoa(reward_index);
             if (!index_string)
+            {
+                ft_errno = JSON_MALLOC_FAIL;
                 return (JSON_MALLOC_FAIL);
+            }
             ft_string prefix = "reward_item_";
             prefix += index_string;
             cma_free(index_string);
@@ -245,10 +258,16 @@ int deserialize_quest(ft_quest &quest, json_group *group)
             if (build_item_from_group(reward_temp, group, prefix) != ER_SUCCESS)
                 return (GAME_GENERAL_ERROR);
             ft_sharedptr<ft_item> reward(new ft_item(reward_temp));
+            if (!reward)
+            {
+                ft_errno = JSON_MALLOC_FAIL;
+                return (JSON_MALLOC_FAIL);
+            }
             quest.get_reward_items().push_back(reward);
             reward_index++;
         }
     }
+    ft_errno = ER_SUCCESS;
     return (ER_SUCCESS);
 }
 

--- a/Test/Test/test_game_serialization_errors.cpp
+++ b/Test/Test/test_game_serialization_errors.cpp
@@ -14,6 +14,7 @@ json_group *serialize_inventory(const ft_inventory &inventory);
 json_group *serialize_equipment(const ft_character &character);
 json_group *serialize_quest(const ft_quest &quest);
 json_group *serialize_character(const ft_character &character);
+int deserialize_inventory(ft_inventory &inventory, json_group *group);
 
 FT_TEST(test_serialize_inventory_allocation_failure_sets_errno, "serialize_inventory reports allocation failure")
 {
@@ -172,6 +173,77 @@ FT_TEST(test_serialize_character_success_clears_errno, "serialize_character clea
     ft_errno = GAME_GENERAL_ERROR;
     json_group *group = serialize_character(character);
     FT_ASSERT(group != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    json_free_groups(group);
+    return (1);
+}
+
+FT_TEST(test_deserialize_inventory_failure_then_success_updates_errno, "deserialize_inventory updates errno after failure and success")
+{
+    ft_inventory inventory;
+    json_group *group = json_create_json_group("inventory");
+
+    FT_ASSERT(group != ft_nullptr);
+    json_item *item = json_create_item("capacity", 2);
+
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("weight_limit", 50);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("current_weight", 10);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("used_slots", 1);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_count", 1);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_stack_size", 1);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_id", 7);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_width", 1);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_height", 1);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_mod1_id", 0);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_mod1_value", 0);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_mod2_id", 0);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_mod2_value", 0);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_mod3_id", 0);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_mod3_value", 0);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_mod4_id", 0);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    item = json_create_item("item_0_mod4_value", 0);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(GAME_GENERAL_ERROR, deserialize_inventory(inventory, group));
+    FT_ASSERT_EQ(GAME_GENERAL_ERROR, ft_errno);
+    item = json_create_item("item_0_max_stack", 5);
+    FT_ASSERT(item != ft_nullptr);
+    json_add_item_to_group(group, item);
+    ft_errno = GAME_GENERAL_ERROR;
+    FT_ASSERT_EQ(ER_SUCCESS, deserialize_inventory(inventory, group));
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     json_free_groups(group);
     return (1);


### PR DESCRIPTION
## Summary
- ensure game load helpers set ft_errno on allocation failures and clear it on successful completion
- propagate the same ft_errno handling to character deserialization
- add a regression test that exercises deserialize_inventory failure followed by success to verify errno reset

## Testing
- make -C Test objs/Test/test_game_serialization_errors.o

------
https://chatgpt.com/codex/tasks/task_e_68dc2ccc519c83319713140d5bae3a42