### PR TITLE
Fix printf errno propagation and tests

### DIFF
--- a/Printf/printf_format.cpp
+++ b/Printf/printf_format.cpp
@@ -1,4 +1,7 @@
 #include "printf_internal.hpp"
+#include "printf_test_hooks.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include <cstdarg>
 #include <unistd.h>
 #include <stdarg.h>
@@ -6,6 +9,14 @@
 #include <stdint.h>
 #include <limits.h>
 #include <stddef.h>
+
+static t_pf_printf_count_override_hook g_pf_printf_count_override_hook = ft_nullptr;
+
+void pf_printf_set_count_override_hook(t_pf_printf_count_override_hook hook)
+{
+    g_pf_printf_count_override_hook = hook;
+    return ;
+}
 
 int pf_printf_fd_v(int fd, const char *format, va_list args)
 {
@@ -195,9 +206,18 @@ int pf_printf_fd_v(int fd, const char *format, va_list args)
             ft_putchar_fd(format[index], fd, &count);
         index++;
     }
+    if (g_pf_printf_count_override_hook != ft_nullptr)
+    {
+        size_t override_value = g_pf_printf_count_override_hook();
+        count = override_value;
+    }
     if (count == SIZE_MAX)
         return (-1);
     if (count > static_cast<size_t>(INT_MAX))
+    {
+        ft_errno = FT_ERANGE;
         return (-1);
+    }
+    ft_errno = ER_SUCCESS;
     return (static_cast<int>(count));
 }

--- a/Printf/printf_printf.cpp
+++ b/Printf/printf_printf.cpp
@@ -1,5 +1,7 @@
 #include "printf.hpp"
 #include "printf_internal.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include <cstdarg>
 #include <unistd.h>
 #include <stdarg.h>
@@ -13,11 +15,16 @@ int pf_printf_fd(int fd, const char *format, ...)
     va_list args;
     int        printed_chars;
 
-    if (!format)
+    if (format == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (0);
+    }
     va_start(args, format);
     printed_chars = pf_printf_fd_v(fd, format, args);
     va_end(args);
+    if (printed_chars >= 0)
+        ft_errno = ER_SUCCESS;
     return (printed_chars);
 }
 
@@ -26,10 +33,15 @@ int pf_printf(const char *format, ...)
     va_list    args;
     int        printed_chars;
 
-    if (!format)
+    if (format == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
         return (0);
+    }
     va_start(args, format);
     printed_chars = pf_printf_fd_v(1, format, args);
     va_end(args);
+    if (printed_chars >= 0)
+        ft_errno = ER_SUCCESS;
     return (printed_chars);
 }

--- a/Printf/printf_test_hooks.hpp
+++ b/Printf/printf_test_hooks.hpp
@@ -1,0 +1,10 @@
+#ifndef PRINTF_TEST_HOOKS_HPP
+# define PRINTF_TEST_HOOKS_HPP
+
+#include <stddef.h>
+
+typedef size_t (*t_pf_printf_count_override_hook)(void);
+
+void    pf_printf_set_count_override_hook(t_pf_printf_count_override_hook hook);
+
+#endif

--- a/Test/Test/test_printf.cpp
+++ b/Test/Test/test_printf.cpp
@@ -1,8 +1,60 @@
 #include "../../Printf/printf.hpp"
+#include "../../Printf/printf_test_hooks.hpp"
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <climits>
 #include <fcntl.h>
 #include <unistd.h>
+
+static size_t pf_test_count_overflow_hook(void)
+{
+    return (static_cast<size_t>(INT_MAX) + 1);
+}
+
+FT_TEST(test_pf_printf_null_format_sets_errno, "pf_printf null format guard updates errno")
+{
+    ft_errno = ER_SUCCESS;
+    typedef int (*t_pf_printf_function)(const char *format, ...);
+    t_pf_printf_function printf_function = pf_printf;
+    int result = printf_function(ft_nullptr);
+    FT_ASSERT_EQ(0, result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_pf_printf_fd_success_clears_errno, "pf_printf_fd success clears errno")
+{
+    const char *file_name = "tmp_pf_printf_errno_success.txt";
+    int file_descriptor = ::open(file_name, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (file_descriptor < 0)
+        return (0);
+    ft_errno = FT_EINVAL;
+    int printed = pf_printf_fd(file_descriptor, "ok");
+    ::close(file_descriptor);
+    ::unlink(file_name);
+    FT_ASSERT_EQ(2, printed);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_pf_printf_fd_overflow_sets_errno, "pf_printf_fd overflow guard sets errno")
+{
+    const char *file_name = "tmp_pf_printf_errno_overflow.txt";
+    int file_descriptor = ::open(file_name, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (file_descriptor < 0)
+        return (0);
+    pf_printf_set_count_override_hook(pf_test_count_overflow_hook);
+    ft_errno = ER_SUCCESS;
+    int printed = pf_printf_fd(file_descriptor, "x");
+    pf_printf_set_count_override_hook(ft_nullptr);
+    ::close(file_descriptor);
+    ::unlink(file_name);
+    FT_ASSERT_EQ(-1, printed);
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
+    return (1);
+}
 
 int test_pf_printf_basic(void)
 {


### PR DESCRIPTION
## Summary
- ensure pf_printf and pf_printf_fd reject null formats with FT_EINVAL and clear stale ft_errno on success
- set pf_printf_fd_v overflow errors to FT_ERANGE, expose a count override hook for testing, and return ER_SUCCESS on normal completion
- add printf tests that assert errno handling for null formats, successful prints, and forced overflow via the new hook

## Testing
- make -C Test *(fails: build interrupted before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2f18f63083318576899397929dfe