### PR TITLE
Ensure directory helpers update errno correctly

### DIFF
--- a/File/file_opendir.cpp
+++ b/File/file_opendir.cpp
@@ -9,15 +9,29 @@ file_dir *file_opendir(const char *directory_path)
 
 file_dirent *file_readdir(file_dir *directory_stream)
 {
+    file_dirent *directory_entry;
+
     if (!directory_stream)
+    {
+        ft_errno = FT_EINVAL;
         return (ft_nullptr);
-    return (cmp_dir_read(directory_stream));
+    }
+    directory_entry = cmp_dir_read(directory_stream);
+    ft_errno = ER_SUCCESS;
+    return (directory_entry);
 }
 
 int file_closedir(file_dir *directory_stream)
 {
+    int close_result;
+
     if (!directory_stream)
+    {
+        ft_errno = FT_EINVAL;
         return (-1);
-    return (cmp_dir_close(directory_stream));
+    }
+    close_result = cmp_dir_close(directory_stream);
+    ft_errno = ER_SUCCESS;
+    return (close_result);
 }
 

--- a/Test/Test/test_file_utils.cpp
+++ b/Test/Test/test_file_utils.cpp
@@ -93,3 +93,50 @@ FT_TEST(test_file_dir_exists_matches_file_exists_semantics, "file_dir_exists ret
     FT_ASSERT_EQ(0, file_dir_exists(directory_path));
     return (1);
 }
+
+FT_TEST(test_file_readdir_handles_null_stream, "file_readdir sets FT_EINVAL when stream is null")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, file_readdir(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_file_readdir_clears_error_on_success, "file_readdir sets ER_SUCCESS after reading entry")
+{
+    file_dir *directory_stream;
+    file_dirent *directory_entry;
+
+    directory_stream = file_opendir(".");
+    FT_ASSERT(directory_stream != ft_nullptr);
+    if (directory_stream == ft_nullptr)
+        return (0);
+    ft_errno = FT_EINVAL;
+    directory_entry = file_readdir(directory_stream);
+    FT_ASSERT(directory_entry != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, file_closedir(directory_stream));
+    return (1);
+}
+
+FT_TEST(test_file_closedir_handles_null_stream, "file_closedir sets FT_EINVAL when stream is null")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, file_closedir(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_file_closedir_clears_error_on_success, "file_closedir sets ER_SUCCESS after close")
+{
+    file_dir *directory_stream;
+
+    directory_stream = file_opendir(".");
+    FT_ASSERT(directory_stream != ft_nullptr);
+    if (directory_stream == ft_nullptr)
+        return (0);
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(0, file_closedir(directory_stream));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- set ft_errno on null stream guards in file_readdir and file_closedir
- clear ft_errno to ER_SUCCESS after invoking the compatibility helpers
- add unit tests covering error and success paths for the directory helpers

## Testing
- make test # fails: No rule to make target 'test'


------
https://chatgpt.com/codex/tasks/task_e_68dc48f30e788331a2b8ad5ac746a5bf