### PR TITLE
Fix storage flush test and inventory errno propagation

### DIFF
--- a/Game/game_load.cpp
+++ b/Game/game_load.cpp
@@ -139,6 +139,7 @@ int deserialize_inventory(ft_inventory &inventory, json_group *group)
     }
     int item_count = ft_atoi(count_item->value);
     int item_index = 0;
+    int loop_error = ER_SUCCESS;
     while (item_index < item_count)
     {
         char *item_index_string = cma_itoa(item_index);
@@ -152,7 +153,10 @@ int deserialize_inventory(ft_inventory &inventory, json_group *group)
         cma_free(item_index_string);
         ft_item item_temp;
         if (build_item_from_group(item_temp, group, item_prefix) != ER_SUCCESS)
-            return (GAME_GENERAL_ERROR);
+        {
+            loop_error = GAME_GENERAL_ERROR;
+            break ;
+        }
         ft_sharedptr<ft_item> item(new ft_item(item_temp));
         if (!item)
         {
@@ -160,8 +164,16 @@ int deserialize_inventory(ft_inventory &inventory, json_group *group)
             return (JSON_MALLOC_FAIL);
         }
         if (inventory.add_item(item) != ER_SUCCESS)
-            return (inventory.get_error());
+        {
+            loop_error = inventory.get_error();
+            break ;
+        }
         item_index++;
+    }
+    if (loop_error != ER_SUCCESS)
+    {
+        ft_errno = loop_error;
+        return (loop_error);
     }
     inventory.set_current_weight(serialized_weight);
     inventory.set_used_slots(serialized_slots);

--- a/Storage/storage_kv_store.cpp
+++ b/Storage/storage_kv_store.cpp
@@ -115,6 +115,7 @@ int kv_store::kv_flush() const
     json_item *item_pointer;
     std::map<std::string, std::string>::const_iterator map_iterator;
     int result;
+    int error_code;
 
     store_group = json_create_json_group("kv_store");
     if (store_group == ft_nullptr)
@@ -138,10 +139,14 @@ int kv_store::kv_flush() const
     head_group = ft_nullptr;
     json_append_group(&head_group, store_group);
     result = json_write_to_file(this->_file_path.c_str(), head_group);
+    error_code = ft_errno;
     json_free_groups(head_group);
     if (result != 0)
     {
-        this->set_error(result);
+        if (error_code != ER_SUCCESS)
+            this->set_error(error_code);
+        else
+            this->set_error(FT_EINVAL);
         return (-1);
     }
     this->set_error(ER_SUCCESS);

--- a/Test/Test/test_storage_kv_store.cpp
+++ b/Test/Test/test_storage_kv_store.cpp
@@ -1,0 +1,85 @@
+#include "../../Storage/kv_store.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include "../../File/file_utils.hpp"
+#include "../../File/open_dir.hpp"
+#include "../../Compatebility/compatebility_internal.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include <cstdio>
+#include <cerrno>
+#if defined(_WIN32) || defined(_WIN64)
+# include <windows.h>
+#else
+# include <unistd.h>
+#endif
+
+static void remove_directory_if_present(const char *directory_path)
+{
+    int directory_exists;
+
+    directory_exists = cmp_directory_exists(directory_path);
+    if (directory_exists != 1)
+        return ;
+#if defined(_WIN32) || defined(_WIN64)
+    RemoveDirectoryA(directory_path);
+#else
+    rmdir(directory_path);
+#endif
+    return ;
+}
+
+static void cleanup_paths(const char *directory_path, const char *file_path)
+{
+    file_delete(file_path);
+    remove_directory_if_present(directory_path);
+    ft_errno = ER_SUCCESS;
+    return ;
+}
+
+static void create_kv_store_file(const char *file_path)
+{
+    FILE *file_pointer;
+
+    file_pointer = ft_fopen(file_path, "w");
+    if (file_pointer == ft_nullptr)
+        return ;
+    std::fputs("{\n  \"kv_store\": {\n    \"__placeholder__\": \"\"\n  }\n}\n", file_pointer);
+    ft_fclose(file_pointer);
+    return ;
+}
+
+FT_TEST(test_kv_store_flush_propagates_json_writer_errno, "kv_store flush propagates json writer errno")
+{
+    const char *directory_path;
+    const char *file_path;
+    int flush_result;
+    int expected_error;
+
+    directory_path = "kv_store_flush_failure_directory";
+    file_path = "kv_store_flush_failure_directory/kv_store.json";
+    cleanup_paths(directory_path, file_path);
+    FT_ASSERT_EQ(0, file_create_directory(directory_path, 0700));
+    create_kv_store_file(file_path);
+    kv_store store(file_path);
+    FT_ASSERT_EQ(ER_SUCCESS, store.get_error());
+    FT_ASSERT_EQ(0, store.kv_delete("__placeholder__"));
+    FT_ASSERT_EQ(ER_SUCCESS, store.get_error());
+    FT_ASSERT_EQ(0, store.kv_set("key", "value"));
+    FT_ASSERT_EQ(ER_SUCCESS, store.get_error());
+    FT_ASSERT_EQ(0, file_delete(file_path));
+    remove_directory_if_present(directory_path);
+    ft_errno = ER_SUCCESS;
+    flush_result = store.kv_flush();
+    FT_ASSERT_EQ(-1, flush_result);
+#if defined(_WIN32) || defined(_WIN64)
+    expected_error = ERROR_PATH_NOT_FOUND + ERRNO_OFFSET;
+#else
+    expected_error = ENOENT + ERRNO_OFFSET;
+#endif
+    FT_ASSERT_EQ(expected_error, ft_errno);
+    FT_ASSERT_EQ(expected_error, store.get_error());
+    cleanup_paths(directory_path, file_path);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- update the kv_store flush regression test to seed the JSON file with a placeholder entry and clear it before exercising the failure path so construction succeeds
- ensure `deserialize_inventory` preserves `ft_errno` after helper failures by capturing loop errors and reporting them once temporary state has been cleaned up

## Testing
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68dcc9abb18483318551c1e6cff82cfd