### PR TITLE
Handle time_now errno propagation and add tests

### DIFF
--- a/Test/Test/test_time_now.cpp
+++ b/Test/Test/test_time_now.cpp
@@ -1,0 +1,90 @@
+#include "../../System_utils/test_runner.hpp"
+#include "../../Time/time.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include <cerrno>
+#include <chrono>
+#include <ctime>
+#include <dlfcn.h>
+
+static bool g_time_now_force_failure = false;
+static int g_time_now_forced_errno = EINVAL;
+
+static void time_now_set_force_failure(bool enable_failure, int error_code)
+{
+    g_time_now_force_failure = enable_failure;
+    g_time_now_forced_errno = error_code;
+    return ;
+}
+
+extern "C" std::time_t time(std::time_t *time_value)
+{
+    typedef std::time_t (*time_function_pointer)(std::time_t *);
+    static time_function_pointer real_time_function = ft_nullptr;
+
+    if (g_time_now_force_failure)
+    {
+        errno = g_time_now_forced_errno;
+        if (time_value != ft_nullptr)
+            *time_value = static_cast<std::time_t>(-1);
+        return (static_cast<std::time_t>(-1));
+    }
+    if (real_time_function == ft_nullptr)
+    {
+        void *symbol_pointer;
+
+        symbol_pointer = dlsym(RTLD_NEXT, "time");
+        if (symbol_pointer != ft_nullptr)
+            real_time_function = reinterpret_cast<time_function_pointer>(symbol_pointer);
+    }
+    if (real_time_function != ft_nullptr)
+        return (real_time_function(time_value));
+    errno = 0;
+    std::chrono::system_clock::time_point current_time_point = std::chrono::system_clock::now();
+    std::time_t fallback_time = std::chrono::system_clock::to_time_t(current_time_point);
+    if (time_value != ft_nullptr)
+        *time_value = fallback_time;
+    return (fallback_time);
+}
+
+FT_TEST(test_time_now_success_resets_errno, "time_now success resets ft_errno")
+{
+    t_time time_value;
+
+    time_now_set_force_failure(false, 0);
+    errno = 0;
+    ft_errno = FT_EINVAL;
+    time_value = time_now();
+    FT_ASSERT(time_value != static_cast<t_time>(-1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_now_ms_success_resets_errno, "time_now_ms success resets ft_errno")
+{
+    long milliseconds_value;
+
+    time_now_set_force_failure(false, 0);
+    errno = 0;
+    ft_errno = FT_EINVAL;
+    milliseconds_value = time_now_ms();
+    FT_ASSERT(milliseconds_value != static_cast<long>(-1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_now_failure_sets_errno, "time_now failure propagates errno")
+{
+    t_time time_value;
+    int error_code;
+
+    error_code = EACCES;
+    time_now_set_force_failure(true, error_code);
+    errno = 0;
+    ft_errno = ER_SUCCESS;
+    time_value = time_now();
+    time_now_set_force_failure(false, 0);
+    FT_ASSERT_EQ(static_cast<t_time>(-1), time_value);
+    FT_ASSERT_EQ(error_code, ft_errno);
+    return (1);
+}

--- a/Time/time_now.cpp
+++ b/Time/time_now.cpp
@@ -1,12 +1,25 @@
 #include "time.hpp"
 #include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
 #include <ctime>
+#include <cerrno>
 
 t_time  time_now(void)
 {
     std::time_t standard_time;
+    int saved_errno;
 
     standard_time = std::time(ft_nullptr);
+    if (standard_time == static_cast<std::time_t>(-1))
+    {
+        saved_errno = errno;
+        if (saved_errno != 0)
+            ft_errno = saved_errno;
+        else
+            ft_errno = FT_ETERM;
+        return (static_cast<t_time>(-1));
+    }
+    ft_errno = ER_SUCCESS;
     return (static_cast<t_time>(standard_time));
 }
 

--- a/Time/time_now_ms.cpp
+++ b/Time/time_now_ms.cpp
@@ -1,10 +1,12 @@
 #include "time.hpp"
+#include "../Errno/errno.hpp"
 #include <chrono>
 
 long    time_now_ms(void)
 {
     std::chrono::system_clock::time_point time_now = std::chrono::system_clock::now();
     std::chrono::milliseconds milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(time_now.time_since_epoch());
+    ft_errno = ER_SUCCESS;
     return (milliseconds.count());
 }
 


### PR DESCRIPTION
## Summary
- ensure `time_now` propagates system errno when `std::time` fails and clears it on success
- reset `ft_errno` when fetching millisecond timestamps
- add regression coverage for the time helpers including a mocked `std::time` failure

## Testing
- `g++ -Wall -Wextra -Werror -std=c++17 -O3 -fno-builtin -fno-builtin-memcpy -fno-builtin-memmove -fno-builtin-memset -fno-builtin-strlen -fno-builtin-strcmp -fno-builtin-isdigit -pthread -Wno-missing-declarations -DTEST_MODULE=\"Libft\" -c Test/Test/test_time_now.cpp -o /tmp/test_time_now.o`

------
https://chatgpt.com/codex/tasks/task_e_68dcd62c0d3c833198ddd44621d58f26