### PR TITLE
Handle trig errno behavior and add coverage

### DIFF
--- a/Math/math_cos.cpp
+++ b/Math/math_cos.cpp
@@ -1,4 +1,5 @@
 #include "math.hpp"
+#include "../Errno/errno.hpp"
 
 double math_cos(double value)
 {
@@ -24,5 +25,6 @@ double math_cos(double value)
         sign = -sign;
         iteration = iteration + 1;
     }
+    ft_errno = ER_SUCCESS;
     return (result);
 }

--- a/Math/math_sin.cpp
+++ b/Math/math_sin.cpp
@@ -1,4 +1,5 @@
 #include "math.hpp"
+#include "../Errno/errno.hpp"
 
 double ft_sin(double value)
 {
@@ -24,5 +25,6 @@ double ft_sin(double value)
         sign = -sign;
         iteration = iteration + 1;
     }
+    ft_errno = ER_SUCCESS;
     return (result);
 }

--- a/Math/math_tan.cpp
+++ b/Math/math_tan.cpp
@@ -1,11 +1,20 @@
 #include "math.hpp"
+#include "../Errno/errno.hpp"
 
 double ft_tan(double value)
 {
     double sin_value;
     double cos_value;
+    double epsilon;
 
+    epsilon = 0.0000000001;
     sin_value = ft_sin(value);
     cos_value = math_cos(value);
+    if (math_fabs(cos_value) < epsilon)
+    {
+        ft_errno = FT_EINVAL;
+        return (math_nan());
+    }
+    ft_errno = ER_SUCCESS;
     return (sin_value / cos_value);
 }

--- a/Test/Test/test_math_trig.cpp
+++ b/Test/Test/test_math_trig.cpp
@@ -1,41 +1,85 @@
 #include "../../Math/math.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
 
-int test_ft_sin_zero(void)
+FT_TEST(test_ft_sin_zero, "ft_sin returns zero for zero input")
 {
     double result;
 
     result = ft_sin(0.0);
-    if (math_fabs(result) < 0.000001)
-        return (1);
-    return (0);
+    FT_ASSERT(math_fabs(result) < 0.000001);
+    return (1);
 }
 
-int test_ft_sin_ninety(void)
+FT_TEST(test_ft_sin_ninety, "ft_sin returns one for ninety degrees")
 {
     double result;
 
     result = ft_sin(math_deg2rad(90.0));
-    if (math_fabs(result - 1.0) < 0.000001)
-        return (1);
-    return (0);
+    FT_ASSERT(math_fabs(result - 1.0) < 0.000001);
+    return (1);
 }
 
-int test_ft_tan_zero(void)
+FT_TEST(test_ft_sin_success_resets_errno, "ft_sin clears ft_errno after prior failure")
+{
+    double result;
+
+    ft_errno = FT_EINVAL;
+    result = ft_sin(0.0);
+    FT_ASSERT(math_fabs(result) < 0.000001);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_math_cos_zero, "math_cos returns one for zero input")
+{
+    double result;
+
+    result = math_cos(0.0);
+    FT_ASSERT(math_fabs(result - 1.0) < 0.000001);
+    return (1);
+}
+
+FT_TEST(test_math_cos_success_resets_errno, "math_cos clears ft_errno after prior failure")
+{
+    double result;
+
+    ft_errno = FT_EINVAL;
+    result = math_cos(0.0);
+    FT_ASSERT(math_fabs(result - 1.0) < 0.000001);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_tan_zero, "ft_tan returns zero for zero input")
 {
     double result;
 
     result = ft_tan(0.0);
-    if (math_fabs(result) < 0.000001)
-        return (1);
-    return (0);
+    FT_ASSERT(math_fabs(result) < 0.000001);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
 }
 
-int test_ft_tan_forty_five(void)
+FT_TEST(test_ft_tan_forty_five, "ft_tan returns one for forty five degrees")
 {
     double result;
 
     result = ft_tan(math_deg2rad(45.0));
-    if (math_fabs(result - 1.0) < 0.000001)
-        return (1);
-    return (0);
+    FT_ASSERT(math_fabs(result - 1.0) < 0.000001);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_tan_near_pi_over_two_sets_errno, "ft_tan near pi over two reports FT_EINVAL")
+{
+    double result;
+    double angle;
+
+    angle = math_deg2rad(90.0);
+    ft_errno = ER_SUCCESS;
+    result = ft_tan(angle);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
 }


### PR DESCRIPTION
## Summary
- guard ft_tan against division by near-zero cosine, reporting FT_EINVAL and clearing errno on success
- clear stale errno values after successful sine and cosine calculations
- convert math trig tests to the common runner and cover errno reset along with the new tangent error case

## Testing
- make -C Test libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68dcd91577308331b26d29ea589babac