### PR TITLE
Reset errno before math_exp calculations

### DIFF
--- a/Math/math_exp.cpp
+++ b/Math/math_exp.cpp
@@ -1,4 +1,5 @@
 #include "math.hpp"
+#include "../Errno/errno.hpp"
 
 double math_exp(double value)
 {
@@ -6,6 +7,7 @@ double math_exp(double value)
     double result;
     int    iteration;
 
+    ft_errno = ER_SUCCESS;
     current_term = 1.0;
     result = 1.0;
     iteration = 1;

--- a/Test/Test/test_math_exp.cpp
+++ b/Test/Test/test_math_exp.cpp
@@ -1,0 +1,21 @@
+#include "../../Math/math.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_math_exp_clears_errno_after_previous_failure, "math_exp resets errno to success after previous failure")
+{
+    double result;
+    double difference;
+    double expected;
+
+    ft_errno = ER_SUCCESS;
+    result = math_log(0.0);
+    FT_ASSERT(math_isnan(result));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    expected = 2.71828182845904523536;
+    result = math_exp(1.0);
+    difference = math_fabs(result - expected);
+    FT_ASSERT(difference < 0.0000000001);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- include the errno header and clear ft_errno at the start of math_exp
- add a regression test verifying math_exp resets ft_errno after a prior failure

## Testing
- make -C Test libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68dced3c1c8c833191bb7e67f3921c4e