### PR TITLE
Improve RSA key generation error reporting

### DIFF
--- a/Encryption/rsa.hpp
+++ b/Encryption/rsa.hpp
@@ -6,6 +6,7 @@
 int        rsa_generate_key_pair(uint64_t *public_key, uint64_t *private_key, uint64_t *modulus, int bit_size);
 uint64_t    rsa_encrypt(uint64_t message, uint64_t public_key, uint64_t modulus);
 uint64_t    rsa_decrypt(uint64_t cipher, uint64_t private_key, uint64_t modulus);
+void        rsa_set_force_mod_inverse_failure(bool enable);
 
 
 

--- a/Test/Test/test_encryption_rsa.cpp
+++ b/Test/Test/test_encryption_rsa.cpp
@@ -1,0 +1,48 @@
+#include "../../Encryption/rsa.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include "../../RNG/rng_internal.hpp"
+
+FT_TEST(test_rsa_generate_key_pair_null_output_sets_errno,
+    "rsa_generate_key_pair rejects null outputs")
+{
+    uint64_t private_key_value = 0;
+    uint64_t modulus_value = 0;
+    ft_errno = ER_SUCCESS;
+    int result_value = rsa_generate_key_pair(nullptr, &private_key_value, &modulus_value, 32);
+    FT_ASSERT_EQ(1, result_value);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_rsa_generate_key_pair_mod_inverse_failure_sets_errno,
+    "rsa_generate_key_pair reports modular inverse failure")
+{
+    uint64_t public_key_value = 0;
+    uint64_t private_key_value = 0;
+    uint64_t modulus_value = 0;
+    ft_errno = ER_SUCCESS;
+    rsa_set_force_mod_inverse_failure(true);
+    int result_value = rsa_generate_key_pair(&public_key_value, &private_key_value, &modulus_value, 32);
+    rsa_set_force_mod_inverse_failure(false);
+    FT_ASSERT_EQ(1, result_value);
+    FT_ASSERT_EQ(FT_ETERM, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_rsa_generate_key_pair_success_clears_errno,
+    "rsa_generate_key_pair succeeds and clears errno")
+{
+    uint64_t public_key_value = 0;
+    uint64_t private_key_value = 0;
+    uint64_t modulus_value = 0;
+    ft_errno = FT_EINVAL;
+    ft_seed_random_engine(1234u);
+    int result_value = rsa_generate_key_pair(&public_key_value, &private_key_value, &modulus_value, 32);
+    FT_ASSERT_EQ(0, result_value);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(public_key_value != 0);
+    FT_ASSERT(private_key_value != 0);
+    FT_ASSERT(modulus_value != 0);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- set `ft_errno` for RSA key generation failures and successes and expose a toggle to force modular inverse failure during tests
- update the RSA interface to expose the test hook used for deterministic failure injection
- add regression tests that verify null pointer handling, forced modular inverse failure, and a successful RSA key generation clears `ft_errno`

## Testing
- make tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68dcfe3e7af88331bd9f2ba5ba9b8487