### PR TITLE
Add errno checks to more string tests

### DIFF
--- a/Test/Test/test_bzero.cpp
+++ b/Test/Test/test_bzero.cpp
@@ -11,11 +11,13 @@ FT_TEST(test_bzero_basic, "ft_bzero basic")
     buffer[1] = 'b';
     buffer[2] = 'c';
     buffer[3] = 'd';
+    ft_errno = FT_EINVAL;
     ft_bzero(buffer, 4);
     FT_ASSERT_EQ(0, buffer[0]);
     FT_ASSERT_EQ(0, buffer[1]);
     FT_ASSERT_EQ(0, buffer[2]);
     FT_ASSERT_EQ(0, buffer[3]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -28,12 +30,14 @@ FT_TEST(test_bzero_partial, "ft_bzero partial")
     buffer[2] = 'c';
     buffer[3] = 'd';
     buffer[4] = 'e';
+    ft_errno = FT_EINVAL;
     ft_bzero(buffer + 1, 3);
     FT_ASSERT_EQ('a', buffer[0]);
     FT_ASSERT_EQ(0, buffer[1]);
     FT_ASSERT_EQ(0, buffer[2]);
     FT_ASSERT_EQ(0, buffer[3]);
     FT_ASSERT_EQ('e', buffer[4]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -44,16 +48,20 @@ FT_TEST(test_bzero_zero_length, "ft_bzero zero length")
     buffer[0] = 'x';
     buffer[1] = 'y';
     buffer[2] = '\0';
+    ft_errno = FT_EINVAL;
     ft_bzero(buffer, 0);
     FT_ASSERT_EQ('x', buffer[0]);
     FT_ASSERT_EQ('y', buffer[1]);
     FT_ASSERT_EQ('\0', buffer[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_bzero_null_zero, "ft_bzero nullptr zero")
 {
+    ft_errno = FT_EINVAL;
     ft_bzero(ft_nullptr, 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_errno.cpp
+++ b/Test/Test/test_errno.cpp
@@ -1,17 +1,81 @@
 #include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
 #include "../../System_utils/test_runner.hpp"
+#include <atomic>
 #include <cerrno>
 #include <cstring>
+#include <thread>
 
 FT_TEST(test_ft_strerror_errno_message, "ft_strerror returns standard errno message")
 {
     const char *expected_message;
     const char *actual_message;
+    int         previous_errno;
 
     expected_message = strerror(EINVAL);
+    previous_errno = FT_EINVAL;
+    ft_errno = previous_errno;
     actual_message = ft_strerror(EINVAL + ERRNO_OFFSET);
     FT_ASSERT(expected_message != NULL);
     FT_ASSERT(actual_message != NULL);
     FT_ASSERT_EQ(0, std::strcmp(expected_message, actual_message));
+    FT_ASSERT_EQ(previous_errno, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_errno_memcpy_tracks_error_state, "ft_memcpy updates ft_errno on failure and success")
+{
+    char        source_buffer[] = "data";
+    char        destination_buffer[5];
+    void       *copy_result;
+
+    ft_errno = ER_SUCCESS;
+    copy_result = ft_memcpy(ft_nullptr, source_buffer, sizeof(source_buffer));
+    FT_ASSERT(copy_result == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+
+    copy_result = ft_memcpy(destination_buffer, source_buffer, sizeof(source_buffer));
+    FT_ASSERT(copy_result == destination_buffer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, std::memcmp(destination_buffer, source_buffer, sizeof(source_buffer)));
+    return (1);
+}
+
+FT_TEST(test_ft_errno_strlen_resets_after_failure, "ft_strlen resets ft_errno to success for valid input")
+{
+    const char *valid_string;
+    int         string_length;
+
+    valid_string = "example";
+    ft_errno = ER_SUCCESS;
+    string_length = ft_strlen(ft_nullptr);
+    FT_ASSERT_EQ(0, string_length);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+
+    string_length = ft_strlen(valid_string);
+    FT_ASSERT_EQ(7, string_length);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_errno_is_thread_local, "ft_errno maintains independent values per thread")
+{
+    std::atomic<int> thread_errno_value;
+    std::thread      worker_thread;
+
+    thread_errno_value.store(ER_SUCCESS);
+    ft_errno = FT_EINVAL;
+    worker_thread = std::thread(
+        [&thread_errno_value]()
+        {
+            ft_errno = ER_SUCCESS;
+            ft_errno = FT_ERANGE;
+            thread_errno_value.store(ft_errno);
+            return ;
+        });
+    worker_thread.join();
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(FT_ERANGE, thread_errno_value.load());
     return (1);
 }

--- a/Test/Test/test_isalnum.cpp
+++ b/Test/Test/test_isalnum.cpp
@@ -1,18 +1,31 @@
 #include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_isalnum, "ft_isalnum")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isalnum('a'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isalnum('9'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalnum('/'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalnum(-1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_isalnum_extended_ascii, "ft_isalnum rejects extended ASCII")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalnum(0xC0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalnum(0xFF));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_isalpha.cpp
+++ b/Test/Test/test_isalpha.cpp
@@ -1,19 +1,34 @@
 #include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_isalpha, "ft_isalpha")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isalpha('a'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isalpha('Z'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalpha('1'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalpha('/'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalpha(-1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_isalpha_high_bit, "ft_isalpha rejects high-bit characters")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalpha(0xC0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isalpha(0xFF));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_isdigit.cpp
+++ b/Test/Test/test_isdigit.cpp
@@ -1,25 +1,42 @@
 #include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_isdigit_true, "ft_isdigit true")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isdigit('5'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isdigit('0'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isdigit('9'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_isdigit_false, "ft_isdigit false")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isdigit('a'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isdigit('/'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isdigit(-1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_isdigit_extended_ascii, "ft_isdigit rejects extended ASCII")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isdigit(0xC8));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isdigit(0xFF));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_islower.cpp
+++ b/Test/Test/test_islower.cpp
@@ -1,21 +1,40 @@
 #include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_islower, "ft_islower")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_islower('a'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_islower('z'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_islower('A'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_islower('0'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_islower(-1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_islower_rejects_adjacent_ascii, "ft_islower rejects punctuation and extended ASCII")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_islower('`'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_islower('{'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_islower(0xE1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_islower(0x5F));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_isprint.cpp
+++ b/Test/Test/test_isprint.cpp
@@ -1,19 +1,34 @@
 #include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_isprint, "ft_isprint")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isprint('A'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isprint(' '));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isprint('\n'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isprint(127));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isprint(-1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_isprint_extended_ascii, "ft_isprint rejects bytes above ASCII")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isprint(0x80));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isprint(0xA0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_isspace.cpp
+++ b/Test/Test/test_isspace.cpp
@@ -1,22 +1,43 @@
 #include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_isspace, "ft_isspace")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isspace(' '));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isspace('\n'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isspace('\t'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isspace('a'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isspace(0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_isspace_additional_controls, "ft_isspace handles form feed and vertical tab")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isspace('\f'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isspace('\r'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isspace('\v'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isspace('\b'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isspace(0xA0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_isupper.cpp
+++ b/Test/Test/test_isupper.cpp
@@ -1,21 +1,40 @@
 #include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_isupper, "ft_isupper")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isupper('A'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1, ft_isupper('Z'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isupper('a'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isupper('1'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isupper(-1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_isupper_rejects_adjacent_ascii, "ft_isupper rejects punctuation and extended ASCII")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isupper('@'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isupper('['));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isupper(0xC0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0, ft_isupper(0x7B));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_memchr.cpp
+++ b/Test/Test/test_memchr.cpp
@@ -10,7 +10,9 @@ FT_TEST(test_memchr_found, "ft_memchr finds character")
     buffer[1] = 'b';
     buffer[2] = 'c';
     buffer[3] = 'd';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(buffer + 2, ft_memchr(buffer, 'c', 4));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -20,7 +22,9 @@ FT_TEST(test_memchr_not_found, "ft_memchr missing character")
     buffer[0] = 'a';
     buffer[1] = 'b';
     buffer[2] = 'c';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_memchr(buffer, 'x', 3));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -31,7 +35,9 @@ FT_TEST(test_memchr_null_char, "ft_memchr search for null")
     buffer[1] = 'b';
     buffer[2] = '\0';
     buffer[3] = 'c';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(buffer + 2, ft_memchr(buffer, '\0', 4));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -39,13 +45,17 @@ FT_TEST(test_memchr_zero_length, "ft_memchr zero length")
 {
     char buffer[1];
     buffer[0] = 'a';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_memchr(buffer, 'a', 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_memchr_nullptr_zero, "ft_memchr nullptr zero length")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_memchr(ft_nullptr, 'a', 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -73,7 +83,9 @@ FT_TEST(test_memchr_limit_stops_search, "ft_memchr respects length limit")
     buffer[1] = 'b';
     buffer[2] = 'c';
     buffer[3] = 'd';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_memchr(buffer, 'c', 2));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -84,7 +96,9 @@ FT_TEST(test_memchr_signed_byte, "ft_memchr matches signed byte values")
     buffer[0] = 'a';
     buffer[1] = static_cast<char>(0xF2);
     buffer[2] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(buffer + 1, ft_memchr(buffer, 0xF2, 3));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_memcmp.cpp
+++ b/Test/Test/test_memcmp.cpp
@@ -13,7 +13,9 @@ FT_TEST(test_memcmp_equal, "ft_memcmp equal buffers")
     b[0] = 'a';
     b[1] = 'b';
     b[2] = 'c';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(0, ft_memcmp(a, b, 3));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -27,7 +29,9 @@ FT_TEST(test_memcmp_less, "ft_memcmp less than")
     b[0] = 'a';
     b[1] = 'b';
     b[2] = 'd';
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_memcmp(a, b, 3) < 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -41,7 +45,9 @@ FT_TEST(test_memcmp_greater, "ft_memcmp greater than")
     b[0] = 'a';
     b[1] = 'b';
     b[2] = 'c';
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_memcmp(a, b, 3) > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -51,7 +57,9 @@ FT_TEST(test_memcmp_zero_length, "ft_memcmp zero length")
     char b[1];
     a[0] = 'x';
     b[0] = 'y';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(0, ft_memcmp(a, b, 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -69,7 +77,9 @@ FT_TEST(test_memcmp_high_bit, "ft_memcmp high-bit comparison")
     char b[1];
     a[0] = (char)0x80;
     b[0] = 0;
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_memcmp(a, b, 1) > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -86,7 +96,9 @@ FT_TEST(test_memcmp_limit_hides_late_difference, "ft_memcmp stops comparing afte
     second[1] = 'b';
     second[2] = 'x';
     second[3] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(0, ft_memcmp(first, second, 2));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_memcpy.cpp
+++ b/Test/Test/test_memcpy.cpp
@@ -14,8 +14,10 @@ FT_TEST(test_memcpy_basic, "ft_memcpy basic")
     source[3] = 'l';
     source[4] = 'o';
     source[5] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(destination, ft_memcpy(destination, source, 6));
     FT_ASSERT_EQ(0, ft_strcmp(destination, source));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -32,14 +34,18 @@ FT_TEST(test_memcpy_zero_length, "ft_memcpy zero length")
     destination[1] = 'b';
     destination[2] = 'c';
     destination[3] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(destination, ft_memcpy(destination, source, 0));
     FT_ASSERT_EQ(0, ft_strcmp(destination, "abc"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_memcpy_zero_length_nullptr, "ft_memcpy zero length with nullptr")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_memcpy(ft_nullptr, ft_nullptr, 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -55,8 +61,12 @@ FT_TEST(test_memcpy_null, "ft_memcpy with nullptr")
 {
     char source[1];
     source[0] = 'a';
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_memcpy(ft_nullptr, source, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_memcpy(source, ft_nullptr, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_memdup.cpp
+++ b/Test/Test/test_memdup.cpp
@@ -14,10 +14,12 @@ FT_TEST(test_memdup_basic, "ft_memdup basic")
     source[2] = 'l';
     source[3] = 'l';
     source[4] = 'o';
+    ft_errno = FT_EINVAL;
     duplicate = ft_memdup(source, 5);
     FT_ASSERT(duplicate != ft_nullptr);
     FT_ASSERT(duplicate != source);
     FT_ASSERT_EQ(0, ft_memcmp(source, duplicate, 5));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     cma_free(duplicate);
     return (1);
 }
@@ -31,6 +33,7 @@ FT_TEST(test_memdup_zero_size, "ft_memdup zero size")
     buffer[2] = 'c';
     void *duplicate;
 
+    ft_errno = FT_EINVAL;
     duplicate = ft_memdup(buffer, 0);
     FT_ASSERT(duplicate != ft_nullptr);
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
@@ -40,7 +43,9 @@ FT_TEST(test_memdup_zero_size, "ft_memdup zero size")
 
 FT_TEST(test_memdup_null_source, "ft_memdup null source")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_memdup(ft_nullptr, 5));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_memmove.cpp
+++ b/Test/Test/test_memmove.cpp
@@ -15,11 +15,13 @@ FT_TEST(test_memmove_overlap_forward, "ft_memmove overlap forward")
     buffer[5] = 'f';
     buffer[6] = 'g';
     buffer[7] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(buffer + 2, ft_memmove(buffer + 2, buffer, 5));
     FT_ASSERT_EQ('a', buffer[0]);
     FT_ASSERT_EQ('a', buffer[2]);
     FT_ASSERT_EQ('e', buffer[6]);
     FT_ASSERT_EQ('\0', buffer[7]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -35,10 +37,12 @@ FT_TEST(test_memmove_overlap_backward, "ft_memmove overlap backward")
     buffer[5] = 'f';
     buffer[6] = 'g';
     buffer[7] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(buffer, ft_memmove(buffer, buffer + 2, 5));
     FT_ASSERT_EQ('c', buffer[0]);
     FT_ASSERT_EQ('g', buffer[4]);
     FT_ASSERT_EQ('\0', buffer[7]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -55,9 +59,11 @@ FT_TEST(test_memmove_zero_length, "ft_memmove zero length")
     destination[1] = 'b';
     destination[2] = 'c';
     destination[3] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(destination, ft_memmove(destination, source, 0));
     FT_ASSERT_EQ('a', destination[0]);
     FT_ASSERT_EQ('c', destination[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -73,8 +79,12 @@ FT_TEST(test_memmove_null, "ft_memmove with nullptr")
 {
     char source[1];
     source[0] = 'a';
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_memmove(ft_nullptr, source, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_memmove(source, ft_nullptr, 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
@@ -94,9 +104,11 @@ FT_TEST(test_memmove_same_pointer, "ft_memmove same pointer")
     buffer[1] = 'i';
     buffer[2] = 'j';
     buffer[3] = 'k';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(buffer, ft_memmove(buffer, buffer, 4));
     FT_ASSERT_EQ('h', buffer[0]);
     FT_ASSERT_EQ('k', buffer[3]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_memset.cpp
+++ b/Test/Test/test_memset.cpp
@@ -15,9 +15,11 @@ FT_TEST(test_memset_basic, "ft_memset basic")
 {
     char buffer[4];
 
+    ft_errno = FT_EINVAL;
     ft_memset(buffer, 'x', 3);
     buffer[3] = '\0';
     FT_ASSERT_EQ(0, ft_strcmp(buffer, "xxx"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -26,6 +28,7 @@ FT_TEST(test_memset_large, "ft_memset large buffer")
     char buffer[1024];
     size_t index;
 
+    ft_errno = FT_EINVAL;
     ft_memset(buffer, 0xAB, sizeof(buffer));
     index = 0;
     while (index < sizeof(buffer))
@@ -34,6 +37,7 @@ FT_TEST(test_memset_large, "ft_memset large buffer")
             FT_ASSERT(0);
         index++;
     }
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -65,6 +69,7 @@ FT_TEST(test_memset_negative, "ft_memset negative value")
     char buffer[4];
     size_t index;
 
+    ft_errno = FT_EINVAL;
     ft_memset(buffer, -1, 3);
     index = 0;
     while (index < 3)
@@ -73,6 +78,7 @@ FT_TEST(test_memset_negative, "ft_memset negative value")
             FT_ASSERT(0);
         index++;
     }
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -81,6 +87,7 @@ FT_TEST(test_memset_overflow, "ft_memset overflow value")
     char buffer[4];
     size_t index;
 
+    ft_errno = FT_EINVAL;
     ft_memset(buffer, 256, 3);
     index = 0;
     while (index < 3)
@@ -89,5 +96,6 @@ FT_TEST(test_memset_overflow, "ft_memset overflow value")
             FT_ASSERT(0);
         index++;
     }
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strchr.cpp
+++ b/Test/Test/test_strchr.cpp
@@ -14,7 +14,9 @@ FT_TEST(test_strchr_basic, "ft_strchr basic")
 
 FT_TEST(test_strchr_not_found, "ft_strchr not found")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_strchr("hello", 'x'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -29,7 +31,9 @@ FT_TEST(test_strchr_null, "ft_strchr nullptr")
 FT_TEST(test_strchr_terminator, "ft_strchr terminator")
 {
     const char *string = "hello";
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(string + 5, ft_strchr(string, '\0'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_strcmp.cpp
+++ b/Test/Test/test_strcmp.cpp
@@ -1,55 +1,78 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strcmp_equal, "ft_strcmp equal strings")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(0, ft_strcmp("abc", "abc"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strcmp_null, "ft_strcmp with nullptr")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(-1, ft_strcmp(ft_nullptr, "abc"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strcmp_second_null, "ft_strcmp second string nullptr")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(-1, ft_strcmp("abc", ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strcmp_less, "ft_strcmp lexicographically less")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strcmp("abc", "abd") < 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strcmp_greater, "ft_strcmp lexicographically greater")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strcmp("abd", "abc") > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strcmp_prefix, "ft_strcmp prefix difference")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strcmp("abc", "abcd") < 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strcmp("abcd", "abc") > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strcmp_empty, "ft_strcmp empty strings")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(0, ft_strcmp("", ""));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strcmp("", "a") < 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strcmp("a", "") > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strcmp_both_null, "ft_strcmp both nullptr")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(-1, ft_strcmp(ft_nullptr, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
@@ -62,7 +85,11 @@ FT_TEST(test_strcmp_high_bit_ordering, "ft_strcmp treats bytes as unsigned")
     left[1] = '\0';
     right[0] = static_cast<char>(0x7F);
     right[1] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strcmp(left, right) > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strcmp(right, left) < 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strlcat.cpp
+++ b/Test/Test/test_strlcat.cpp
@@ -10,8 +10,10 @@ FT_TEST(test_strlcat_basic, "ft_strlcat basic")
     destination[0] = 'h';
     destination[1] = 'i';
     destination[2] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(6u, ft_strlcat(destination, "1234", 10));
     FT_ASSERT_EQ(0, ft_strcmp(destination, "hi1234"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -22,8 +24,10 @@ FT_TEST(test_strlcat_truncate, "ft_strlcat truncate")
     destination[0] = 'h';
     destination[1] = 'i';
     destination[2] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(7u, ft_strlcat(destination, "world", 6));
     FT_ASSERT_EQ(0, ft_strcmp(destination, "hiwor"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -34,10 +38,12 @@ FT_TEST(test_strlcat_zero_size, "ft_strlcat zero size")
     destination[0] = 'h';
     destination[1] = 'i';
     destination[2] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(5u, ft_strlcat(destination, "hello", 0));
     FT_ASSERT_EQ('h', destination[0]);
     FT_ASSERT_EQ('i', destination[1]);
     FT_ASSERT_EQ('\0', destination[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -51,8 +57,10 @@ FT_TEST(test_strlcat_insufficient_dest, "ft_strlcat size less than dest length")
     destination[3] = 'l';
     destination[4] = 'o';
     destination[5] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(8u, ft_strlcat(destination, "world", 3));
     FT_ASSERT_EQ(0, ft_strcmp(destination, "hello"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -61,8 +69,10 @@ FT_TEST(test_strlcat_null_arguments_errno, "ft_strlcat null arguments set errno"
     char destination_buffer[4];
 
     destination_buffer[0] = '\0';
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0u, ft_strlcat(ft_nullptr, "abc", 3));
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(0u, ft_strlcat(destination_buffer, ft_nullptr, 3));
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
@@ -91,11 +101,13 @@ FT_TEST(test_strlcat_truncated_destination, "ft_strlcat handles unterminated des
     destination[4] = 'Y';
     destination[5] = 'Z';
     destination[6] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(6u, ft_strlcat(destination, "pq", 4));
     FT_ASSERT_EQ('A', destination[0]);
     FT_ASSERT_EQ('D', destination[3]);
     FT_ASSERT_EQ('Y', destination[4]);
     FT_ASSERT_EQ('Z', destination[5]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_strlcpy.cpp
+++ b/Test/Test/test_strlcpy.cpp
@@ -7,8 +7,10 @@ FT_TEST(test_strlcpy_basic, "ft_strlcpy basic")
 {
     char destination[6];
 
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", 6));
     FT_ASSERT_EQ(0, ft_strcmp(destination, "hello"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -16,10 +18,12 @@ FT_TEST(test_strlcpy_truncate, "ft_strlcpy truncate")
 {
     char destination[3];
 
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", 3));
     FT_ASSERT_EQ('h', destination[0]);
     FT_ASSERT_EQ('e', destination[1]);
     FT_ASSERT_EQ('\0', destination[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -31,9 +35,11 @@ FT_TEST(test_strlcpy_zero, "ft_strlcpy zero size")
     destination[1] = 'b';
     destination[2] = 'c';
     destination[3] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", 0));
     FT_ASSERT_EQ('a', destination[0]);
     FT_ASSERT_EQ('c', destination[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -97,10 +103,12 @@ FT_TEST(test_strlcpy_preserves_tail, "ft_strlcpy preserves bytes beyond terminat
     destination[5] = 'x';
     destination[6] = 'y';
     destination[7] = 'z';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", sizeof(destination)));
     FT_ASSERT_EQ(0, ft_strcmp(destination, "hello"));
     FT_ASSERT_EQ('y', destination[6]);
     FT_ASSERT_EQ('z', destination[7]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -146,10 +154,12 @@ FT_TEST(test_strlcpy_two_byte_buffer, "ft_strlcpy truncates with size two")
     destination[1] = 'q';
     destination[2] = 'r';
     destination[3] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", 2));
     FT_ASSERT_EQ('h', destination[0]);
     FT_ASSERT_EQ('\0', destination[1]);
     FT_ASSERT_EQ('r', destination[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -176,12 +186,14 @@ FT_TEST(test_strlcpy_buffer_matches_source_length, "ft_strlcpy buffer equals sou
     destination[2] = 'q';
     destination[3] = 'q';
     destination[4] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(5u, ft_strlcpy(destination, "hello", sizeof(destination)));
     FT_ASSERT_EQ('h', destination[0]);
     FT_ASSERT_EQ('e', destination[1]);
     FT_ASSERT_EQ('l', destination[2]);
     FT_ASSERT_EQ('l', destination[3]);
     FT_ASSERT_EQ('\0', destination[4]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -197,10 +209,12 @@ FT_TEST(test_strlcpy_embedded_null_source, "ft_strlcpy stops at embedded null")
     destination[0] = 'x';
     destination[1] = 'y';
     destination[2] = 'z';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(1u, ft_strlcpy(destination, source, sizeof(destination)));
     FT_ASSERT_EQ('a', destination[0]);
     FT_ASSERT_EQ('\0', destination[1]);
     FT_ASSERT_EQ('z', destination[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -215,12 +229,14 @@ FT_TEST(test_strlcpy_long_source_counts_full_length, "ft_strlcpy counts full sou
     destination[2] = 't';
     destination[3] = 'u';
     destination[4] = 'v';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(26u, ft_strlcpy(destination, source, sizeof(destination)));
     FT_ASSERT_EQ('a', destination[0]);
     FT_ASSERT_EQ('b', destination[1]);
     FT_ASSERT_EQ('c', destination[2]);
     FT_ASSERT_EQ('d', destination[3]);
     FT_ASSERT_EQ('\0', destination[4]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_strncmp.cpp
+++ b/Test/Test/test_strncmp.cpp
@@ -1,47 +1,64 @@
 #include "../../Libft/libft.hpp"
 #include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
 #include "../../System_utils/test_runner.hpp"
 
 FT_TEST(test_strncmp_prefix_equal, "ft_strncmp equal prefix")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(0, ft_strncmp("abcdef", "abcxyz", 3));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strncmp_less, "ft_strncmp less")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strncmp("abc", "abd", 3) < 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strncmp_greater, "ft_strncmp greater")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strncmp("abd", "abc", 3) > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strncmp_zero_length, "ft_strncmp zero length")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(0, ft_strncmp("abc", "xyz", 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strncmp_shorter_first, "ft_strncmp shorter first")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strncmp("ab", "abc", 3) < 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strncmp_shorter_second, "ft_strncmp shorter second")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strncmp("abc", "ab", 3) > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strncmp_null_arguments, "ft_strncmp null arguments return error")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(-1, ft_strncmp(ft_nullptr, "abc", 3));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(-1, ft_strncmp("abc", ft_nullptr, 3));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 
@@ -56,7 +73,9 @@ FT_TEST(test_strncmp_high_bit_values, "ft_strncmp orders high-bit characters")
     second[0] = static_cast<char>(0x10);
     second[1] = 'a';
     second[2] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT(ft_strncmp(first, second, 2) > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -75,6 +94,8 @@ FT_TEST(test_strncmp_embedded_nulls_stop_comparison, "ft_strncmp stops comparing
     second[2] = '\0';
     second[3] = 'd';
     second[4] = '\0';
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(0, ft_strncmp(first, second, 4));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strncpy.cpp
+++ b/Test/Test/test_strncpy.cpp
@@ -17,6 +17,7 @@ FT_TEST(test_strncpy_full_copy, "ft_strncpy full copy with padding")
     destination[3] = 'x';
     destination[4] = 'x';
     destination[5] = '\0';
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(destination, ft_strncpy(destination, source, 5));
     FT_ASSERT_EQ('h', destination[0]);
     FT_ASSERT_EQ('i', destination[1]);
@@ -24,6 +25,7 @@ FT_TEST(test_strncpy_full_copy, "ft_strncpy full copy with padding")
     FT_ASSERT_EQ('\0', destination[3]);
     FT_ASSERT_EQ('\0', destination[4]);
     FT_ASSERT_EQ('\0', destination[5]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -44,11 +46,13 @@ FT_TEST(test_strncpy_truncate, "ft_strncpy truncates without null")
     destination[3] = 'X';
     destination[4] = 'X';
     destination[5] = '\0';
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(destination, ft_strncpy(destination, source, 3));
     FT_ASSERT_EQ('h', destination[0]);
     FT_ASSERT_EQ('e', destination[1]);
     FT_ASSERT_EQ('l', destination[2]);
     FT_ASSERT_EQ('X', destination[3]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -60,8 +64,10 @@ FT_TEST(test_strncpy_zero_length, "ft_strncpy zero length")
     destination[1] = 'b';
     destination[2] = 'c';
     destination[3] = '\0';
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(destination, ft_strncpy(destination, "xyz", 0));
     FT_ASSERT_EQ('a', destination[0]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -73,8 +79,12 @@ FT_TEST(test_strncpy_null, "ft_strncpy with nullptr")
     buffer[1] = 'b';
     buffer[2] = 'c';
     buffer[3] = '\0';
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_strncpy(ft_nullptr, buffer, 3));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_strncpy(buffer, ft_nullptr, 3));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_strnstr.cpp
+++ b/Test/Test/test_strnstr.cpp
@@ -7,13 +7,17 @@ FT_TEST(test_strnstr_basic, "ft_strnstr basic")
 {
     const char *haystack = "hello world";
 
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(haystack + 6, ft_strnstr(haystack, "world", 11));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strnstr_not_found, "ft_strnstr not found")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_strnstr("hello", "xyz", 5));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -21,19 +25,25 @@ FT_TEST(test_strnstr_empty_needle, "ft_strnstr empty needle")
 {
     const char *haystack = "hello";
 
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(haystack, ft_strnstr(haystack, "", 5));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strnstr_size_limit, "ft_strnstr size limit")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_strnstr("hello", "lo", 3));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strnstr_zero_size, "ft_strnstr zero size")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_strnstr("hello", "he", 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -41,14 +51,18 @@ FT_TEST(test_strnstr_empty_needle_zero_size, "ft_strnstr empty needle ignores si
 {
     const char *haystack = "hello";
 
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(haystack, ft_strnstr(haystack, "", 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
 FT_TEST(test_strnstr_null_arguments, "ft_strnstr null arguments return nullptr")
 {
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_strnstr(ft_nullptr, "abc", 3));
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(ft_nullptr, ft_strnstr("abc", ft_nullptr, 3));
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
@@ -68,6 +82,8 @@ FT_TEST(test_strnstr_restart_within_limit, "ft_strnstr restarts search within li
 {
     const char *haystack = "abcabcd";
 
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(haystack + 3, ft_strnstr(haystack, "abcd", 7));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strrchr.cpp
+++ b/Test/Test/test_strrchr.cpp
@@ -15,7 +15,9 @@ FT_TEST(test_strrchr_last, "ft_strrchr last occurrence")
 
 FT_TEST(test_strrchr_not_found, "ft_strrchr not found")
 {
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_strrchr("hello", 'x'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -31,7 +33,9 @@ FT_TEST(test_strrchr_terminator, "ft_strrchr terminator")
 {
     const char *string = "world";
 
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(string + 5, ft_strrchr(string, '\0'));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_strstr.cpp
+++ b/Test/Test/test_strstr.cpp
@@ -19,7 +19,9 @@ FT_TEST(test_strstr_not_found, "ft_strstr not found")
     const char *haystack = "hello";
     const char *needle = "world";
 
+    ft_errno = FT_EINVAL;
     FT_ASSERT_EQ(ft_nullptr, ft_strstr(haystack, needle));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -27,7 +29,9 @@ FT_TEST(test_strstr_empty_needle, "ft_strstr empty needle")
 {
     const char *haystack = "abc";
 
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(haystack, ft_strstr(haystack, ""));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -36,7 +40,9 @@ FT_TEST(test_strstr_empty_haystack, "ft_strstr empty haystack")
     const char *haystack = "";
     const char *needle = "a";
 
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(ft_nullptr, ft_strstr(haystack, needle));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -58,6 +64,8 @@ FT_TEST(test_strstr_overlapping_partial_match, "ft_strstr restarts after overlap
     const char *haystack = "ababac";
     const char *needle = "abac";
 
+    ft_errno = FT_ERANGE;
     FT_ASSERT_EQ(haystack + 2, ft_strstr(haystack, needle));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_tolower.cpp
+++ b/Test/Test/test_tolower.cpp
@@ -28,8 +28,10 @@ FT_TEST(test_tolower_mixed, "ft_to_lower mixed characters")
     string[4] = 'C';
     string[5] = '?';
     string[6] = '\0';
+    ft_errno = FT_EINVAL;
     ft_to_lower(string);
     FT_ASSERT_EQ(0, ft_strcmp(string, "a1b!c?"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -37,8 +39,10 @@ FT_TEST(test_tolower_empty, "ft_to_lower empty string")
 {
     char string[1];
     string[0] = '\0';
+    ft_errno = FT_EINVAL;
     ft_to_lower(string);
     FT_ASSERT_EQ(0, ft_strcmp(string, ""));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -59,10 +63,12 @@ FT_TEST(test_tolower_non_ascii_preserved, "ft_to_lower leaves non-ASCII bytes un
     string[2] = static_cast<char>(0x80);
     string[3] = 'Z';
     string[4] = '\0';
+    ft_errno = FT_EINVAL;
     ft_to_lower(string);
     FT_ASSERT_EQ(static_cast<char>(0xC7), string[0]);
     FT_ASSERT_EQ('a', string[1]);
     FT_ASSERT_EQ(static_cast<char>(0x80), string[2]);
     FT_ASSERT_EQ('z', string[3]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }

--- a/Test/Test/test_toupper.cpp
+++ b/Test/Test/test_toupper.cpp
@@ -29,8 +29,10 @@ FT_TEST(test_toupper_mixed, "ft_to_upper mixed characters")
     string[4] = 'c';
     string[5] = '?';
     string[6] = '\0';
+    ft_errno = FT_EINVAL;
     ft_to_upper(string);
     FT_ASSERT_EQ(0, ft_strcmp(string, "A1B!C?"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -39,8 +41,10 @@ FT_TEST(test_toupper_empty, "ft_to_upper empty string")
     char string[1];
 
     string[0] = '\0';
+    ft_errno = FT_EINVAL;
     ft_to_upper(string);
     FT_ASSERT_EQ(0, ft_strcmp(string, ""));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -62,11 +66,13 @@ FT_TEST(test_toupper_stops_at_terminator, "ft_to_upper stops at first null byte"
     string[3] = 'x';
     string[4] = 'y';
     string[5] = '\0';
+    ft_errno = FT_EINVAL;
     ft_to_upper(string);
     FT_ASSERT_EQ('A', string[0]);
     FT_ASSERT_EQ(static_cast<char>(0xE1), string[1]);
     FT_ASSERT_EQ('\0', string[2]);
     FT_ASSERT_EQ('x', string[3]);
     FT_ASSERT_EQ('y', string[4]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }


### PR DESCRIPTION
## Summary
- seed ft_errno before running ft_strcmp and ft_strncmp assertions and verify each case restores ER_SUCCESS or reports FT_EINVAL on invalid input
- extend ft_strnstr, ft_strrchr, and ft_strchr tests to confirm successful lookups reset errno while error paths report FT_EINVAL
- seed ft_errno across strlcpy, strlcat, strncpy, and strstr scenarios to ensure successful copies leave errno at ER_SUCCESS and invalid arguments raise FT_EINVAL
- add errno checks to classification and case-conversion tests so is* helpers along with ft_to_upper and ft_to_lower clear or preserve the error flag appropriately

## Testing
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_isdigit.cpp -o /tmp/test_isdigit.o
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_isalpha.cpp -o /tmp/test_isalpha.o
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_isalnum.cpp -o /tmp/test_isalnum.o
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_isupper.cpp -o /tmp/test_isupper.o
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_islower.cpp -o /tmp/test_islower.o
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_isprint.cpp -o /tmp/test_isprint.o
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_isspace.cpp -o /tmp/test_isspace.o
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_toupper.cpp -o /tmp/test_toupper.o
- g++ -Wall -Wextra -Werror -std=c++17 -pthread -c Test/Test/test_tolower.cpp -o /tmp/test_tolower.o

------
https://chatgpt.com/codex/tasks/task_e_68de0ebbd65c83319323e9844737984e