### PR TITLE
Add ft_deque tests

### DIFF
--- a/Test/Test/test_cma.cpp
+++ b/Test/Test/test_cma.cpp
@@ -4,7 +4,24 @@
 #include "../../CPP_class/class_nullptr.hpp"
 #include "../../System_utils/test_runner.hpp"
 #include <cstdint>
+#include <climits>
 #include <thread>
+
+static void cma_free_split_result(char **strings)
+{
+    ft_size_t index;
+
+    if (!strings)
+        return ;
+    index = 0;
+    while (strings[index])
+    {
+        cma_free(strings[index]);
+        index++;
+    }
+    cma_free(strings);
+    return ;
+}
 
 int test_cma_checked_free_basic(void)
 {
@@ -163,6 +180,438 @@ FT_TEST(test_cma_realloc_success_sets_errno, "cma_realloc reports success on gro
     }
     FT_ASSERT_EQ(ft_errno, ER_SUCCESS);
     cma_free(reallocation_pointer);
+    return (1);
+}
+
+FT_TEST(test_cma_itoa_positive_number, "cma_itoa converts positive numbers")
+{
+    char    *converted_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    converted_string = cma_itoa(12345);
+    if (!converted_string)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(converted_string, "12345"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(converted_string);
+    return (1);
+}
+
+FT_TEST(test_cma_itoa_handles_negative_and_zero,
+        "cma_itoa preserves sign and handles zero")
+{
+    char    *negative_string;
+    char    *zero_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    negative_string = cma_itoa(-2048);
+    if (!negative_string)
+        return (0);
+    zero_string = cma_itoa(0);
+    if (!zero_string)
+    {
+        cma_free(negative_string);
+        return (0);
+    }
+    FT_ASSERT_EQ(0, ft_strcmp(negative_string, "-2048"));
+    FT_ASSERT_EQ(0, ft_strcmp(zero_string, "0"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(negative_string);
+    cma_free(zero_string);
+    return (1);
+}
+
+FT_TEST(test_cma_itoa_handles_int_min, "cma_itoa duplicates INT_MIN literal")
+{
+    char    *minimum_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    minimum_string = cma_itoa(FT_INT_MIN);
+    if (!minimum_string)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(minimum_string, "-2147483648"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(minimum_string);
+    return (1);
+}
+
+FT_TEST(test_cma_itoa_allocation_failure_sets_errno,
+        "cma_itoa reports allocation failures")
+{
+    char    *converted_string;
+
+    cma_set_alloc_limit(2);
+    ft_errno = ER_SUCCESS;
+    converted_string = cma_itoa(9999);
+    FT_ASSERT_EQ(ft_nullptr, converted_string);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    cma_set_alloc_limit(0);
+    return (1);
+}
+
+FT_TEST(test_cma_itoa_base_hexadecimal,
+        "cma_itoa_base converts numbers in hexadecimal")
+{
+    char    *converted_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    converted_string = cma_itoa_base(305441741, 16);
+    if (!converted_string)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(converted_string, "1234ABCD"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(converted_string);
+    return (1);
+}
+
+FT_TEST(test_cma_itoa_base_negative_decimal,
+        "cma_itoa_base prefixes negatives when base is decimal")
+{
+    char    *converted_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    converted_string = cma_itoa_base(-256, 10);
+    if (!converted_string)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(converted_string, "-256"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(converted_string);
+    return (1);
+}
+
+FT_TEST(test_cma_itoa_base_rejects_invalid_base,
+        "cma_itoa_base validates base range")
+{
+    char    *converted_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = ER_SUCCESS;
+    converted_string = cma_itoa_base(42, 1);
+    FT_ASSERT_EQ(ft_nullptr, converted_string);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_strtrim_trims_prefix_and_suffix,
+        "cma_strtrim removes leading and trailing characters")
+{
+    char    *trimmed_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    trimmed_string = cma_strtrim("***hello***", "*");
+    if (!trimmed_string)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(trimmed_string, "hello"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(trimmed_string);
+    return (1);
+}
+
+FT_TEST(test_cma_strtrim_returns_empty_when_all_trimmed,
+        "cma_strtrim returns an empty string when every character is trimmed")
+{
+    char    *trimmed_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    trimmed_string = cma_strtrim("     ", " ");
+    if (!trimmed_string)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(trimmed_string, ""));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(trimmed_string);
+    return (1);
+}
+
+FT_TEST(test_cma_strtrim_rejects_null_input,
+        "cma_strtrim returns nullptr when input or set is null")
+{
+    char    *trimmed_string;
+
+    cma_set_alloc_limit(0);
+    ft_errno = ER_SUCCESS;
+    trimmed_string = cma_strtrim(ft_nullptr, " ");
+    FT_ASSERT_EQ(ft_nullptr, trimmed_string);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    trimmed_string = cma_strtrim("example", ft_nullptr);
+    FT_ASSERT_EQ(ft_nullptr, trimmed_string);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_substr_within_bounds,
+        "cma_substr extracts segments within the source bounds")
+{
+    char    *substring;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    substring = cma_substr("abcdef", 2, 3);
+    if (!substring)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(substring, "cde"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(substring);
+    return (1);
+}
+
+FT_TEST(test_cma_substr_truncates_when_length_exceeds,
+        "cma_substr truncates when requested length exceeds remaining characters")
+{
+    char    *substring;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    substring = cma_substr("libft", 3, 10);
+    if (!substring)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(substring, "ft"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(substring);
+    return (1);
+}
+
+FT_TEST(test_cma_substr_handles_out_of_range_start,
+        "cma_substr returns an empty string when start is outside the source")
+{
+    char    *substring;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    substring = cma_substr("short", 42, 3);
+    if (!substring)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(substring, ""));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(substring);
+    return (1);
+}
+
+FT_TEST(test_cma_substr_rejects_null_source,
+        "cma_substr returns nullptr when source is null")
+{
+    char    *substring;
+
+    cma_set_alloc_limit(0);
+    ft_errno = ER_SUCCESS;
+    substring = cma_substr(ft_nullptr, 0, 1);
+    FT_ASSERT_EQ(ft_nullptr, substring);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_split_basic_tokens, "cma_split separates tokens and null-terminates the array")
+{
+    char        **parts;
+    ft_size_t    index;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    parts = cma_split("alpha,beta,gamma", ',');
+    if (!parts)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(parts[0], "alpha"));
+    FT_ASSERT_EQ(0, ft_strcmp(parts[1], "beta"));
+    FT_ASSERT_EQ(0, ft_strcmp(parts[2], "gamma"));
+    FT_ASSERT_EQ(ft_nullptr, parts[3]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    index = 0;
+    while (parts[index])
+    {
+        FT_ASSERT(parts[index] != ft_nullptr);
+        index++;
+    }
+    cma_free_split_result(parts);
+    return (1);
+}
+
+FT_TEST(test_cma_split_skips_repeated_delimiters, "cma_split ignores empty segments between delimiters")
+{
+    char    **parts;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    parts = cma_split("::left::right:", ':');
+    if (!parts)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(parts[0], "left"));
+    FT_ASSERT_EQ(0, ft_strcmp(parts[1], "right"));
+    FT_ASSERT_EQ(ft_nullptr, parts[2]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free_split_result(parts);
+    return (1);
+}
+
+FT_TEST(test_cma_split_null_string_returns_empty_array, "cma_split returns an empty array when input is null")
+{
+    char    **parts;
+
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    parts = cma_split(ft_nullptr, ',');
+    if (!parts)
+        return (0);
+    FT_ASSERT_EQ(ft_nullptr, parts[0]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(parts);
+    return (1);
+}
+
+FT_TEST(test_cma_split_allocation_failure_sets_errno, "cma_split propagates allocation failures")
+{
+    char    **parts;
+
+    cma_set_alloc_limit(1);
+    ft_errno = ER_SUCCESS;
+    parts = cma_split("a,b", ',');
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, parts);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_strdup_copies_string, "cma_strdup duplicates the input string")
+{
+    const char  *source;
+    char        *duplicate;
+
+    source = "duplicate target";
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    duplicate = cma_strdup(source);
+    if (!duplicate)
+        return (0);
+    FT_ASSERT(duplicate != source);
+    FT_ASSERT_EQ(0, ft_strcmp(source, duplicate));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(duplicate);
+    return (1);
+}
+
+FT_TEST(test_cma_strdup_null_input_preserves_errno, "cma_strdup returns nullptr without touching errno when input is null")
+{
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, cma_strdup(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_strdup_allocation_failure_sets_errno, "cma_strdup surfaces allocation errors")
+{
+    char    *duplicate;
+
+    cma_set_alloc_limit(1);
+    ft_errno = ER_SUCCESS;
+    duplicate = cma_strdup("needs space");
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, duplicate);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_memdup_copies_buffer, "cma_memdup duplicates raw bytes")
+{
+    unsigned char       source[5];
+    unsigned char       *duplicate;
+
+    source[0] = 0x10;
+    source[1] = 0x20;
+    source[2] = 0x30;
+    source[3] = 0x40;
+    source[4] = 0x50;
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    duplicate = static_cast<unsigned char *>(cma_memdup(source, sizeof(source)));
+    if (!duplicate)
+        return (0);
+    FT_ASSERT_EQ(0, ft_memcmp(source, duplicate, sizeof(source)));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(duplicate);
+    return (1);
+}
+
+FT_TEST(test_cma_memdup_zero_size_returns_valid_block, "cma_memdup returns a block when size is zero")
+{
+    unsigned char   source;
+    void            *duplicate;
+
+    source = 0xAB;
+    cma_set_alloc_limit(0);
+    ft_errno = FT_EALLOC;
+    duplicate = cma_memdup(&source, 0);
+    if (!duplicate)
+        return (0);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(duplicate);
+    return (1);
+}
+
+FT_TEST(test_cma_memdup_null_source_sets_errno, "cma_memdup rejects null source pointers when size is non-zero")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, cma_memdup(ft_nullptr, 4));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_memdup_allocation_failure_sets_errno, "cma_memdup propagates allocation failures")
+{
+    void    *duplicate;
+
+    cma_set_alloc_limit(1);
+    ft_errno = ER_SUCCESS;
+    duplicate = cma_memdup("buffer", 16);
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, duplicate);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_alloc_size_reports_block_size, "cma_alloc_size returns the stored allocation size")
+{
+    void        *buffer;
+    ft_size_t   reported_size;
+
+    cma_set_alloc_limit(0);
+    buffer = cma_malloc(64);
+    if (!buffer)
+        return (0);
+    ft_errno = FT_EINVAL;
+    reported_size = cma_alloc_size(buffer);
+    FT_ASSERT_EQ(static_cast<ft_size_t>(64), reported_size);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(buffer);
+    return (1);
+}
+
+FT_TEST(test_cma_alloc_size_null_pointer_sets_errno, "cma_alloc_size sets FT_EINVAL for null pointers")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(static_cast<ft_size_t>(0), cma_alloc_size(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cma_alloc_size_rejects_non_cma_pointer, "cma_alloc_size detects pointers outside the allocator")
+{
+    char        *buffer;
+    ft_size_t   reported_size;
+
+    cma_set_alloc_limit(0);
+    buffer = static_cast<char *>(cma_malloc(32));
+    if (!buffer)
+        return (0);
+    ft_errno = ER_SUCCESS;
+    reported_size = cma_alloc_size(buffer + 1);
+    FT_ASSERT_EQ(static_cast<ft_size_t>(0), reported_size);
+    FT_ASSERT_EQ(CMA_INVALID_PTR, ft_errno);
+    cma_free(buffer);
     return (1);
 }
 

--- a/Test/Test/test_environment.cpp
+++ b/Test/Test/test_environment.cpp
@@ -4,6 +4,7 @@
 #include "../../Errno/errno.hpp"
 #include "../Compatebility/compatebility_system_test_hooks.hpp"
 #include <cerrno>
+#include <cstring>
 
 FT_TEST(test_ft_unsetenv_rejects_empty_name, "ft_unsetenv rejects empty names")
 {
@@ -33,11 +34,67 @@ FT_TEST(test_ft_getenv_missing_clears_errno, "ft_getenv clears errno when variab
     return (1);
 }
 
+FT_TEST(test_ft_getenv_returns_value, "ft_getenv returns stored value")
+{
+    const char *variable_name;
+    char *value;
+
+    variable_name = "LIBFT_TEST_GETENV_PRESENT";
+    FT_ASSERT_EQ(0, ft_setenv(variable_name, "present", 1));
+    ft_errno = FT_EINVAL;
+    value = ft_getenv(variable_name);
+    FT_ASSERT(value != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, std::strcmp(value, "present"));
+    ft_unsetenv(variable_name);
+    return (1);
+}
+
 FT_TEST(test_ft_setenv_null_value_sets_errno, "ft_setenv null value sets FT_EINVAL")
 {
     ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(-1, ft_setenv("LIBFT_TEST_NULL_VALUE", ft_nullptr, 1));
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_setenv_null_name_sets_errno, "ft_setenv rejects null name")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, ft_setenv(ft_nullptr, "value", 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_setenv_empty_name_sets_errno, "ft_setenv rejects empty name")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, ft_setenv("", "value", 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_setenv_equals_sign_sets_errno, "ft_setenv rejects names with equals")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, ft_setenv("INVALID=NAME", "value", 1));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_setenv_success_resets_errno, "ft_setenv stores value and clears errno")
+{
+    const char *variable_name;
+    char *value;
+
+    variable_name = "LIBFT_TEST_SETENV_SUCCESS";
+    ft_errno = FT_ETERM;
+    FT_ASSERT_EQ(0, ft_setenv(variable_name, "stored", 1));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    value = ft_getenv(variable_name);
+    FT_ASSERT(value != ft_nullptr);
+    FT_ASSERT_EQ(0, std::strcmp(value, "stored"));
+    ft_unsetenv(variable_name);
     return (1);
 }
 

--- a/Test/Test/test_file_io.cpp
+++ b/Test/Test/test_file_io.cpp
@@ -5,6 +5,11 @@
 #include "../../System_utils/test_runner.hpp"
 #include <cerrno>
 #include <cstdio>
+#if defined(_WIN32) || defined(_WIN64)
+# include <io.h>
+#else
+# include <unistd.h>
+#endif
 
 static void create_test_file(void)
 {
@@ -14,6 +19,24 @@ static void create_test_file(void)
         std::fputs("Line1\nLine2\n", file);
         ft_fclose(file);
     }
+    return ;
+}
+
+static void force_file_descriptor_failure(FILE *file_handle)
+{
+    int file_descriptor;
+
+    if (file_handle == ft_nullptr)
+        return ;
+#if defined(_WIN32) || defined(_WIN64)
+    file_descriptor = _fileno(file_handle);
+    if (file_descriptor >= 0)
+        _close(file_descriptor);
+#else
+    file_descriptor = fileno(file_handle);
+    if (file_descriptor >= 0)
+        close(file_descriptor);
+#endif
     return ;
 }
 
@@ -56,6 +79,21 @@ FT_TEST(test_fclose_null, "ft_fclose with null")
     ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(EOF, ft_fclose(ft_nullptr));
     FT_ASSERT_EQ(FILE_INVALID_FD, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_fclose_failure_sets_errno, "ft_fclose propagates fclose failures")
+{
+    FILE *file;
+
+    create_test_file();
+    file = ft_fopen("test_file_io.txt", "r");
+    if (file == ft_nullptr)
+        return (0);
+    force_file_descriptor_failure(file);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(EOF, ft_fclose(file));
+    FT_ASSERT_EQ(EBADF + ERRNO_OFFSET, ft_errno);
     return (1);
 }
 
@@ -110,6 +148,22 @@ FT_TEST(test_fgets_edge_cases, "ft_fgets edge cases")
     FT_ASSERT_EQ(ft_nullptr, ft_fgets(buffer, 5, ft_nullptr));
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     FT_ASSERT_EQ(FT_SUCCESS, ft_fclose(file));
+    return (1);
+}
+
+FT_TEST(test_fgets_stream_error_sets_errno, "ft_fgets reports stream errors")
+{
+    char buffer[8];
+    FILE *file;
+
+    create_test_file();
+    file = ft_fopen("test_file_io.txt", "r");
+    if (file == ft_nullptr)
+        return (0);
+    force_file_descriptor_failure(file);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_fgets(buffer, sizeof(buffer), file));
+    FT_ASSERT_EQ(EBADF + ERRNO_OFFSET, ft_errno);
     return (1);
 }
 

--- a/Test/Test/test_geometry.cpp
+++ b/Test/Test/test_geometry.cpp
@@ -1,0 +1,158 @@
+#include "../../Geometry/geometry.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_intersect_aabb_overlap, "intersect_aabb detects overlapping boxes")
+{
+    aabb first;
+    aabb second;
+
+    first.minimum_x = 0.0;
+    first.minimum_y = 0.0;
+    first.maximum_x = 5.0;
+    first.maximum_y = 5.0;
+    second.minimum_x = 3.0;
+    second.minimum_y = 3.0;
+    second.maximum_x = 8.0;
+    second.maximum_y = 8.0;
+    FT_ASSERT(intersect_aabb(first, second));
+    FT_ASSERT(intersect_aabb(second, first));
+    return (1);
+}
+
+FT_TEST(test_intersect_aabb_separated, "intersect_aabb returns false when separated on axis")
+{
+    aabb first;
+    aabb second;
+
+    first.minimum_x = -2.0;
+    first.minimum_y = -2.0;
+    first.maximum_x = 2.0;
+    first.maximum_y = 2.0;
+    second.minimum_x = 3.0;
+    second.minimum_y = -1.0;
+    second.maximum_x = 6.0;
+    second.maximum_y = 1.0;
+    FT_ASSERT_EQ(false, intersect_aabb(first, second));
+    FT_ASSERT_EQ(false, intersect_aabb(second, first));
+    return (1);
+}
+
+FT_TEST(test_intersect_aabb_touching_edge, "intersect_aabb treats shared boundary as collision")
+{
+    aabb first;
+    aabb second;
+
+    first.minimum_x = 0.0;
+    first.minimum_y = 0.0;
+    first.maximum_x = 4.0;
+    first.maximum_y = 4.0;
+    second.minimum_x = 4.0;
+    second.minimum_y = 1.0;
+    second.maximum_x = 7.0;
+    second.maximum_y = 3.0;
+    FT_ASSERT(intersect_aabb(first, second));
+    FT_ASSERT(intersect_aabb(second, first));
+    return (1);
+}
+
+FT_TEST(test_intersect_circle_overlap, "intersect_circle detects overlapping circles")
+{
+    circle first;
+    circle second;
+
+    first.center_x = 0.0;
+    first.center_y = 0.0;
+    first.radius = 4.0;
+    second.center_x = 3.0;
+    second.center_y = 0.0;
+    second.radius = 3.0;
+    FT_ASSERT(intersect_circle(first, second));
+    FT_ASSERT(intersect_circle(second, first));
+    return (1);
+}
+
+FT_TEST(test_intersect_circle_separated, "intersect_circle returns false when distance exceeds radii")
+{
+    circle first;
+    circle second;
+
+    first.center_x = -5.0;
+    first.center_y = -5.0;
+    first.radius = 2.0;
+    second.center_x = 2.0;
+    second.center_y = 2.0;
+    second.radius = 1.5;
+    FT_ASSERT_EQ(false, intersect_circle(first, second));
+    FT_ASSERT_EQ(false, intersect_circle(second, first));
+    return (1);
+}
+
+FT_TEST(test_intersect_circle_touching, "intersect_circle treats tangential contact as intersection")
+{
+    circle first;
+    circle second;
+
+    first.center_x = 0.0;
+    first.center_y = 0.0;
+    first.radius = 3.0;
+    second.center_x = 4.0;
+    second.center_y = 0.0;
+    second.radius = 1.0;
+    FT_ASSERT(intersect_circle(first, second));
+    FT_ASSERT(intersect_circle(second, first));
+    return (1);
+}
+
+FT_TEST(test_intersect_sphere_overlap, "intersect_sphere detects overlapping spheres")
+{
+    sphere first;
+    sphere second;
+
+    first.center_x = 1.0;
+    first.center_y = 2.0;
+    first.center_z = 3.0;
+    first.radius = 5.0;
+    second.center_x = 4.0;
+    second.center_y = 3.0;
+    second.center_z = 5.0;
+    second.radius = 4.0;
+    FT_ASSERT(intersect_sphere(first, second));
+    FT_ASSERT(intersect_sphere(second, first));
+    return (1);
+}
+
+FT_TEST(test_intersect_sphere_separated, "intersect_sphere returns false when centers far apart")
+{
+    sphere first;
+    sphere second;
+
+    first.center_x = -4.0;
+    first.center_y = -4.0;
+    first.center_z = -4.0;
+    first.radius = 1.0;
+    second.center_x = 4.0;
+    second.center_y = 4.0;
+    second.center_z = 4.0;
+    second.radius = 1.0;
+    FT_ASSERT_EQ(false, intersect_sphere(first, second));
+    FT_ASSERT_EQ(false, intersect_sphere(second, first));
+    return (1);
+}
+
+FT_TEST(test_intersect_sphere_touching, "intersect_sphere treats tangential contact as collision")
+{
+    sphere first;
+    sphere second;
+
+    first.center_x = 0.0;
+    first.center_y = 0.0;
+    first.center_z = 0.0;
+    first.radius = 2.5;
+    second.center_x = 5.0;
+    second.center_y = 0.0;
+    second.center_z = 0.0;
+    second.radius = 2.5;
+    FT_ASSERT(intersect_sphere(first, second));
+    FT_ASSERT(intersect_sphere(second, first));
+    return (1);
+}

--- a/Test/Test/test_template_algorithm.cpp
+++ b/Test/Test/test_template_algorithm.cpp
@@ -1,0 +1,162 @@
+#include "../../Template/algorithm.hpp"
+#include "../../RNG/rng.hpp"
+#include "../../RNG/rng_internal.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <vector>
+#include <array>
+
+FT_TEST(test_ft_sort_orders_values, "ft_sort orders values using operator<")
+{
+    std::vector<int> values;
+    values.push_back(5);
+    values.push_back(1);
+    values.push_back(4);
+    values.push_back(2);
+    values.push_back(3);
+    ft_sort(values.begin(), values.end());
+    std::array<int, 5> expected = {1, 2, 3, 4, 5};
+    size_t index;
+
+    index = 0;
+    while (index < expected.size())
+    {
+        FT_ASSERT_EQ(expected[index], values[index]);
+        index++;
+    }
+    return (1);
+}
+
+FT_TEST(test_ft_sort_custom_comparator, "ft_sort supports custom comparators")
+{
+    std::vector<int> values;
+    values.push_back(2);
+    values.push_back(5);
+    values.push_back(1);
+    values.push_back(4);
+    values.push_back(3);
+    ft_sort(values.begin(), values.end(), [](int left, int right){ return (left > right); });
+    std::array<int, 5> expected = {5, 4, 3, 2, 1};
+    size_t index;
+
+    index = 0;
+    while (index < expected.size())
+    {
+        FT_ASSERT_EQ(expected[index], values[index]);
+        index++;
+    }
+    return (1);
+}
+
+FT_TEST(test_ft_binary_search_default, "ft_binary_search finds elements in ascending ranges")
+{
+    std::vector<int> values;
+    values.push_back(1);
+    values.push_back(3);
+    values.push_back(5);
+    values.push_back(7);
+    values.push_back(9);
+
+    FT_ASSERT(ft_binary_search(values.begin(), values.end(), 7));
+    FT_ASSERT_EQ(false, ft_binary_search(values.begin(), values.end(), 4));
+    return (1);
+}
+
+FT_TEST(test_ft_binary_search_custom_comparator, "ft_binary_search respects custom ordering")
+{
+    std::vector<int> values;
+    values.push_back(9);
+    values.push_back(7);
+    values.push_back(5);
+    values.push_back(3);
+    values.push_back(1);
+
+    FT_ASSERT(ft_binary_search(values.begin(), values.end(), 5,
+            [](int left, int right){ return (left > right); }));
+    FT_ASSERT_EQ(false, ft_binary_search(values.begin(), values.end(), 6,
+            [](int left, int right){ return (left > right); }));
+    return (1);
+}
+
+FT_TEST(test_ft_binary_search_empty_range, "ft_binary_search returns false for empty ranges")
+{
+    std::vector<int> values;
+
+    FT_ASSERT_EQ(false, ft_binary_search(values.begin(), values.end(), 1));
+    return (1);
+}
+
+FT_TEST(test_ft_shuffle_matches_manual_simulation, "ft_shuffle matches manual Fisher-Yates simulation with seeded RNG")
+{
+    std::vector<int> expected;
+    expected.push_back(1);
+    expected.push_back(2);
+    expected.push_back(3);
+    expected.push_back(4);
+    expected.push_back(5);
+    if (!expected.empty())
+    {
+        size_t iterator_index;
+
+        ft_seed_random_engine(123u);
+        iterator_index = expected.size() - 1;
+        while (iterator_index > 0)
+        {
+            size_t random_index;
+
+            random_index = static_cast<size_t>(ft_random_int());
+            random_index %= iterator_index + 1;
+            int temporary_value = expected[iterator_index];
+            expected[iterator_index] = expected[random_index];
+            expected[random_index] = temporary_value;
+            iterator_index--;
+        }
+    }
+    std::vector<int> shuffled;
+    shuffled.push_back(1);
+    shuffled.push_back(2);
+    shuffled.push_back(3);
+    shuffled.push_back(4);
+    shuffled.push_back(5);
+    ft_seed_random_engine(123u);
+    ft_shuffle(shuffled.begin(), shuffled.end());
+    size_t index;
+
+    index = 0;
+    while (index < shuffled.size())
+    {
+        FT_ASSERT_EQ(expected[index], shuffled[index]);
+        index++;
+    }
+    return (1);
+}
+
+FT_TEST(test_ft_reverse_basic, "ft_reverse reverses the provided range")
+{
+    std::vector<int> values;
+    values.push_back(1);
+    values.push_back(2);
+    values.push_back(3);
+    values.push_back(4);
+    values.push_back(5);
+    ft_reverse(values.begin(), values.end());
+    std::array<int, 5> expected = {5, 4, 3, 2, 1};
+    size_t index;
+
+    index = 0;
+    while (index < expected.size())
+    {
+        FT_ASSERT_EQ(expected[index], values[index]);
+        index++;
+    }
+    return (1);
+}
+
+FT_TEST(test_ft_reverse_single_element, "ft_reverse leaves single element range unchanged")
+{
+    std::vector<int> values;
+    values.push_back(42);
+    ft_reverse(values.begin(), values.end());
+    FT_ASSERT_EQ(1UL, values.size());
+    FT_ASSERT_EQ(42, values[0]);
+    return (1);
+}

--- a/Test/Test/test_template_bitset.cpp
+++ b/Test/Test/test_template_bitset.cpp
@@ -1,0 +1,85 @@
+#include "../../Template/bitset.hpp"
+#include "../../Template/move.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_ft_bitset_basic_operations, "ft_bitset set, reset, flip, and test manage bit states")
+{
+    ft_bitset bitset_value(16);
+
+    FT_ASSERT_EQ(16UL, bitset_value.size());
+    FT_ASSERT_EQ(ER_SUCCESS, bitset_value.get_error());
+
+    bitset_value.set(3);
+    FT_ASSERT(bitset_value.test(3));
+    FT_ASSERT_EQ(ER_SUCCESS, bitset_value.get_error());
+
+    bitset_value.set(7);
+    FT_ASSERT(bitset_value.test(7));
+    FT_ASSERT_EQ(ER_SUCCESS, bitset_value.get_error());
+
+    bitset_value.reset(3);
+    FT_ASSERT_EQ(false, bitset_value.test(3));
+    FT_ASSERT(bitset_value.test(7));
+    FT_ASSERT_EQ(ER_SUCCESS, bitset_value.get_error());
+
+    bitset_value.flip(7);
+    FT_ASSERT_EQ(false, bitset_value.test(7));
+    FT_ASSERT_EQ(ER_SUCCESS, bitset_value.get_error());
+
+    bitset_value.set(0);
+    bitset_value.clear();
+    FT_ASSERT_EQ(false, bitset_value.test(0));
+    FT_ASSERT_EQ(ER_SUCCESS, bitset_value.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_bitset_out_of_range_errors, "ft_bitset reports errors when accessing out of range indices")
+{
+    ft_bitset bitset_value(8);
+
+    bitset_value.set(12);
+    FT_ASSERT_EQ(BITSET_OUT_OF_RANGE, bitset_value.get_error());
+
+    FT_ASSERT_EQ(false, bitset_value.test(9));
+    FT_ASSERT_EQ(BITSET_OUT_OF_RANGE, bitset_value.get_error());
+
+    bitset_value.reset(15);
+    FT_ASSERT_EQ(BITSET_OUT_OF_RANGE, bitset_value.get_error());
+
+    bitset_value.set(4);
+    FT_ASSERT(bitset_value.test(4));
+    FT_ASSERT_EQ(ER_SUCCESS, bitset_value.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_bitset_move_transfers_storage, "ft_bitset move operations transfer storage without data loss")
+{
+    ft_bitset source_bitset(12);
+
+    source_bitset.set(1);
+    source_bitset.set(8);
+    FT_ASSERT(source_bitset.test(1));
+    FT_ASSERT(source_bitset.test(8));
+
+    ft_bitset moved_bitset(ft_move(source_bitset));
+
+    FT_ASSERT_EQ(12UL, moved_bitset.size());
+    FT_ASSERT(moved_bitset.test(1));
+    FT_ASSERT(moved_bitset.test(8));
+    FT_ASSERT_EQ(ER_SUCCESS, moved_bitset.get_error());
+
+    FT_ASSERT_EQ(0UL, source_bitset.size());
+    FT_ASSERT_EQ(ER_SUCCESS, source_bitset.get_error());
+
+    ft_bitset assigned_bitset(3);
+    assigned_bitset = ft_move(moved_bitset);
+
+    FT_ASSERT_EQ(12UL, assigned_bitset.size());
+    FT_ASSERT(assigned_bitset.test(1));
+    FT_ASSERT(assigned_bitset.test(8));
+    FT_ASSERT_EQ(ER_SUCCESS, assigned_bitset.get_error());
+    FT_ASSERT_EQ(0UL, moved_bitset.size());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_bitset.get_error());
+    return (1);
+}

--- a/Test/Test/test_template_circular_buffer.cpp
+++ b/Test/Test/test_template_circular_buffer.cpp
@@ -1,0 +1,107 @@
+#include "../../Template/circular_buffer.hpp"
+#include "../../Template/move.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_ft_circular_buffer_push_pop_cycle, "ft_circular_buffer preserves order across wrap around")
+{
+    ft_circular_buffer<int> buffer_instance(3);
+
+    FT_ASSERT_EQ(false, buffer_instance.is_full());
+    FT_ASSERT_EQ(true, buffer_instance.is_empty());
+    FT_ASSERT_EQ(0UL, buffer_instance.size());
+    FT_ASSERT_EQ(3UL, buffer_instance.capacity());
+
+    buffer_instance.push(1);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+    buffer_instance.push(2);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+    buffer_instance.push(3);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+
+    FT_ASSERT(buffer_instance.is_full());
+    FT_ASSERT_EQ(false, buffer_instance.is_empty());
+
+    int first_value = buffer_instance.pop();
+    FT_ASSERT_EQ(1, first_value);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+
+    buffer_instance.push(4);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+
+    int second_value = buffer_instance.pop();
+    FT_ASSERT_EQ(2, second_value);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+
+    int third_value = buffer_instance.pop();
+    FT_ASSERT_EQ(3, third_value);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+
+    int fourth_value = buffer_instance.pop();
+    FT_ASSERT_EQ(4, fourth_value);
+    FT_ASSERT(buffer_instance.is_empty());
+    FT_ASSERT_EQ(0UL, buffer_instance.size());
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_circular_buffer_error_states, "ft_circular_buffer surfaces full and empty error codes")
+{
+    ft_circular_buffer<int> buffer_instance(2);
+
+    buffer_instance.push(10);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+    buffer_instance.push(20);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+
+    buffer_instance.push(30);
+    FT_ASSERT_EQ(CIRCULAR_BUFFER_FULL, buffer_instance.get_error());
+
+    buffer_instance.clear();
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+    FT_ASSERT(buffer_instance.is_empty());
+
+    int empty_value = buffer_instance.pop();
+    FT_ASSERT_EQ(0, empty_value);
+    FT_ASSERT_EQ(CIRCULAR_BUFFER_EMPTY, buffer_instance.get_error());
+
+    buffer_instance.push(50);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+    buffer_instance.push(60);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+
+    buffer_instance.pop();
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+    buffer_instance.pop();
+    FT_ASSERT_EQ(ER_SUCCESS, buffer_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_circular_buffer_move_semantics, "ft_circular_buffer move constructor and assignment transfer storage")
+{
+    ft_circular_buffer<int> original_buffer(2);
+    original_buffer.push(5);
+    original_buffer.push(7);
+
+    ft_circular_buffer<int> moved_buffer(ft_move(original_buffer));
+
+    FT_ASSERT(original_buffer.is_empty());
+    FT_ASSERT_EQ(ER_SUCCESS, original_buffer.get_error());
+
+    FT_ASSERT_EQ(false, moved_buffer.is_empty());
+    FT_ASSERT_EQ(2UL, moved_buffer.size());
+    FT_ASSERT_EQ(5, moved_buffer.pop());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_buffer.get_error());
+
+    ft_circular_buffer<int> assigned_buffer(3);
+    assigned_buffer = ft_move(moved_buffer);
+
+    FT_ASSERT(moved_buffer.is_empty());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_buffer.get_error());
+
+    FT_ASSERT_EQ(1UL, assigned_buffer.size());
+    FT_ASSERT_EQ(7, assigned_buffer.pop());
+    FT_ASSERT_EQ(ER_SUCCESS, assigned_buffer.get_error());
+    FT_ASSERT(assigned_buffer.is_empty());
+    return (1);
+}

--- a/Test/Test/test_template_deque.cpp
+++ b/Test/Test/test_template_deque.cpp
@@ -1,0 +1,121 @@
+#include "../../Template/deque.hpp"
+#include "../../Template/move.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_ft_deque_push_pop_order, "ft_deque preserves order across push and pop operations")
+{
+    ft_deque<int> deque_instance;
+
+    deque_instance.push_back(5);
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    deque_instance.push_front(3);
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    deque_instance.push_back(7);
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+
+    FT_ASSERT_EQ(false, deque_instance.empty());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    FT_ASSERT_EQ(3UL, deque_instance.size());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+
+    FT_ASSERT_EQ(3, deque_instance.front());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    FT_ASSERT_EQ(7, deque_instance.back());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+
+    int first_value = deque_instance.pop_front();
+    FT_ASSERT_EQ(3, first_value);
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+
+    int last_value = deque_instance.pop_back();
+    FT_ASSERT_EQ(7, last_value);
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+
+    FT_ASSERT_EQ(1UL, deque_instance.size());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    FT_ASSERT_EQ(5, deque_instance.front());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+
+    deque_instance.clear();
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    FT_ASSERT(deque_instance.empty());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_deque_pop_on_empty_sets_error, "ft_deque reports underflow errors when popping from an empty container")
+{
+    ft_deque<int> deque_instance;
+
+    int value_from_front = deque_instance.pop_front();
+    FT_ASSERT_EQ(0, value_from_front);
+    FT_ASSERT_EQ(DEQUE_EMPTY, deque_instance.get_error());
+
+    int value_from_back = deque_instance.pop_back();
+    FT_ASSERT_EQ(0, value_from_back);
+    FT_ASSERT_EQ(DEQUE_EMPTY, deque_instance.get_error());
+
+    FT_ASSERT(deque_instance.empty());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_deque_allocation_failure_sets_error, "ft_deque surfaces allocation failures during push operations")
+{
+    ft_deque<int> deque_instance;
+
+    cma_set_alloc_limit(1);
+    deque_instance.push_back(42);
+    cma_set_alloc_limit(0);
+
+    FT_ASSERT_EQ(DEQUE_ALLOC_FAIL, deque_instance.get_error());
+    FT_ASSERT(deque_instance.empty());
+
+    deque_instance.push_back(5);
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    FT_ASSERT_EQ(1UL, deque_instance.size());
+    FT_ASSERT_EQ(ER_SUCCESS, deque_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_deque_move_transfers_ownership, "ft_deque move operations transfer nodes and reset sources")
+{
+    ft_deque<int> source_deque;
+    source_deque.push_back(1);
+    source_deque.push_back(2);
+    source_deque.push_back(3);
+    FT_ASSERT_EQ(ER_SUCCESS, source_deque.get_error());
+
+    ft_deque<int> moved_deque(ft_move(source_deque));
+
+    FT_ASSERT(source_deque.empty());
+    FT_ASSERT_EQ(ER_SUCCESS, source_deque.get_error());
+    FT_ASSERT_EQ(3UL, moved_deque.size());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_deque.get_error());
+    FT_ASSERT_EQ(1, moved_deque.front());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_deque.get_error());
+    FT_ASSERT_EQ(3, moved_deque.back());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_deque.get_error());
+
+    ft_deque<int> target_deque;
+    target_deque.push_back(99);
+    FT_ASSERT_EQ(ER_SUCCESS, target_deque.get_error());
+
+    target_deque = ft_move(moved_deque);
+
+    FT_ASSERT(moved_deque.empty());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_deque.get_error());
+    FT_ASSERT_EQ(3UL, target_deque.size());
+    FT_ASSERT_EQ(ER_SUCCESS, target_deque.get_error());
+    FT_ASSERT_EQ(1, target_deque.pop_front());
+    FT_ASSERT_EQ(ER_SUCCESS, target_deque.get_error());
+    FT_ASSERT_EQ(3, target_deque.pop_back());
+    FT_ASSERT_EQ(ER_SUCCESS, target_deque.get_error());
+    FT_ASSERT_EQ(1UL, target_deque.size());
+    FT_ASSERT_EQ(ER_SUCCESS, target_deque.get_error());
+    FT_ASSERT_EQ(2, target_deque.front());
+    FT_ASSERT_EQ(ER_SUCCESS, target_deque.get_error());
+    return (1);
+}

--- a/Test/Test/test_template_event_emitter.cpp
+++ b/Test/Test/test_template_event_emitter.cpp
@@ -1,0 +1,115 @@
+#include "../../Template/event_emitter.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+static int g_event_listener_one_total = 0;
+static int g_event_listener_two_total = 0;
+
+static void event_listener_add_to_first(int value)
+{
+    g_event_listener_one_total += value;
+    return ;
+}
+
+static void event_listener_add_to_second(int value)
+{
+    g_event_listener_two_total += value;
+    return ;
+}
+
+FT_TEST(test_ft_event_emitter_invokes_registered_listeners, "ft_event_emitter emits events to all matching listeners")
+{
+    ft_event_emitter<int, int> emitter_instance;
+
+    g_event_listener_one_total = 0;
+    g_event_listener_two_total = 0;
+
+    emitter_instance.on(7, event_listener_add_to_first);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+    emitter_instance.on(7, event_listener_add_to_second);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+
+    emitter_instance.emit(7, 5);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+
+    FT_ASSERT_EQ(5, g_event_listener_one_total);
+    FT_ASSERT_EQ(5, g_event_listener_two_total);
+    FT_ASSERT_EQ(2UL, emitter_instance.size());
+    FT_ASSERT_EQ(false, emitter_instance.empty());
+    return (1);
+}
+
+FT_TEST(test_ft_event_emitter_remove_listener_stops_callback, "ft_event_emitter remove_listener prevents future delivery")
+{
+    ft_event_emitter<int, int> emitter_instance;
+
+    g_event_listener_one_total = 0;
+    g_event_listener_two_total = 0;
+
+    emitter_instance.on(3, event_listener_add_to_first);
+    emitter_instance.on(3, event_listener_add_to_second);
+    FT_ASSERT_EQ(2UL, emitter_instance.size());
+
+    emitter_instance.remove_listener(3, event_listener_add_to_first);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+    FT_ASSERT_EQ(1UL, emitter_instance.size());
+
+    emitter_instance.emit(3, 4);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+
+    FT_ASSERT_EQ(0, g_event_listener_one_total);
+    FT_ASSERT_EQ(4, g_event_listener_two_total);
+
+    emitter_instance.remove_listener(3, event_listener_add_to_first);
+    FT_ASSERT_EQ(EVENT_EMITTER_NOT_FOUND, emitter_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_event_emitter_emit_missing_sets_error, "ft_event_emitter reports when no listeners match an event")
+{
+    ft_event_emitter<int, int> emitter_instance;
+
+    emitter_instance.emit(1, 10);
+    FT_ASSERT_EQ(EVENT_EMITTER_NOT_FOUND, emitter_instance.get_error());
+    FT_ASSERT_EQ(0UL, emitter_instance.size());
+    FT_ASSERT(emitter_instance.empty());
+    return (1);
+}
+
+FT_TEST(test_ft_event_emitter_allocation_failure_sets_error, "ft_event_emitter surfaces allocation failures during listener registration")
+{
+    ft_event_emitter<int, int> emitter_instance;
+
+    cma_set_alloc_limit(1);
+    emitter_instance.on(9, event_listener_add_to_first);
+    cma_set_alloc_limit(0);
+
+    FT_ASSERT_EQ(EVENT_EMITTER_ALLOC_FAIL, emitter_instance.get_error());
+    FT_ASSERT_EQ(0UL, emitter_instance.size());
+    FT_ASSERT(emitter_instance.empty());
+    return (1);
+}
+
+FT_TEST(test_ft_event_emitter_growth_preserves_existing_listeners, "ft_event_emitter keep existing listeners when resizing")
+{
+    ft_event_emitter<int, int> emitter_instance(1);
+
+    g_event_listener_one_total = 0;
+    g_event_listener_two_total = 0;
+
+    emitter_instance.on(11, event_listener_add_to_first);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+    emitter_instance.on(12, event_listener_add_to_second);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+    emitter_instance.on(11, event_listener_add_to_second);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+
+    emitter_instance.emit(11, 2);
+    FT_ASSERT_EQ(ER_SUCCESS, emitter_instance.get_error());
+
+    FT_ASSERT_EQ(2, g_event_listener_one_total);
+    FT_ASSERT_EQ(2, g_event_listener_two_total);
+    FT_ASSERT_EQ(3UL, emitter_instance.size());
+    return (1);
+}

--- a/Test/Test/test_template_optional_variant.cpp
+++ b/Test/Test/test_template_optional_variant.cpp
@@ -1,0 +1,80 @@
+#include "../../Template/optional.hpp"
+#include "../../Template/variant.hpp"
+#include "../../Template/move.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cstring>
+
+FT_TEST(test_ft_optional_reports_empty_state, "ft_optional reports empty state when no value is stored")
+{
+    ft_optional<int> optional_value;
+
+    FT_ASSERT_EQ(false, optional_value.has_value());
+    int &fallback_value = optional_value.value();
+
+    FT_ASSERT_EQ(0, fallback_value);
+    FT_ASSERT_EQ(OPTIONAL_EMPTY, optional_value.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_optional_holds_value_and_resets, "ft_optional stores values and clears them on reset")
+{
+    ft_optional<int> optional_value(42);
+
+    FT_ASSERT(optional_value.has_value());
+    FT_ASSERT_EQ(42, optional_value.value());
+    FT_ASSERT_EQ(ER_SUCCESS, optional_value.get_error());
+    optional_value.reset();
+    FT_ASSERT_EQ(false, optional_value.has_value());
+    FT_ASSERT_EQ(ER_SUCCESS, optional_value.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_optional_move_transfers_state, "ft_optional move assignment transfers ownership and clears source")
+{
+    ft_optional<int> source_optional(99);
+    ft_optional<int> destination_optional;
+
+    destination_optional = ft_move(source_optional);
+    FT_ASSERT(destination_optional.has_value());
+    FT_ASSERT_EQ(99, destination_optional.value());
+    FT_ASSERT_EQ(false, source_optional.has_value());
+    FT_ASSERT_EQ(ER_SUCCESS, destination_optional.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, source_optional.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_variant_emplace_and_get, "ft_variant emplace selects alternative and returns stored value")
+{
+    ft_variant<int, const char*> variant_value;
+
+    variant_value.emplace<int>(17);
+    FT_ASSERT(variant_value.holds_alternative<int>());
+    FT_ASSERT_EQ(17, variant_value.get<int>());
+    FT_ASSERT_EQ(ER_SUCCESS, variant_value.get_error());
+    variant_value.emplace<const char*>("hello");
+    FT_ASSERT(variant_value.holds_alternative<const char*>());
+    const char *string_value = variant_value.get<const char*>();
+    FT_ASSERT_EQ(0, std::strcmp("hello", string_value));
+    int wrong_access = variant_value.get<int>();
+    FT_ASSERT_EQ(0, wrong_access);
+    FT_ASSERT_EQ(VARIANT_BAD_ACCESS, variant_value.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_variant_visit_and_reset, "ft_variant visit dispatches to active alternative and handles reset")
+{
+    ft_variant<int, long> variant_value(12);
+    long visit_sum = 0;
+
+    variant_value.visit([&visit_sum](const auto &value){ visit_sum += value; });
+    FT_ASSERT_EQ(12L, visit_sum);
+    FT_ASSERT_EQ(ER_SUCCESS, variant_value.get_error());
+    variant_value.reset();
+    FT_ASSERT_EQ(false, variant_value.holds_alternative<int>());
+    visit_sum = 5;
+    variant_value.visit([&visit_sum](const auto &value){ visit_sum += value; });
+    FT_ASSERT_EQ(5L, visit_sum);
+    FT_ASSERT_EQ(VARIANT_BAD_ACCESS, variant_value.get_error());
+    return (1);
+}

--- a/Test/Test/test_template_priority_queue.cpp
+++ b/Test/Test/test_template_priority_queue.cpp
@@ -1,0 +1,101 @@
+#include "../../Template/priority_queue.hpp"
+#include "../../Template/move.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <functional>
+
+FT_TEST(test_ft_priority_queue_push_pop_order, "ft_priority_queue pop returns elements in comparator order")
+{
+    ft_priority_queue<int> queue_instance;
+
+    queue_instance.push(5);
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+    queue_instance.push(1);
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+    queue_instance.push(9);
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+
+    FT_ASSERT_EQ(false, queue_instance.empty());
+    FT_ASSERT_EQ(3UL, queue_instance.size());
+    FT_ASSERT_EQ(9, queue_instance.top());
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+
+    int first_value = queue_instance.pop();
+    FT_ASSERT_EQ(9, first_value);
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+    FT_ASSERT_EQ(2UL, queue_instance.size());
+
+    int second_value = queue_instance.pop();
+    FT_ASSERT_EQ(5, second_value);
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+
+    int third_value = queue_instance.pop();
+    FT_ASSERT_EQ(1, third_value);
+    FT_ASSERT(queue_instance.empty());
+    FT_ASSERT_EQ(0UL, queue_instance.size());
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_priority_queue_custom_comparator, "ft_priority_queue honors custom comparator for ordering")
+{
+    ft_priority_queue<int, std::greater<int> > queue_instance(0, std::greater<int>());
+
+    queue_instance.push(4);
+    queue_instance.push(2);
+    queue_instance.push(7);
+
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+    FT_ASSERT_EQ(3UL, queue_instance.size());
+    FT_ASSERT_EQ(2, queue_instance.top());
+
+    int first_value = queue_instance.pop();
+    FT_ASSERT_EQ(2, first_value);
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+    FT_ASSERT_EQ(4, queue_instance.top());
+
+    queue_instance.pop();
+    queue_instance.pop();
+    FT_ASSERT(queue_instance.empty());
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_priority_queue_error_handling_and_moves, "ft_priority_queue reports errors and transfers ownership on move")
+{
+    ft_priority_queue<int> queue_instance;
+
+    int empty_value = queue_instance.pop();
+    FT_ASSERT_EQ(0, empty_value);
+    FT_ASSERT_EQ(PRIORITY_QUEUE_EMPTY, queue_instance.get_error());
+
+    int top_empty = queue_instance.top();
+    FT_ASSERT_EQ(0, top_empty);
+    FT_ASSERT_EQ(PRIORITY_QUEUE_EMPTY, queue_instance.get_error());
+
+    queue_instance.push(11);
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+    queue_instance.push(3);
+    FT_ASSERT_EQ(ER_SUCCESS, queue_instance.get_error());
+
+    ft_priority_queue<int> moved_queue(ft_move(queue_instance));
+
+    FT_ASSERT(queue_instance.empty());
+    int moved_from_pop = queue_instance.pop();
+    FT_ASSERT_EQ(0, moved_from_pop);
+    FT_ASSERT_EQ(PRIORITY_QUEUE_EMPTY, queue_instance.get_error());
+
+    FT_ASSERT_EQ(false, moved_queue.empty());
+    FT_ASSERT_EQ(2UL, moved_queue.size());
+    FT_ASSERT_EQ(11, moved_queue.top());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_queue.get_error());
+
+    int popped_value = moved_queue.pop();
+    FT_ASSERT_EQ(11, popped_value);
+    FT_ASSERT_EQ(ER_SUCCESS, moved_queue.get_error());
+
+    moved_queue.clear();
+    FT_ASSERT(moved_queue.empty());
+    FT_ASSERT_EQ(ER_SUCCESS, moved_queue.get_error());
+    return (1);
+}

--- a/Test/Test/test_template_tuple.cpp
+++ b/Test/Test/test_template_tuple.cpp
@@ -1,0 +1,78 @@
+#include "../../Template/tuple.hpp"
+#include "../../Template/move.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include "../../CPP_class/class_string_class.hpp"
+
+FT_TEST(test_ft_tuple_construction_and_get, "ft_tuple stores provided values and exposes them by index and type")
+{
+    ft_tuple<int, ft_string, double> tuple_instance(7, ft_string("value"), 3.5);
+
+    int first_value = tuple_instance.get<0>();
+    FT_ASSERT_EQ(7, first_value);
+    FT_ASSERT_EQ(ER_SUCCESS, tuple_instance.get_error());
+
+    ft_string &second_value = tuple_instance.get<1>();
+    FT_ASSERT(second_value == "value");
+    FT_ASSERT_EQ(ER_SUCCESS, tuple_instance.get_error());
+
+    double third_value = tuple_instance.get<2>();
+    FT_ASSERT_EQ(3.5, third_value);
+    FT_ASSERT_EQ(ER_SUCCESS, tuple_instance.get_error());
+
+    double type_lookup = tuple_instance.get<double>();
+    FT_ASSERT_EQ(3.5, type_lookup);
+    FT_ASSERT_EQ(ER_SUCCESS, tuple_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_tuple_reset_and_error_reporting, "ft_tuple signals bad access after reset and recovers on new construction")
+{
+    ft_tuple<int, ft_string> tuple_instance(42, ft_string("answer"));
+
+    tuple_instance.reset();
+    FT_ASSERT_EQ(ER_SUCCESS, tuple_instance.get_error());
+
+    int missing_value = tuple_instance.get<0>();
+    FT_ASSERT_EQ(0, missing_value);
+    FT_ASSERT_EQ(TUPLE_BAD_ACCESS, tuple_instance.get_error());
+
+    ft_string &missing_string = tuple_instance.get<1>();
+    FT_ASSERT(missing_string == "");
+    FT_ASSERT_EQ(TUPLE_BAD_ACCESS, tuple_instance.get_error());
+
+    ft_tuple<int, ft_string> refreshed_tuple(11, ft_string("eleven"));
+    tuple_instance = ft_move(refreshed_tuple);
+    FT_ASSERT_EQ(ER_SUCCESS, tuple_instance.get_error());
+    FT_ASSERT_EQ(11, tuple_instance.get<0>());
+    FT_ASSERT_EQ(ER_SUCCESS, tuple_instance.get_error());
+    return (1);
+}
+
+FT_TEST(test_ft_tuple_move_semantics, "ft_tuple move constructor releases original storage and retains values")
+{
+    ft_tuple<int, ft_string> original_tuple(5, ft_string("five"));
+
+    ft_tuple<int, ft_string> moved_tuple(ft_move(original_tuple));
+
+    int moved_value = moved_tuple.get<0>();
+    FT_ASSERT_EQ(5, moved_value);
+    FT_ASSERT_EQ(ER_SUCCESS, moved_tuple.get_error());
+
+    ft_string &moved_string = moved_tuple.get<1>();
+    FT_ASSERT(moved_string == "five");
+    FT_ASSERT_EQ(ER_SUCCESS, moved_tuple.get_error());
+
+    int default_value = original_tuple.get<0>();
+    FT_ASSERT_EQ(0, default_value);
+    FT_ASSERT_EQ(TUPLE_BAD_ACCESS, original_tuple.get_error());
+
+    ft_tuple<int, ft_string> assigned_tuple(1, ft_string("one"));
+    assigned_tuple = ft_move(moved_tuple);
+
+    FT_ASSERT_EQ(ER_SUCCESS, moved_tuple.get_error());
+    int assigned_value = assigned_tuple.get<0>();
+    FT_ASSERT_EQ(5, assigned_value);
+    FT_ASSERT_EQ(ER_SUCCESS, assigned_tuple.get_error());
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add ft_deque unit tests that exercise push/pop ordering, empty pops, allocation failures, and move semantics

## Testing
- make -s -C Test OPT_LEVEL=0
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68de4b9875588331af7f8a5f3b37653c