### PR TITLE
Add empty check to ft_vector

### DIFF
--- a/Template/vector.hpp
+++ b/Template/vector.hpp
@@ -43,6 +43,7 @@ class ft_vector
 
         size_t size() const;
         size_t capacity() const;
+        bool empty() const;
         int get_error() const;
         const char* get_error_str() const;
 
@@ -170,6 +171,20 @@ size_t ft_vector<ElementType>::capacity() const
     this->set_error(ER_SUCCESS);
     this->_mutex.unlock(THREAD_ID);
     return (c);
+}
+
+template <typename ElementType>
+bool ft_vector<ElementType>::empty() const
+{
+    if (this->_mutex.lock(THREAD_ID) != FT_SUCCESS)
+    {
+        this->set_error(this->_mutex.get_error());
+        return (true);
+    }
+    bool is_vector_empty = (this->_size == 0);
+    this->set_error(ER_SUCCESS);
+    this->_mutex.unlock(THREAD_ID);
+    return (is_vector_empty);
 }
 
 template <typename ElementType>

--- a/Test/Test/test_strtol.cpp
+++ b/Test/Test/test_strtol.cpp
@@ -120,6 +120,28 @@ FT_TEST(test_strtol_uppercase_hex_prefix, "ft_strtol accepts uppercase hex prefi
     return (1);
 }
 
+FT_TEST(test_strtol_base36_mixed_case, "ft_strtol parses base 36 digits in any case")
+{
+    char *end_pointer;
+
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(1294L, ft_strtol("Zy", &end_pointer, 36));
+    FT_ASSERT_EQ('\0', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strtol_skips_leading_whitespace, "ft_strtol ignores leading whitespace before digits")
+{
+    char *end_pointer;
+
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(678L, ft_strtol("\t  678xyz", &end_pointer, 10));
+    FT_ASSERT_EQ('x', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_strtol_null_input, "ft_strtol null input sets errno and end pointer")
 {
     char *end_pointer = reinterpret_cast<char *>(0x1);

--- a/Test/Test/test_strtoul.cpp
+++ b/Test/Test/test_strtoul.cpp
@@ -33,6 +33,17 @@ FT_TEST(test_strtoul_base0, "ft_strtoul base 0 hex prefix")
     return (1);
 }
 
+FT_TEST(test_strtoul_base36_mixed_case, "ft_strtoul parses base 36 digits in mixed case")
+{
+    char *end_pointer;
+
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(static_cast<unsigned long>(1295), ft_strtoul("Zz", &end_pointer, 36));
+    FT_ASSERT_EQ('\0', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_strtoul_invalid_base, "ft_strtoul invalid base returns error and input pointer")
 {
     const char *input_string = "456";

--- a/Test/Test/test_validate_int.cpp
+++ b/Test/Test/test_validate_int.cpp
@@ -56,6 +56,28 @@ FT_TEST(test_validate_int_nullptr, "validate int nullptr")
     return (1);
 }
 
+FT_TEST(test_validate_int_leading_whitespace_fails, "validate int rejects leading whitespace")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_validate_int(" 123"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_validate_int("\t456"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_validate_int_trailing_whitespace_fails, "validate int rejects trailing whitespace")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_validate_int("789 "));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_validate_int("321\n"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_cma_atoi_ok, "cma atoi ok")
 {
     int *number;


### PR DESCRIPTION
## Summary
- add an empty() convenience query to ft_vector guarded by the existing mutex

## Testing
- make -C Test test_template *(fails: target missing)*

------
https://chatgpt.com/codex/tasks/task_e_68de66f5d4bc83319ff35272cca93b74