### PR TITLE
Add tests for networking send utils and socket config

### DIFF
--- a/Test/Test/test_compatebility_file_path.cpp
+++ b/Test/Test/test_compatebility_file_path.cpp
@@ -1,0 +1,51 @@
+#include "../../Compatebility/compatebility_internal.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cstring>
+
+FT_TEST(test_cmp_path_separator_matches_platform, "cmp_path_separator returns platform separator")
+{
+#if defined(_WIN32) || defined(_WIN64)
+    const char expected_separator = '\\';
+#else
+    const char expected_separator = '/';
+#endif
+    FT_ASSERT_EQ(expected_separator, cmp_path_separator());
+    return (1);
+}
+
+FT_TEST(test_cmp_normalize_slashes_translates_alternate_separator, "cmp_normalize_slashes converts alternate separator characters")
+{
+#if defined(_WIN32) || defined(_WIN64)
+    char path[] = "folder/subdir/file.txt";
+    cmp_normalize_slashes(path);
+    FT_ASSERT_EQ(0, std::strcmp("folder\\subdir\\file.txt", path));
+#else
+    char path[] = "folder\\subdir\\file.txt";
+    cmp_normalize_slashes(path);
+    FT_ASSERT_EQ(0, std::strcmp("folder/subdir/file.txt", path));
+#endif
+    return (1);
+}
+
+FT_TEST(test_cmp_normalize_slashes_preserves_native_separator, "cmp_normalize_slashes leaves native separator untouched")
+{
+#if defined(_WIN32) || defined(_WIN64)
+    char path[] = "folder\\native\\path";
+    cmp_normalize_slashes(path);
+    FT_ASSERT_EQ(0, std::strcmp("folder\\native\\path", path));
+#else
+    char path[] = "folder/native/path";
+    cmp_normalize_slashes(path);
+    FT_ASSERT_EQ(0, std::strcmp("folder/native/path", path));
+#endif
+    return (1);
+}
+
+FT_TEST(test_cmp_normalize_slashes_handles_empty_string, "cmp_normalize_slashes handles empty strings without modification")
+{
+    char path[] = "";
+
+    cmp_normalize_slashes(path);
+    FT_ASSERT_EQ(0, std::strcmp("", path));
+    return (1);
+}

--- a/Test/Test/test_environment.cpp
+++ b/Test/Test/test_environment.cpp
@@ -98,6 +98,40 @@ FT_TEST(test_ft_setenv_success_resets_errno, "ft_setenv stores value and clears 
     return (1);
 }
 
+FT_TEST(test_ft_setenv_overwrite_disabled_preserves_existing, "ft_setenv leaves value unchanged when overwrite is zero")
+{
+    const char *variable_name;
+    char *value;
+
+    variable_name = "LIBFT_TEST_SETENV_NO_OVERWRITE";
+    FT_ASSERT_EQ(0, ft_setenv(variable_name, "initial", 1));
+    ft_errno = FT_ETERM;
+    FT_ASSERT_EQ(0, ft_setenv(variable_name, "replacement", 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    value = ft_getenv(variable_name);
+    FT_ASSERT(value != ft_nullptr);
+    FT_ASSERT_EQ(0, std::strcmp(value, "initial"));
+    FT_ASSERT_EQ(0, ft_unsetenv(variable_name));
+    return (1);
+}
+
+FT_TEST(test_ft_setenv_overwrite_disabled_creates_variable, "ft_setenv creates variable when overwrite is zero and missing")
+{
+    const char *variable_name;
+    char *value;
+
+    variable_name = "LIBFT_TEST_SETENV_CREATE_NO_OVERWRITE";
+    ft_unsetenv(variable_name);
+    ft_errno = FT_ETERM;
+    FT_ASSERT_EQ(0, ft_setenv(variable_name, "created", 0));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    value = ft_getenv(variable_name);
+    FT_ASSERT(value != ft_nullptr);
+    FT_ASSERT_EQ(0, std::strcmp(value, "created"));
+    FT_ASSERT_EQ(0, ft_unsetenv(variable_name));
+    return (1);
+}
+
 FT_TEST(test_ft_unsetenv_rejects_equals_sign, "ft_unsetenv rejects names containing equals")
 {
     ft_errno = ER_SUCCESS;

--- a/Test/Test/test_errno.cpp
+++ b/Test/Test/test_errno.cpp
@@ -5,7 +5,68 @@
 #include <atomic>
 #include <cerrno>
 #include <cstring>
+#include <string>
 #include <thread>
+#include <unistd.h>
+#include <sys/wait.h>
+
+static bool capture_ft_exit_output(const char *message, int errno_value, int exit_code,
+        std::string &output, int &child_status)
+{
+    int pipe_fds[2];
+    pid_t child_process_id;
+    char buffer[256];
+    ssize_t bytes_read;
+
+    output.clear();
+    child_status = -1;
+    if (pipe(pipe_fds) != 0)
+        return (false);
+    child_process_id = fork();
+    if (child_process_id < 0)
+    {
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return (false);
+    }
+    if (child_process_id == 0)
+    {
+        close(pipe_fds[0]);
+        if (dup2(pipe_fds[1], 2) < 0)
+            _exit(127);
+        close(pipe_fds[1]);
+        ft_errno = errno_value;
+        ft_exit(message, exit_code);
+        _exit(127);
+    }
+    close(pipe_fds[1]);
+    while (true)
+    {
+        bytes_read = read(pipe_fds[0], buffer, sizeof(buffer));
+        if (bytes_read > 0)
+        {
+            output.append(buffer, static_cast<size_t>(bytes_read));
+        }
+        else if (bytes_read == 0)
+        {
+            break ;
+        }
+        else if (errno == EINTR)
+        {
+            continue ;
+        }
+        else
+        {
+            close(pipe_fds[0]);
+            waitpid(child_process_id, &child_status, 0);
+            return (false);
+        }
+    }
+    close(pipe_fds[0]);
+    if (waitpid(child_process_id, &child_status, 0) < 0)
+        return (false);
+    return (true);
+}
 
 FT_TEST(test_ft_strerror_errno_message, "ft_strerror returns standard errno message")
 {
@@ -77,5 +138,127 @@ FT_TEST(test_ft_errno_is_thread_local, "ft_errno maintains independent values pe
     worker_thread.join();
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     FT_ASSERT_EQ(FT_ERANGE, thread_errno_value.load());
+    return (1);
+}
+
+FT_TEST(test_ft_perror_null_message_outputs_errno, "ft_perror prints strerror when message is null")
+{
+    int     pipe_fds[2];
+    int     saved_stderr;
+    ssize_t read_count;
+    char    buffer[256];
+    int     original_errno_value;
+    const char *expected_message;
+
+    original_errno_value = ft_errno;
+    expected_message = ft_strerror(FT_EINVAL);
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(0, pipe(pipe_fds));
+    saved_stderr = dup(2);
+    FT_ASSERT(saved_stderr >= 0);
+    FT_ASSERT_EQ(0, dup2(pipe_fds[1], 2));
+    close(pipe_fds[1]);
+
+    ft_perror(ft_nullptr);
+
+    read_count = read(pipe_fds[0], buffer, sizeof(buffer) - 1);
+    FT_ASSERT(read_count > 0);
+    buffer[read_count] = '\0';
+    FT_ASSERT(ft_strstr(buffer, expected_message) != ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+
+    FT_ASSERT_EQ(0, dup2(saved_stderr, 2));
+    close(saved_stderr);
+    close(pipe_fds[0]);
+    ft_errno = original_errno_value;
+    return (1);
+}
+
+FT_TEST(test_ft_perror_prefixes_custom_message, "ft_perror prefixes custom text before strerror output")
+{
+    int     pipe_fds[2];
+    int     saved_stderr;
+    ssize_t read_count;
+    char    buffer[256];
+    int     original_errno_value;
+    const char *expected_message;
+
+    original_errno_value = ft_errno;
+    expected_message = ft_strerror(FT_EIO);
+    ft_errno = FT_EIO;
+    FT_ASSERT_EQ(0, pipe(pipe_fds));
+    saved_stderr = dup(2);
+    FT_ASSERT(saved_stderr >= 0);
+    FT_ASSERT_EQ(0, dup2(pipe_fds[1], 2));
+    close(pipe_fds[1]);
+
+    ft_perror("custom context");
+
+    read_count = read(pipe_fds[0], buffer, sizeof(buffer) - 1);
+    FT_ASSERT(read_count > 0);
+    buffer[read_count] = '\0';
+    FT_ASSERT(ft_strstr(buffer, "custom context: ") != ft_nullptr);
+    FT_ASSERT(ft_strstr(buffer, expected_message) != ft_nullptr);
+    FT_ASSERT_EQ(FT_EIO, ft_errno);
+
+    FT_ASSERT_EQ(0, dup2(saved_stderr, 2));
+    close(saved_stderr);
+    close(pipe_fds[0]);
+    ft_errno = original_errno_value;
+    return (1);
+}
+
+FT_TEST(test_ft_exit_message_without_errno, "ft_exit prints message without strerror when errno indicates success")
+{
+    std::string captured_output;
+    int         child_status;
+    int         original_errno_value;
+
+    original_errno_value = ft_errno;
+    FT_ASSERT(capture_ft_exit_output("shutting down", ER_SUCCESS, 23, captured_output, child_status));
+    FT_ASSERT(WIFEXITED(child_status));
+    FT_ASSERT_EQ(23, WEXITSTATUS(child_status));
+    FT_ASSERT_EQ(std::string("shutting down\n"), captured_output);
+    FT_ASSERT_EQ(original_errno_value, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_exit_message_with_errno, "ft_exit appends strerror details when errno set")
+{
+    std::string captured_output;
+    int         child_status;
+    const char *expected_error_message;
+    int         original_errno_value;
+
+    original_errno_value = ft_errno;
+    expected_error_message = ft_strerror(FT_EIO);
+    FT_ASSERT(capture_ft_exit_output("fatal failure", FT_EIO, 90, captured_output, child_status));
+    FT_ASSERT(WIFEXITED(child_status));
+    FT_ASSERT_EQ(90, WEXITSTATUS(child_status));
+    FT_ASSERT(!captured_output.empty());
+    FT_ASSERT(captured_output.find("fatal failure: ") != std::string::npos);
+    FT_ASSERT(captured_output.find(expected_error_message) != std::string::npos);
+    FT_ASSERT_EQ('\n', captured_output.back());
+    FT_ASSERT_EQ(original_errno_value, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_exit_without_message_outputs_errno, "ft_exit prints strerror when no message provided")
+{
+    std::string captured_output;
+    int         child_status;
+    const char *expected_error_message;
+    std::string expected_output;
+    int         original_errno_value;
+
+    original_errno_value = ft_errno;
+    expected_error_message = ft_strerror(FT_EINVAL);
+    expected_output = expected_error_message;
+    expected_output.push_back('\n');
+    FT_ASSERT(capture_ft_exit_output(ft_nullptr, FT_EINVAL, 7, captured_output, child_status));
+    FT_ASSERT(WIFEXITED(child_status));
+    FT_ASSERT_EQ(7, WEXITSTATUS(child_status));
+    FT_ASSERT_EQ(expected_output, captured_output);
+    FT_ASSERT_EQ(original_errno_value, ft_errno);
     return (1);
 }

--- a/Test/Test/test_get_next_line_read_file.cpp
+++ b/Test/Test/test_get_next_line_read_file.cpp
@@ -1,0 +1,71 @@
+#include "../../GetNextLine/get_next_line.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../CPP_class/class_istringstream.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_ft_read_file_lines_basic, "ft_read_file_lines collects lines from stream")
+{
+    ft_istringstream input("First\nSecond\n");
+    char **lines;
+
+    ft_errno = FT_EINVAL;
+    lines = ft_read_file_lines(input, 4);
+    if (lines == ft_nullptr)
+        return (0);
+    if (lines[0] == ft_nullptr || lines[1] == ft_nullptr)
+    {
+        cma_free_double(lines);
+        return (0);
+    }
+    if (lines[2] != ft_nullptr)
+    {
+        cma_free_double(lines);
+        return (0);
+    }
+    if (ft_strcmp(lines[0], "First\n") != 0)
+    {
+        cma_free_double(lines);
+        return (0);
+    }
+    if (ft_strcmp(lines[1], "Second\n") != 0)
+    {
+        cma_free_double(lines);
+        return (0);
+    }
+    if (ft_errno != ER_SUCCESS)
+    {
+        cma_free_double(lines);
+        return (0);
+    }
+    cma_free_double(lines);
+    return (1);
+}
+
+FT_TEST(test_ft_read_file_lines_empty_stream_returns_null, "ft_read_file_lines returns nullptr for empty input")
+{
+    ft_istringstream input("");
+    char **lines;
+
+    ft_errno = FT_EINVAL;
+    lines = ft_read_file_lines(input, 8);
+    FT_ASSERT_EQ(ft_nullptr, lines);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_read_file_lines_allocation_failure_sets_errno, "ft_read_file_lines reports allocation failures")
+{
+    ft_istringstream input("alpha\n");
+    char **lines;
+
+    cma_set_alloc_limit(1);
+    ft_errno = ER_SUCCESS;
+    lines = ft_read_file_lines(input, 4);
+    cma_set_alloc_limit(0);
+    FT_ASSERT_EQ(ft_nullptr, lines);
+    FT_ASSERT_EQ(FT_EALLOC, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_is_constant_evaluated.cpp
+++ b/Test/Test/test_is_constant_evaluated.cpp
@@ -1,0 +1,90 @@
+#include "../../Libft/libft.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+static constexpr bool g_compile_time_result = ft_is_constant_evaluated();
+static_assert(g_compile_time_result, "ft_is_constant_evaluated should return true during constant evaluation");
+
+static size_t build_word_from_bytes(const unsigned char *bytes)
+{
+    size_t index;
+    size_t value;
+
+    index = 0;
+    value = 0;
+    while (index < sizeof(size_t))
+    {
+        value <<= 8;
+        value |= static_cast<size_t>(bytes[index]);
+        index++;
+    }
+    return (value);
+}
+
+FT_TEST(test_ft_is_constant_evaluated_compile_time_true,
+        "ft_is_constant_evaluated reports true in constexpr contexts")
+{
+    constexpr bool compile_time_value = ft_is_constant_evaluated();
+
+    FT_ASSERT_EQ(true, compile_time_value);
+    return (1);
+}
+
+FT_TEST(test_ft_is_constant_evaluated_runtime_false,
+        "ft_is_constant_evaluated reports false at runtime")
+{
+    bool runtime_value;
+
+    runtime_value = ft_is_constant_evaluated();
+    FT_ASSERT_EQ(false, runtime_value);
+    return (1);
+}
+
+FT_TEST(test_ft_detail_repeat_byte_spreads_pattern,
+        "ft_detail::repeat_byte duplicates byte patterns across a word")
+{
+    size_t expected_value;
+    size_t computed_value;
+    size_t index;
+
+    expected_value = 0;
+    index = 0;
+    while (index < sizeof(size_t))
+    {
+        expected_value <<= 8;
+        expected_value |= 0xAB;
+        index++;
+    }
+    computed_value = ft_detail::repeat_byte(0xAB);
+    FT_ASSERT_EQ(expected_value, computed_value);
+    return (1);
+}
+
+FT_TEST(test_ft_detail_has_zero_detects_zero_byte,
+        "ft_detail::has_zero detects zero bytes within a word")
+{
+    unsigned char bytes[sizeof(size_t)];
+    size_t index;
+    size_t word_value;
+
+    index = 0;
+    while (index < sizeof(size_t))
+    {
+        bytes[index] = 0xFF;
+        index++;
+    }
+    if (sizeof(size_t) > 0)
+        bytes[sizeof(size_t) / 2] = 0x00;
+    word_value = build_word_from_bytes(bytes);
+    FT_ASSERT_EQ(true, ft_detail::has_zero(word_value));
+    return (1);
+}
+
+FT_TEST(test_ft_detail_has_zero_without_zero_byte,
+        "ft_detail::has_zero returns false when no zero byte present")
+{
+    size_t non_zero_word;
+
+    non_zero_word = ft_detail::repeat_byte(0x7F);
+    FT_ASSERT_EQ(false, ft_detail::has_zero(non_zero_word));
+    return (1);
+}

--- a/Test/Test/test_networking_socket_config.cpp
+++ b/Test/Test/test_networking_socket_config.cpp
@@ -1,0 +1,69 @@
+#include "../../Networking/networking.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include "../../Template/move.hpp"
+
+FT_TEST(test_socket_config_copy_detects_string_error,
+    "SocketConfig copy constructor captures ft_string error state")
+{
+    SocketConfig original;
+    const char *error_string;
+
+    original._ip = ft_string(FT_EINVAL);
+    original._multicast_group = "239.1.1.1";
+    ft_errno = ER_SUCCESS;
+    SocketConfig copy(original);
+    FT_ASSERT_EQ(FT_EINVAL, copy.get_error());
+    error_string = copy.get_error_str();
+    FT_ASSERT(error_string != ft_nullptr);
+    FT_ASSERT_EQ(0, ft_strcmp(error_string, ft_strerror(FT_EINVAL)));
+    return (1);
+}
+
+FT_TEST(test_socket_config_move_resets_source_fields,
+    "SocketConfig move constructor transfers values and clears source")
+{
+    SocketConfig original;
+
+    original._type = SocketType::CLIENT;
+    original._ip = "10.1.2.3";
+    original._port = 4242;
+    original._backlog = 4;
+    original._protocol = IPPROTO_UDP;
+    original._address_family = AF_INET6;
+    original._reuse_address = false;
+    original._non_blocking = true;
+    original._recv_timeout = 1000;
+    original._send_timeout = 2000;
+    original._multicast_group = "239.0.0.1";
+    original._multicast_interface = "eth0";
+    ft_errno = ER_SUCCESS;
+    SocketConfig moved(ft_move(original));
+    FT_ASSERT_EQ(SocketType::CLIENT, moved._type);
+    FT_ASSERT_EQ(0, ft_strcmp(moved._ip.c_str(), "10.1.2.3"));
+    FT_ASSERT_EQ(4242, moved._port);
+    FT_ASSERT_EQ(4, moved._backlog);
+    FT_ASSERT_EQ(IPPROTO_UDP, moved._protocol);
+    FT_ASSERT_EQ(AF_INET6, moved._address_family);
+    FT_ASSERT_EQ(false, moved._reuse_address);
+    FT_ASSERT_EQ(true, moved._non_blocking);
+    FT_ASSERT_EQ(1000, moved._recv_timeout);
+    FT_ASSERT_EQ(2000, moved._send_timeout);
+    FT_ASSERT_EQ(0, ft_strcmp(moved._multicast_group.c_str(), "239.0.0.1"));
+    FT_ASSERT_EQ(0, ft_strcmp(moved._multicast_interface.c_str(), "eth0"));
+    FT_ASSERT_EQ(SocketType::CLIENT, original._type);
+    FT_ASSERT_EQ(0, original._port);
+    FT_ASSERT_EQ(0, original._backlog);
+    FT_ASSERT_EQ(0, original._protocol);
+    FT_ASSERT_EQ(0, original._address_family);
+    FT_ASSERT_EQ(false, original._reuse_address);
+    FT_ASSERT_EQ(false, original._non_blocking);
+    FT_ASSERT_EQ(0, original._recv_timeout);
+    FT_ASSERT_EQ(0, original._send_timeout);
+    FT_ASSERT_EQ(0, ft_strcmp(original._multicast_group.c_str(), ""));
+    FT_ASSERT_EQ(0, ft_strcmp(original._multicast_interface.c_str(), ""));
+    FT_ASSERT_EQ(ER_SUCCESS, moved.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_networking_ssl_send.cpp
+++ b/Test/Test/test_networking_ssl_send.cpp
@@ -1,0 +1,277 @@
+#include "../../Networking/networking.hpp"
+#include "../../Networking/ssl_wrapper.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <openssl/ssl.h>
+#include <cerrno>
+#ifndef _WIN32
+#include <dlfcn.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+struct mock_ssl_state
+{
+    int placeholder;
+};
+
+static mock_ssl_state g_mock_ssl_state;
+static bool g_mock_ssl_active = false;
+static int g_mock_ssl_fd_value = -1;
+static int g_mock_ssl_peek_sequence[8];
+static int g_mock_ssl_error_sequence[8];
+static int g_mock_ssl_errno_sequence[8];
+static int g_mock_ssl_peek_length = 0;
+static int g_mock_ssl_peek_index = 0;
+static int g_mock_ssl_error_index = 0;
+
+static void mock_ssl_reset(void)
+{
+    g_mock_ssl_active = true;
+    g_mock_ssl_fd_value = -1;
+    g_mock_ssl_peek_length = 0;
+    g_mock_ssl_peek_index = 0;
+    g_mock_ssl_error_index = 0;
+    return ;
+}
+
+static void mock_ssl_disable(void)
+{
+    g_mock_ssl_active = false;
+    return ;
+}
+
+static SSL *mock_ssl_pointer(void)
+{
+    return (reinterpret_cast<SSL *>(&g_mock_ssl_state));
+}
+
+static void mock_ssl_set_fd(int file_descriptor)
+{
+    g_mock_ssl_fd_value = file_descriptor;
+    return ;
+}
+
+static void mock_ssl_add_peek_result(int peek_result, int error_code, int error_number)
+{
+    if (g_mock_ssl_peek_length >= 8)
+        return ;
+    g_mock_ssl_peek_sequence[g_mock_ssl_peek_length] = peek_result;
+    g_mock_ssl_error_sequence[g_mock_ssl_peek_length] = error_code;
+    g_mock_ssl_errno_sequence[g_mock_ssl_peek_length] = error_number;
+    g_mock_ssl_peek_length++;
+    return ;
+}
+
+#ifndef _WIN32
+extern "C" int SSL_get_fd(const SSL *ssl_connection)
+{
+    if (g_mock_ssl_active && ssl_connection == reinterpret_cast<const SSL *>(&g_mock_ssl_state))
+        return (g_mock_ssl_fd_value);
+    typedef int (*ssl_get_fd_type)(const SSL *);
+    static ssl_get_fd_type real_ssl_get_fd = NULL;
+    if (!real_ssl_get_fd)
+        real_ssl_get_fd = reinterpret_cast<ssl_get_fd_type>(dlsym(RTLD_NEXT, "SSL_get_fd"));
+    if (!real_ssl_get_fd)
+        return (-1);
+    return (real_ssl_get_fd(ssl_connection));
+}
+
+extern "C" int SSL_peek(SSL *ssl_connection, void *buffer, int buffer_length)
+{
+    (void)buffer;
+    (void)buffer_length;
+    if (g_mock_ssl_active && ssl_connection == reinterpret_cast<SSL *>(&g_mock_ssl_state))
+    {
+        if (g_mock_ssl_peek_length <= 0)
+            return (1);
+        int index = g_mock_ssl_peek_index;
+        if (index >= g_mock_ssl_peek_length)
+            index = g_mock_ssl_peek_length - 1;
+        errno = g_mock_ssl_errno_sequence[index];
+        g_mock_ssl_peek_index = g_mock_ssl_peek_index + 1;
+        return (g_mock_ssl_peek_sequence[index]);
+    }
+    typedef int (*ssl_peek_type)(SSL *, void *, int);
+    static ssl_peek_type real_ssl_peek = NULL;
+    if (!real_ssl_peek)
+        real_ssl_peek = reinterpret_cast<ssl_peek_type>(dlsym(RTLD_NEXT, "SSL_peek"));
+    if (!real_ssl_peek)
+        return (-1);
+    return (real_ssl_peek(ssl_connection, buffer, buffer_length));
+}
+
+extern "C" int SSL_get_error(const SSL *ssl_connection, int return_code)
+{
+    (void)return_code;
+    if (g_mock_ssl_active && ssl_connection == reinterpret_cast<const SSL *>(&g_mock_ssl_state))
+    {
+        if (g_mock_ssl_peek_length <= 0)
+            return (SSL_ERROR_NONE);
+        int index = g_mock_ssl_error_index;
+        if (index >= g_mock_ssl_peek_length)
+            index = g_mock_ssl_peek_length - 1;
+        g_mock_ssl_error_index = g_mock_ssl_error_index + 1;
+        return (g_mock_ssl_error_sequence[index]);
+    }
+    typedef int (*ssl_get_error_type)(const SSL *, int);
+    static ssl_get_error_type real_ssl_get_error = NULL;
+    if (!real_ssl_get_error)
+        real_ssl_get_error = reinterpret_cast<ssl_get_error_type>(dlsym(RTLD_NEXT, "SSL_get_error"));
+    if (!real_ssl_get_error)
+        return (SSL_ERROR_SYSCALL);
+    return (real_ssl_get_error(ssl_connection, return_code));
+}
+#endif
+
+FT_TEST(test_networking_check_ssl_after_send_null_pointer_sets_errno,
+    "networking_check_ssl_after_send rejects null SSL pointer")
+{
+    int result;
+
+    mock_ssl_disable();
+    ft_errno = ER_SUCCESS;
+    result = networking_check_ssl_after_send(ft_nullptr);
+    FT_ASSERT_EQ(-1, result);
+    FT_ASSERT_EQ(SOCKET_SEND_FAILED, ft_errno);
+    return (1);
+}
+
+#ifndef _WIN32
+static int create_socket_pair(int sockets[2])
+{
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0)
+        return (-1);
+    return (0);
+}
+
+FT_TEST(test_networking_check_ssl_after_send_reports_success_without_fd,
+    "networking_check_ssl_after_send treats negative fd as success")
+{
+    int result;
+
+    mock_ssl_reset();
+    mock_ssl_set_fd(-1);
+    ft_errno = FT_EINVAL;
+    result = networking_check_ssl_after_send(mock_ssl_pointer());
+    mock_ssl_disable();
+    FT_ASSERT_EQ(0, result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_networking_check_ssl_after_send_detects_remote_close,
+    "networking_check_ssl_after_send reports zero-length SSL_peek")
+{
+    int sockets[2];
+    int result;
+
+    if (create_socket_pair(sockets) != 0)
+        return (0);
+    mock_ssl_reset();
+    mock_ssl_set_fd(sockets[0]);
+    mock_ssl_add_peek_result(0, SSL_ERROR_NONE, 0);
+    ft_errno = ER_SUCCESS;
+    if (::write(sockets[1], "x", 1) != 1)
+    {
+        ::close(sockets[0]);
+        ::close(sockets[1]);
+        mock_ssl_disable();
+        return (0);
+    }
+    result = networking_check_ssl_after_send(mock_ssl_pointer());
+    ::close(sockets[0]);
+    ::close(sockets[1]);
+    mock_ssl_disable();
+    FT_ASSERT_EQ(-1, result);
+    FT_ASSERT_EQ(SOCKET_SEND_FAILED, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_networking_check_ssl_after_send_retries_want_read,
+    "networking_check_ssl_after_send retries SSL_ERROR_WANT_* and succeeds")
+{
+    int sockets[2];
+    int result;
+
+    if (create_socket_pair(sockets) != 0)
+        return (0);
+    mock_ssl_reset();
+    mock_ssl_set_fd(sockets[0]);
+    mock_ssl_add_peek_result(-1, SSL_ERROR_WANT_READ, EAGAIN);
+    mock_ssl_add_peek_result(-1, SSL_ERROR_WANT_WRITE, EAGAIN);
+    mock_ssl_add_peek_result(1, SSL_ERROR_NONE, 0);
+    ft_errno = FT_EINVAL;
+    if (::write(sockets[1], "y", 1) != 1)
+    {
+        ::close(sockets[0]);
+        ::close(sockets[1]);
+        mock_ssl_disable();
+        return (0);
+    }
+    result = networking_check_ssl_after_send(mock_ssl_pointer());
+    ::close(sockets[0]);
+    ::close(sockets[1]);
+    mock_ssl_disable();
+    FT_ASSERT_EQ(0, result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_networking_check_ssl_after_send_propagates_syscall_errno,
+    "networking_check_ssl_after_send surfaces SSL_ERROR_SYSCALL errno")
+{
+    int sockets[2];
+    int result;
+
+    if (create_socket_pair(sockets) != 0)
+        return (0);
+    mock_ssl_reset();
+    mock_ssl_set_fd(sockets[0]);
+    mock_ssl_add_peek_result(-1, SSL_ERROR_SYSCALL, EPIPE);
+    ft_errno = ER_SUCCESS;
+    if (::write(sockets[1], "z", 1) != 1)
+    {
+        ::close(sockets[0]);
+        ::close(sockets[1]);
+        mock_ssl_disable();
+        return (0);
+    }
+    result = networking_check_ssl_after_send(mock_ssl_pointer());
+    ::close(sockets[0]);
+    ::close(sockets[1]);
+    mock_ssl_disable();
+    FT_ASSERT_EQ(-1, result);
+    FT_ASSERT_EQ(EPIPE + ERRNO_OFFSET, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_networking_check_ssl_after_send_zero_return_sets_socket_failed,
+    "networking_check_ssl_after_send maps SSL_ERROR_ZERO_RETURN to SOCKET_SEND_FAILED")
+{
+    int sockets[2];
+    int result;
+
+    if (create_socket_pair(sockets) != 0)
+        return (0);
+    mock_ssl_reset();
+    mock_ssl_set_fd(sockets[0]);
+    mock_ssl_add_peek_result(-1, SSL_ERROR_ZERO_RETURN, 0);
+    ft_errno = ER_SUCCESS;
+    if (::write(sockets[1], "q", 1) != 1)
+    {
+        ::close(sockets[0]);
+        ::close(sockets[1]);
+        mock_ssl_disable();
+        return (0);
+    }
+    result = networking_check_ssl_after_send(mock_ssl_pointer());
+    ::close(sockets[0]);
+    ::close(sockets[1]);
+    mock_ssl_disable();
+    FT_ASSERT_EQ(-1, result);
+    FT_ASSERT_EQ(SOCKET_SEND_FAILED, ft_errno);
+    return (1);
+}
+#endif

--- a/Test/Test/test_printf_fprintf.cpp
+++ b/Test/Test/test_printf_fprintf.cpp
@@ -1,0 +1,240 @@
+#include "../../Printf/printf.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cstdarg>
+#include <cstdio>
+#include <cerrno>
+#include <unistd.h>
+#if defined(_WIN32) || defined(_WIN64)
+# include <io.h>
+#endif
+
+static int create_pipe(int pipe_fds[2])
+{
+    if (pipe(pipe_fds) != 0)
+        return (0);
+    return (1);
+}
+
+static int close_pipe_end(int file_descriptor)
+{
+    if (close(file_descriptor) != 0)
+        return (0);
+    return (1);
+}
+
+static int read_pipe_into_buffer(int read_fd, char *buffer, size_t buffer_size, ssize_t *bytes_read)
+{
+    if (buffer == ft_nullptr || bytes_read == ft_nullptr)
+        return (0);
+    *bytes_read = read(read_fd, buffer, buffer_size);
+    if (*bytes_read < 0)
+        return (0);
+    return (1);
+}
+
+static int call_ft_vfprintf(FILE *stream, const char *format, ...)
+{
+    va_list arguments;
+    int result;
+
+    va_start(arguments, format);
+    result = ft_vfprintf(stream, format, arguments);
+    va_end(arguments);
+    return (result);
+}
+
+FT_TEST(test_ft_vfprintf_writes_output, "ft_vfprintf formats text into the provided stream")
+{
+    int pipe_fds[2];
+    FILE *stream;
+    ssize_t bytes_read;
+    char buffer[64];
+    char word[] = "done";
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    stream = fdopen(pipe_fds[1], "w");
+    if (stream == ft_nullptr)
+    {
+        close_pipe_end(pipe_fds[0]);
+        close_pipe_end(pipe_fds[1]);
+        return (0);
+    }
+    ft_errno = FT_EINVAL;
+    int printed = call_ft_vfprintf(stream, "Value:%d %s!", 42, word);
+    FT_ASSERT_EQ(14, printed);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, fflush(stream));
+    FT_ASSERT_EQ(0, fclose(stream));
+    stream = static_cast<FILE *>(ft_nullptr);
+    pipe_fds[1] = -1;
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "Value:42 done!"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_vfprintf_null_arguments_return_error, "ft_vfprintf rejects null stream or format")
+{
+    int pipe_fds[2];
+    FILE *stream;
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, call_ft_vfprintf(static_cast<FILE *>(ft_nullptr), "noop"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT(create_pipe(pipe_fds));
+    stream = fdopen(pipe_fds[1], "w");
+    if (stream == ft_nullptr)
+    {
+        close_pipe_end(pipe_fds[0]);
+        close_pipe_end(pipe_fds[1]);
+        return (0);
+    }
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, call_ft_vfprintf(stream, static_cast<const char *>(ft_nullptr)));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(0, fclose(stream));
+    stream = static_cast<FILE *>(ft_nullptr);
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_vfprintf_write_failure_sets_errno, "ft_vfprintf propagates stream write failures")
+{
+    FILE *stream;
+
+    stream = std::tmpfile();
+    if (stream == ft_nullptr)
+        return (0);
+#if defined(_WIN32) || defined(_WIN64)
+    int descriptor = _fileno(stream);
+    if (descriptor != -1)
+        _close(descriptor);
+#else
+    int descriptor = fileno(stream);
+    if (descriptor != -1)
+        close(descriptor);
+#endif
+    ft_errno = ER_SUCCESS;
+    int printed = call_ft_vfprintf(stream, "%s", "fail");
+    FT_ASSERT_EQ(-1, printed);
+    FT_ASSERT_EQ(EBADF + ERRNO_OFFSET, ft_errno);
+    fclose(stream);
+    return (1);
+}
+
+FT_TEST(test_ft_fprintf_writes_and_counts, "ft_fprintf forwards to ft_vfprintf and returns byte count")
+{
+    int pipe_fds[2];
+    FILE *stream;
+    ssize_t bytes_read;
+    char buffer[64];
+    char name[] = "world";
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    stream = fdopen(pipe_fds[1], "w");
+    if (stream == ft_nullptr)
+    {
+        close_pipe_end(pipe_fds[0]);
+        close_pipe_end(pipe_fds[1]);
+        return (0);
+    }
+    ft_errno = FT_EINVAL;
+    int printed = ft_fprintf(stream, "Hello %s", name);
+    FT_ASSERT_EQ(11, printed);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, fflush(stream));
+    FT_ASSERT_EQ(0, fclose(stream));
+    stream = static_cast<FILE *>(ft_nullptr);
+    pipe_fds[1] = -1;
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "Hello world"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_fprintf_null_arguments_return_error, "ft_fprintf rejects null stream or format")
+{
+    int pipe_fds[2];
+    FILE *stream;
+    typedef int (*t_ft_fprintf_plain)(FILE *, const char *, ...);
+    t_ft_fprintf_plain plain_ft_fprintf;
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, ft_fprintf(static_cast<FILE *>(ft_nullptr), "noop"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT(create_pipe(pipe_fds));
+    stream = fdopen(pipe_fds[1], "w");
+    if (stream == ft_nullptr)
+    {
+        close_pipe_end(pipe_fds[0]);
+        close_pipe_end(pipe_fds[1]);
+        return (0);
+    }
+    ft_errno = ER_SUCCESS;
+    plain_ft_fprintf = ft_fprintf;
+    FT_ASSERT_EQ(-1, plain_ft_fprintf(stream, static_cast<const char *>(ft_nullptr)));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(0, fclose(stream));
+    stream = static_cast<FILE *>(ft_nullptr);
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_pf_printf_writes_to_stdout, "pf_printf writes formatted output to STDOUT")
+{
+    int pipe_fds[2];
+    int stdout_backup;
+    ssize_t bytes_read;
+    char buffer[64];
+    char status[] = "done";
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    stdout_backup = dup(STDOUT_FILENO);
+    if (stdout_backup < 0)
+    {
+        close_pipe_end(pipe_fds[0]);
+        close_pipe_end(pipe_fds[1]);
+        return (0);
+    }
+    if (dup2(pipe_fds[1], STDOUT_FILENO) < 0)
+    {
+        close_pipe_end(pipe_fds[0]);
+        close_pipe_end(pipe_fds[1]);
+        close(stdout_backup);
+        return (0);
+    }
+    ft_errno = FT_EINVAL;
+    int printed = pf_printf("Sum=%d %s", 7, status);
+    FT_ASSERT_EQ(10, printed);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(0, fflush(stdout));
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    pipe_fds[1] = -1;
+    FT_ASSERT(dup2(stdout_backup, STDOUT_FILENO) >= 0);
+    close(stdout_backup);
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "Sum=7 done"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_pf_printf_null_format_sets_errno, "pf_printf rejects null format strings")
+{
+    typedef int (*t_pf_printf_plain)(const char *, ...);
+    t_pf_printf_plain plain_pf_printf;
+
+    ft_errno = ER_SUCCESS;
+    plain_pf_printf = pf_printf;
+    FT_ASSERT_EQ(-1, plain_pf_printf(static_cast<const char *>(ft_nullptr)));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_printf_print_args.cpp
+++ b/Test/Test/test_printf_print_args.cpp
@@ -1,0 +1,423 @@
+#include "../../Printf/printf_internal.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include <cstddef>
+#include <unistd.h>
+#include <cstdio>
+
+static int create_pipe(int pipe_fds[2])
+{
+    if (pipe(pipe_fds) != 0)
+        return (0);
+    return (1);
+}
+
+static int close_pipe_end(int file_descriptor)
+{
+    if (close(file_descriptor) != 0)
+        return (0);
+    return (1);
+}
+
+static int read_pipe_into_buffer(int read_fd, char *buffer, size_t buffer_size, ssize_t *bytes_read)
+{
+    if (buffer == ft_nullptr || bytes_read == ft_nullptr)
+        return (0);
+    *bytes_read = read(read_fd, buffer, buffer_size);
+    if (*bytes_read < 0)
+        return (0);
+    return (1);
+}
+
+FT_TEST(test_ft_putchar_fd_writes_character, "ft_putchar_fd writes a single byte and updates count")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[2];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = 0;
+    ft_putchar_fd('Z', pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(1), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, 1, &bytes_read));
+    FT_ASSERT_EQ(static_cast<ssize_t>(1), bytes_read);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "Z"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putchar_fd_ignores_null_count, "ft_putchar_fd skips writing when count pointer is null")
+{
+    int pipe_fds[2];
+    ssize_t bytes_read;
+    char buffer[2];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    ft_putchar_fd('A', pipe_fds[1], ft_nullptr);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, 1, &bytes_read));
+    FT_ASSERT_EQ(static_cast<ssize_t>(0), bytes_read);
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putnbr_fd_writes_negative_number, "ft_putnbr_fd prints negative values with sign and updates count")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[32];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = 0;
+    ft_putnbr_fd(-12345, pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(6), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "-12345"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_puthex_fd_respects_uppercase_flag, "ft_puthex_fd selects uppercase digits when requested")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[32];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = 0;
+    ft_puthex_fd(0x1FAB, pipe_fds[1], true, &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(4), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "1FAB"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_puthex_fd_lowercase_output, "ft_puthex_fd emits lowercase digits when flag disabled")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[32];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = 0;
+    ft_puthex_fd(0xBEEF, pipe_fds[1], false, &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(4), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "beef"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putfloat_fd_matches_snprintf, "ft_putfloat_fd mirrors standard formatting at given precision")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[64];
+    char expected[64];
+    int expected_length;
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    expected_length = std::snprintf(expected, sizeof(expected), "%.3f", 3.14159);
+    FT_ASSERT(expected_length > 0);
+    write_count = 0;
+    ft_putfloat_fd(3.14159, pipe_fds[1], &write_count, 3);
+    FT_ASSERT_EQ(static_cast<size_t>(expected_length), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, expected));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putgeneral_fd_uppercase, "ft_putgeneral_fd honors uppercase flag and precision")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[64];
+    char expected[64];
+    int expected_length;
+    double value;
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    value = 12345.6789;
+    expected_length = std::snprintf(expected, sizeof(expected), "%.*G", 4, value);
+    FT_ASSERT(expected_length > 0);
+    write_count = 0;
+    ft_putgeneral_fd(value, true, pipe_fds[1], &write_count, 4);
+    FT_ASSERT_EQ(static_cast<size_t>(expected_length), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, expected));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putstr_fd_writes_string, "ft_putstr_fd streams the provided string and updates count")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[32];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = 0;
+    ft_putstr_fd("hello", pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(5), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "hello"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putstr_fd_null_pointer_writes_literal, "ft_putstr_fd prints (null) when given a null pointer")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[32];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = 0;
+    ft_putstr_fd(ft_nullptr, pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(6), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "(null)"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putunsigned_fd_prints_decimal, "ft_putunsigned_fd renders the full decimal representation")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[64];
+    char expected[64];
+    int expected_length;
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    expected_length = std::snprintf(expected, sizeof(expected), "%ju", static_cast<uintmax_t>(1234567890));
+    FT_ASSERT(expected_length > 0);
+    write_count = 0;
+    ft_putunsigned_fd(1234567890, pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(expected_length), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, expected));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putunsigned_fd_zero_value, "ft_putunsigned_fd prints zero without extra digits")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[8];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = 0;
+    ft_putunsigned_fd(0, pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(1), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "0"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putoctal_fd_outputs_octal_digits, "ft_putoctal_fd emits octal representation")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[32];
+    char expected[32];
+    int expected_length;
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    expected_length = std::snprintf(expected, sizeof(expected), "%llo", static_cast<unsigned long long>(0754321));
+    FT_ASSERT(expected_length > 0);
+    write_count = 0;
+    ft_putoctal_fd(0754321, pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(expected_length), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, expected));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putptr_fd_formats_address, "ft_putptr_fd prefixes addresses with 0x and hexadecimal digits")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[64];
+    char expected[64];
+    int expected_length;
+    int sample_value;
+    uintptr_t address_value;
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    sample_value = 42;
+    address_value = reinterpret_cast<uintptr_t>(&sample_value);
+    expected_length = std::snprintf(expected, sizeof(expected), "0x%llx", static_cast<unsigned long long>(address_value));
+    FT_ASSERT(expected_length > 0);
+    write_count = 0;
+    ft_putptr_fd(&sample_value, pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(expected_length), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, expected));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putptr_fd_null_pointer, "ft_putptr_fd prints zero address for null pointers")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[16];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = 0;
+    ft_putptr_fd(ft_nullptr, pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(3), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, "0x0"));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putscientific_fd_lowercase, "ft_putscientific_fd prints lowercase exponential notation by default")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[64];
+    char expected[64];
+    int expected_length;
+    double value;
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    value = 9876.54321;
+    expected_length = std::snprintf(expected, sizeof(expected), "%.*e", 5, value);
+    FT_ASSERT(expected_length > 0);
+    write_count = 0;
+    ft_putscientific_fd(value, false, pipe_fds[1], &write_count, 5);
+    FT_ASSERT_EQ(static_cast<size_t>(expected_length), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, expected));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putscientific_fd_uppercase, "ft_putscientific_fd honors uppercase flag")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[64];
+    char expected[64];
+    int expected_length;
+    double value;
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    value = 0.0012345;
+    expected_length = std::snprintf(expected, sizeof(expected), "%.*E", 3, value);
+    FT_ASSERT(expected_length > 0);
+    write_count = 0;
+    ft_putscientific_fd(value, true, pipe_fds[1], &write_count, 3);
+    FT_ASSERT_EQ(static_cast<size_t>(expected_length), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT(bytes_read >= 0);
+    buffer[static_cast<size_t>(bytes_read)] = '\0';
+    FT_ASSERT_EQ(0, ft_strcmp(buffer, expected));
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putstr_fd_skips_when_count_in_error, "ft_putstr_fd does not write when count already signals error")
+{
+    int pipe_fds[2];
+    size_t write_count;
+    ssize_t bytes_read;
+    char buffer[8];
+
+    FT_ASSERT(create_pipe(pipe_fds));
+    write_count = SIZE_MAX;
+    ft_putstr_fd("ignored", pipe_fds[1], &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(SIZE_MAX), write_count);
+    FT_ASSERT(close_pipe_end(pipe_fds[1]));
+    FT_ASSERT(read_pipe_into_buffer(pipe_fds[0], buffer, sizeof(buffer) - 1, &bytes_read));
+    FT_ASSERT_EQ(static_cast<ssize_t>(0), bytes_read);
+    FT_ASSERT(close_pipe_end(pipe_fds[0]));
+    return (1);
+}
+
+FT_TEST(test_ft_putnbr_fd_marks_error_on_failed_write, "ft_putnbr_fd marks count as error when su_write fails")
+{
+    size_t write_count;
+
+    write_count = 0;
+    ft_errno = ER_SUCCESS;
+    ft_putnbr_fd(42, -1, &write_count);
+    FT_ASSERT_EQ(static_cast<size_t>(SIZE_MAX), write_count);
+    FT_ASSERT(ft_errno != ER_SUCCESS);
+    ft_errno = ER_SUCCESS;
+    return (1);
+}
+
+FT_TEST(test_ft_strlen_printf_handles_null, "ft_strlen_printf treats null pointers as length six")
+{
+    FT_ASSERT_EQ(static_cast<size_t>(6), ft_strlen_printf(ft_nullptr));
+    FT_ASSERT_EQ(static_cast<size_t>(4), ft_strlen_printf("test"));
+    return (1);
+}

--- a/Test/Test/test_rng_random_seed.cpp
+++ b/Test/Test/test_rng_random_seed.cpp
@@ -1,0 +1,103 @@
+#include "../../RNG/rng.hpp"
+#include "../../RNG/rng_internal.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#if !defined(_WIN32) && !defined(_WIN64)
+#include "../Compatebility/compatebility_system_test_hooks.hpp"
+#endif
+#include <atomic>
+#include <cstdint>
+
+FT_TEST(test_ft_random_seed_hashes_string, "ft_random_seed hashes deterministic strings")
+{
+    const char *seed_string = "entropy";
+    uint32_t expected_hash = 2166136261u;
+    int index = 0;
+
+    while (seed_string[index] != '\0')
+    {
+        expected_hash ^= static_cast<unsigned char>(seed_string[index]);
+        expected_hash *= 16777619u;
+        index = index + 1;
+    }
+    ft_errno = FT_EINVAL;
+    uint32_t computed_hash = ft_random_seed(seed_string);
+    FT_ASSERT_EQ(expected_hash, computed_hash);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_random_seed_empty_string_returns_offset_basis, "ft_random_seed returns offset basis for empty input")
+{
+    const char *seed_string = "";
+    ft_errno = FT_EINVAL;
+    uint32_t computed_hash = ft_random_seed(seed_string);
+    FT_ASSERT_EQ(2166136261u, computed_hash);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_random_seed_null_seed_uses_random_device, "ft_random_seed clears errno when using random_device")
+{
+    ft_errno = FT_EINVAL;
+    (void)ft_random_seed(ft_nullptr);
+    if (ft_errno != ER_SUCCESS)
+        return (0);
+    ft_errno = FT_EINVAL;
+    (void)ft_random_seed(ft_nullptr);
+    if (ft_errno != ER_SUCCESS)
+        return (0);
+    return (1);
+}
+
+FT_TEST(test_ft_seed_random_engine_with_entropy_sets_flag, "ft_seed_random_engine_with_entropy seeds when needed")
+{
+    g_random_engine_seeded.store(false, std::memory_order_release);
+    ft_errno = FT_EINVAL;
+    ft_seed_random_engine_with_entropy();
+    if (g_random_engine_seeded.load(std::memory_order_acquire) != true)
+        return (0);
+    if (ft_errno != ER_SUCCESS)
+        return (0);
+    g_random_engine_seeded.store(false, std::memory_order_release);
+    return (1);
+}
+
+FT_TEST(test_ft_seed_random_engine_with_entropy_skips_when_seeded, "ft_seed_random_engine_with_entropy respects existing seed")
+{
+    g_random_engine_seeded.store(true, std::memory_order_release);
+    ft_errno = FT_EINVAL;
+    ft_seed_random_engine_with_entropy();
+    if (g_random_engine_seeded.load(std::memory_order_acquire) != true)
+        return (0);
+    if (ft_errno != ER_SUCCESS)
+        return (0);
+    g_random_engine_seeded.store(false, std::memory_order_release);
+    return (1);
+}
+
+FT_TEST(test_ft_random_uint32_success_clears_errno, "ft_random_uint32 propagates rng_secure_bytes success")
+{
+    ft_errno = FT_EINVAL;
+    (void)ft_random_uint32();
+    if (ft_errno != ER_SUCCESS)
+        return (0);
+    return (1);
+}
+
+#if !defined(_WIN32) && !defined(_WIN64)
+FT_TEST(test_ft_random_uint32_failure_returns_zero, "ft_random_uint32 returns zero when secure bytes fail")
+{
+    cmp_clear_force_rng_failures();
+    ft_errno = ER_SUCCESS;
+    cmp_force_rng_open_failure(EACCES);
+    uint32_t random_value = ft_random_uint32();
+    cmp_clear_force_rng_failures();
+    if (ft_errno != EACCES + ERRNO_OFFSET)
+        return (0);
+    if (random_value != 0u)
+        return (0);
+    return (1);
+}
+#endif

--- a/Test/Test/test_strlen.cpp
+++ b/Test/Test/test_strlen.cpp
@@ -105,3 +105,26 @@ FT_TEST(test_strlen_size_t_nullptr_sets_errno, "ft_strlen_size_t nullptr sets FT
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
+
+FT_TEST(test_strlen_size_t_handles_unaligned_pointers,
+        "ft_strlen_size_t measures strings that begin at unaligned addresses")
+{
+    char buffer[7];
+    size_t index;
+    char *start_pointer;
+    size_t measured_length;
+
+    index = 0;
+    while (index < 6)
+    {
+        buffer[index] = 'a';
+        index++;
+    }
+    buffer[6] = '\0';
+    start_pointer = buffer + 1;
+    ft_errno = FT_EINVAL;
+    measured_length = ft_strlen_size_t(start_pointer);
+    FT_ASSERT_EQ(static_cast<size_t>(5), measured_length);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_strmapi.cpp
+++ b/Test/Test/test_strmapi.cpp
@@ -76,3 +76,19 @@ FT_TEST(test_strmapi_null_arguments_set_errno, "ft_strmapi null inputs set FT_EI
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }
+
+FT_TEST(test_strmapi_success_after_failure_resets_errno, "ft_strmapi clears errno after a prior failure")
+{
+    char *result;
+
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_strmapi(ft_nullptr, to_upper_map));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    result = ft_strmapi("abc", to_upper_map);
+    if (result == ft_nullptr)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp("ABC", result));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(result);
+    return (1);
+}

--- a/Test/Test/test_strtol.cpp
+++ b/Test/Test/test_strtol.cpp
@@ -152,3 +152,31 @@ FT_TEST(test_strtol_null_input, "ft_strtol null input sets errno and end pointer
     FT_ASSERT_EQ(ft_nullptr, end_pointer);
     return (1);
 }
+
+FT_TEST(test_strtol_base_two_rejects_invalid_digit,
+        "ft_strtol stops parsing when encountering digits beyond the base")
+{
+    char *end_pointer;
+    long parsed_value;
+
+    ft_errno = FT_EINVAL;
+    parsed_value = ft_strtol("10102", &end_pointer, 2);
+    FT_ASSERT_EQ(10L, parsed_value);
+    FT_ASSERT_EQ('2', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strtol_mixed_case_digits_custom_base,
+        "ft_strtol accepts mixed-case digits for bases above ten")
+{
+    char *end_pointer;
+    long parsed_value;
+
+    ft_errno = FT_EINVAL;
+    parsed_value = ft_strtol("aB19", &end_pointer, 20);
+    FT_ASSERT_EQ(84429L, parsed_value);
+    FT_ASSERT_EQ('\0', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_strtoul.cpp
+++ b/Test/Test/test_strtoul.cpp
@@ -127,3 +127,31 @@ FT_TEST(test_strtoul_null_input, "ft_strtoul null input sets errno and end point
     FT_ASSERT_EQ(ft_nullptr, end_pointer);
     return (1);
 }
+
+FT_TEST(test_strtoul_base_eight_rejects_invalid_digit,
+        "ft_strtoul stops consuming digits outside the specified base")
+{
+    char *end_pointer;
+    unsigned long parsed_value;
+
+    ft_errno = FT_EINVAL;
+    parsed_value = ft_strtoul("0778", &end_pointer, 8);
+    FT_ASSERT_EQ(static_cast<unsigned long>(63), parsed_value);
+    FT_ASSERT_EQ('8', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strtoul_mixed_case_digits_custom_base,
+        "ft_strtoul accepts mixed-case alphabetic digits within range")
+{
+    char *end_pointer;
+    unsigned long parsed_value;
+
+    ft_errno = FT_EINVAL;
+    parsed_value = ft_strtoul("gF0", &end_pointer, 17);
+    FT_ASSERT_EQ(static_cast<unsigned long>(4879), parsed_value);
+    FT_ASSERT_EQ('\0', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_tolower.cpp
+++ b/Test/Test/test_tolower.cpp
@@ -72,3 +72,24 @@ FT_TEST(test_tolower_non_ascii_preserved, "ft_to_lower leaves non-ASCII bytes un
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
+
+FT_TEST(test_tolower_stops_at_terminator, "ft_to_lower stops when encountering the null terminator")
+{
+    char string[6];
+
+    string[0] = 'H';
+    string[1] = 'I';
+    string[2] = '\0';
+    string[3] = 'X';
+    string[4] = 'Y';
+    string[5] = '\0';
+    ft_errno = FT_EINVAL;
+    ft_to_lower(string);
+    FT_ASSERT_EQ('h', string[0]);
+    FT_ASSERT_EQ('i', string[1]);
+    FT_ASSERT_EQ('\0', string[2]);
+    FT_ASSERT_EQ('X', string[3]);
+    FT_ASSERT_EQ('Y', string[4]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add an ssl-focused regression suite that exercises networking_check_ssl_after_send for success, null, and peek failure paths using socketpair-backed mocks
- cover SocketConfig copy and move constructors to assert error propagation and field resets

## Testing
- make -C Test -j2 >/tmp/make.log
- ./Test/libft_tests >/tmp/test_output.log

------
https://chatgpt.com/codex/tasks/task_e_68de6b8a030083319fc46b622cb25792