### PR TITLE
Add tests for config flag parser

### DIFF
--- a/Test/Test/test_config_flag_parser.cpp
+++ b/Test/Test/test_config_flag_parser.cpp
@@ -1,0 +1,143 @@
+#include "../../Config/flag_parser.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include "../../CMA/CMA.hpp"
+
+FT_TEST(test_cnfg_parse_flags_collects_unique_alpha, "cnfg_parse_flags collects unique alphabetical short flags")
+{
+    char program_argument[] = "program";
+    char short_flags_one[] = "-av";
+    char short_flags_two[] = "-b";
+    char duplicate_short_flag[] = "-a";
+    char numeric_argument[] = "-1";
+    char long_flag_argument[] = "--long";
+    char mixed_argument[] = "-C9";
+    char *arguments[] = {
+        program_argument,
+        short_flags_one,
+        short_flags_two,
+        duplicate_short_flag,
+        numeric_argument,
+        long_flag_argument,
+        mixed_argument
+    };
+    ft_errno = FT_EALLOC;
+    char *parsed_flags = cnfg_parse_flags(7, arguments);
+    FT_ASSERT(parsed_flags != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(parsed_flags[0] == 'a');
+    FT_ASSERT(parsed_flags[1] == 'v');
+    FT_ASSERT(parsed_flags[2] == 'b');
+    FT_ASSERT(parsed_flags[3] == 'C');
+    FT_ASSERT(parsed_flags[4] == '\0');
+    cma_free(parsed_flags);
+    return (1);
+}
+
+FT_TEST(test_cnfg_parse_flags_null_arguments_set_errno, "cnfg_parse_flags rejects null argument arrays")
+{
+    ft_errno = ER_SUCCESS;
+    char *parsed_flags = cnfg_parse_flags(2, ft_nullptr);
+    FT_ASSERT(parsed_flags == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cnfg_parse_long_flags_deduplicates, "cnfg_parse_long_flags ignores duplicates and short arguments")
+{
+    char program_argument[] = "program";
+    char long_flag_one[] = "--alpha";
+    char long_flag_two[] = "--beta";
+    char duplicate_long_flag[] = "--alpha";
+    char short_argument[] = "-z";
+    char *arguments[] = {
+        program_argument,
+        long_flag_one,
+        long_flag_two,
+        duplicate_long_flag,
+        short_argument
+    };
+    ft_errno = FT_EINVAL;
+    char **parsed_flags = cnfg_parse_long_flags(5, arguments);
+    FT_ASSERT(parsed_flags != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(parsed_flags[0] != ft_nullptr);
+    FT_ASSERT(ft_strcmp(parsed_flags[0], "alpha") == 0);
+    FT_ASSERT(parsed_flags[1] != ft_nullptr);
+    FT_ASSERT(ft_strcmp(parsed_flags[1], "beta") == 0);
+    FT_ASSERT(parsed_flags[2] == ft_nullptr);
+    size_t index = 0;
+    while (parsed_flags[index])
+    {
+        cma_free(parsed_flags[index]);
+        ++index;
+    }
+    cma_free(parsed_flags);
+    return (1);
+}
+
+FT_TEST(test_cnfg_parse_long_flags_null_arguments_set_errno, "cnfg_parse_long_flags rejects null argument arrays")
+{
+    ft_errno = ER_SUCCESS;
+    char **parsed_flags = cnfg_parse_long_flags(2, ft_nullptr);
+    FT_ASSERT(parsed_flags == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_cnfg_flag_parser_parse_populates_counts, "cnfg_flag_parser parses and tracks short and long flags")
+{
+    char program_argument[] = "program";
+    char short_flag_a[] = "-a";
+    char long_flag_long[] = "--long";
+    char long_flag_extra[] = "--extra";
+    char short_flag_b[] = "-b";
+    char *arguments[] = {
+        program_argument,
+        short_flag_a,
+        long_flag_long,
+        long_flag_extra,
+        short_flag_b
+    };
+    cnfg_flag_parser parser;
+    ft_errno = FT_EINVAL;
+    bool parse_result = parser.parse(5, arguments);
+    FT_ASSERT(parse_result);
+    FT_ASSERT_EQ(ER_SUCCESS, parser.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(parser.get_short_flag_count() == 2);
+    FT_ASSERT(parser.get_long_flag_count() == 2);
+    FT_ASSERT(parser.get_total_flag_count() == 4);
+    FT_ASSERT(parser.has_short_flag('a'));
+    FT_ASSERT(parser.has_short_flag('b'));
+    FT_ASSERT(!parser.has_short_flag('c'));
+    FT_ASSERT(parser.has_long_flag("long"));
+    FT_ASSERT(parser.has_long_flag("extra"));
+    FT_ASSERT(!parser.has_long_flag("missing"));
+    return (1);
+}
+
+FT_TEST(test_cnfg_flag_parser_failure_resets_state, "cnfg_flag_parser clears flags when parsing fails")
+{
+    char program_argument[] = "program";
+    char short_flag_a[] = "-a";
+    char *valid_arguments[] = {
+        program_argument,
+        short_flag_a
+    };
+    cnfg_flag_parser parser;
+    bool initial_parse = parser.parse(2, valid_arguments);
+    FT_ASSERT(initial_parse);
+    FT_ASSERT(parser.get_total_flag_count() == 1);
+    bool parse_result = parser.parse(2, ft_nullptr);
+    FT_ASSERT(!parse_result);
+    FT_ASSERT_EQ(FT_EINVAL, parser.get_error());
+    FT_ASSERT(parser.get_short_flag_count() == 0);
+    FT_ASSERT(parser.get_long_flag_count() == 0);
+    FT_ASSERT(parser.get_total_flag_count() == 0);
+    FT_ASSERT(!parser.has_short_flag('a'));
+    FT_ASSERT(!parser.has_long_flag("anything"));
+    return (1);
+}

--- a/Test/Test/test_get_next_line_strjoin.cpp
+++ b/Test/Test/test_get_next_line_strjoin.cpp
@@ -1,0 +1,97 @@
+#include "../../GetNextLine/get_next_line.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+static char *duplicate_literal(const char *literal)
+{
+    char *duplicate;
+    ft_size_t index;
+
+    duplicate = static_cast<char *>(cma_malloc(ft_strlen_size_t(literal) + 1));
+    if (!duplicate)
+        return (ft_nullptr);
+    index = 0;
+    while (literal[index] != '\0')
+    {
+        duplicate[index] = literal[index];
+        index++;
+    }
+    duplicate[index] = '\0';
+    return (duplicate);
+}
+
+FT_TEST(test_ft_strjoin_gnl_concatenates_inputs, "ft_strjoin_gnl concatenates two buffers and frees the first")
+{
+    char *first;
+    char *second;
+    char *joined;
+
+    first = duplicate_literal("Hello");
+    second = duplicate_literal(" world");
+    if (!first || !second)
+    {
+        cma_free(first);
+        cma_free(second);
+        return (0);
+    }
+    ft_errno = FT_EINVAL;
+    joined = ft_strjoin_gnl(first, second);
+    cma_free(second);
+    if (!joined)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(joined, "Hello world"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(joined);
+    return (1);
+}
+
+FT_TEST(test_ft_strjoin_gnl_accepts_null_first, "ft_strjoin_gnl handles null first buffer")
+{
+    char *second;
+    char *joined;
+
+    second = duplicate_literal("line");
+    if (!second)
+        return (0);
+    ft_errno = FT_EINVAL;
+    joined = ft_strjoin_gnl(ft_nullptr, second);
+    cma_free(second);
+    if (!joined)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(joined, "line"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(joined);
+    return (1);
+}
+
+FT_TEST(test_ft_strjoin_gnl_null_inputs_fail, "ft_strjoin_gnl rejects when both buffers are null")
+{
+    char *joined;
+
+    ft_errno = ER_SUCCESS;
+    joined = ft_strjoin_gnl(ft_nullptr, ft_nullptr);
+    FT_ASSERT_EQ(ft_nullptr, joined);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_strjoin_gnl_second_null_copies_first, "ft_strjoin_gnl returns duplicate when second buffer is null")
+{
+    char *first;
+    char *joined;
+
+    first = duplicate_literal("partial");
+    if (!first)
+        return (0);
+    ft_errno = FT_EINVAL;
+    joined = ft_strjoin_gnl(first, ft_nullptr);
+    if (!joined)
+        return (0);
+    FT_ASSERT_EQ(0, ft_strcmp(joined, "partial"));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(joined);
+    return (1);
+}

--- a/Test/Test/test_pthread_mutex.cpp
+++ b/Test/Test/test_pthread_mutex.cpp
@@ -1,0 +1,121 @@
+#include "../../PThread/mutex.hpp"
+#include "../../PThread/pthread.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+static void *capture_thread_identifier(void *argument)
+{
+    pthread_t *destination;
+
+    destination = static_cast<pthread_t *>(argument);
+    *destination = pthread_self();
+    return (ft_nullptr);
+}
+
+FT_TEST(test_pt_mutex_try_lock_initial_success, "pt_mutex::try_lock acquires an unlocked mutex")
+{
+    pt_mutex mutex;
+    pthread_t thread_identifier;
+    int try_result;
+    int unlock_result;
+
+    thread_identifier = pthread_self();
+    try_result = mutex.try_lock(thread_identifier);
+    FT_ASSERT_EQ(FT_SUCCESS, try_result);
+    FT_ASSERT_EQ(ER_SUCCESS, mutex.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(mutex.lockState());
+    unlock_result = mutex.unlock(thread_identifier);
+    FT_ASSERT_EQ(FT_SUCCESS, unlock_result);
+    FT_ASSERT_EQ(ER_SUCCESS, mutex.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(!mutex.lockState());
+    return (1);
+}
+
+FT_TEST(test_pt_mutex_try_lock_detects_foreign_owner, "pt_mutex::try_lock rejects locks held by other threads")
+{
+    pt_mutex mutex;
+    pthread_t owning_thread_identifier;
+    pthread_t requesting_thread_identifier;
+    pthread_t helper_thread_identifier;
+    int lock_result;
+    int try_result;
+    int unlock_result;
+
+    requesting_thread_identifier = pthread_self();
+    owning_thread_identifier = 0;
+    FT_ASSERT_EQ(0, pthread_create(&helper_thread_identifier, ft_nullptr, capture_thread_identifier, &owning_thread_identifier));
+    FT_ASSERT_EQ(0, pthread_join(helper_thread_identifier, ft_nullptr));
+    FT_ASSERT(pthread_equal(requesting_thread_identifier, owning_thread_identifier) == 0);
+    lock_result = mutex.lock(owning_thread_identifier);
+    FT_ASSERT_EQ(FT_SUCCESS, lock_result);
+    FT_ASSERT(mutex.lockState());
+    try_result = mutex.try_lock(requesting_thread_identifier);
+    FT_ASSERT_EQ(PT_ERR_ALREADY_LOCKED, try_result);
+    FT_ASSERT_EQ(PT_ERR_ALREADY_LOCKED, mutex.get_error());
+    FT_ASSERT_EQ(PT_ERR_ALREADY_LOCKED, ft_errno);
+    FT_ASSERT(mutex.lockState());
+    unlock_result = mutex.unlock(owning_thread_identifier);
+    FT_ASSERT_EQ(FT_SUCCESS, unlock_result);
+    FT_ASSERT_EQ(ER_SUCCESS, mutex.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(!mutex.lockState());
+    return (1);
+}
+
+FT_TEST(test_pt_mutex_try_lock_rejects_reentrant_attempt, "pt_mutex::try_lock blocks reentrant acquisition by owner")
+{
+    pt_mutex mutex;
+    pthread_t thread_identifier;
+    int lock_result;
+    int try_result;
+    int unlock_result;
+
+    thread_identifier = pthread_self();
+    lock_result = mutex.lock(thread_identifier);
+    FT_ASSERT_EQ(FT_SUCCESS, lock_result);
+    FT_ASSERT(mutex.lockState());
+    try_result = mutex.try_lock(thread_identifier);
+    FT_ASSERT_EQ(-1, try_result);
+    FT_ASSERT_EQ(PT_ERR_ALREADY_LOCKED, mutex.get_error());
+    FT_ASSERT_EQ(PT_ERR_ALREADY_LOCKED, ft_errno);
+    FT_ASSERT(mutex.lockState());
+    unlock_result = mutex.unlock(thread_identifier);
+    FT_ASSERT_EQ(FT_SUCCESS, unlock_result);
+    FT_ASSERT_EQ(ER_SUCCESS, mutex.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(!mutex.lockState());
+    return (1);
+}
+
+FT_TEST(test_pt_mutex_unlock_requires_ownership, "pt_mutex::unlock enforces ownership before releasing")
+{
+    pt_mutex mutex;
+    pthread_t owning_thread_identifier;
+    pthread_t foreign_thread_identifier;
+    pthread_t helper_thread_identifier;
+    int lock_result;
+    int unlock_result;
+
+    owning_thread_identifier = pthread_self();
+    lock_result = mutex.lock(owning_thread_identifier);
+    FT_ASSERT_EQ(FT_SUCCESS, lock_result);
+    FT_ASSERT(mutex.lockState());
+    foreign_thread_identifier = 0;
+    FT_ASSERT_EQ(0, pthread_create(&helper_thread_identifier, ft_nullptr, capture_thread_identifier, &foreign_thread_identifier));
+    FT_ASSERT_EQ(0, pthread_join(helper_thread_identifier, ft_nullptr));
+    FT_ASSERT(pthread_equal(owning_thread_identifier, foreign_thread_identifier) == 0);
+    unlock_result = mutex.unlock(foreign_thread_identifier);
+    FT_ASSERT_EQ(-1, unlock_result);
+    FT_ASSERT_EQ(PT_ERR_MUTEX_OWNER, mutex.get_error());
+    FT_ASSERT_EQ(PT_ERR_MUTEX_OWNER, ft_errno);
+    FT_ASSERT(mutex.lockState());
+    unlock_result = mutex.unlock(owning_thread_identifier);
+    FT_ASSERT_EQ(FT_SUCCESS, unlock_result);
+    FT_ASSERT_EQ(ER_SUCCESS, mutex.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT(!mutex.lockState());
+    return (1);
+}

--- a/Test/Test/test_rng_dice_roll.cpp
+++ b/Test/Test/test_rng_dice_roll.cpp
@@ -1,0 +1,72 @@
+#include "../../RNG/rng.hpp"
+#include "../../RNG/rng_internal.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+#include "../../Libft/libft.hpp"
+#include <limits>
+#include <random>
+
+FT_TEST(test_ft_dice_roll_deterministic_sum, "ft_dice_roll produces reproducible sums with seeded engine")
+{
+    std::uniform_int_distribution<int> distribution(0, std::numeric_limits<int>::max());
+    int expected_result;
+    int actual_result;
+    int index;
+
+    ft_seed_random_engine(1337u);
+    ft_errno = FT_EINVAL;
+    actual_result = ft_dice_roll(4, 6);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+
+    ft_seed_random_engine(1337u);
+    expected_result = 0;
+    index = 0;
+    while (index < 4)
+    {
+        int roll_value;
+
+        roll_value = distribution(g_random_engine);
+        expected_result += (roll_value % 6) + 1;
+        index++;
+    }
+    FT_ASSERT_EQ(expected_result, actual_result);
+    return (1);
+}
+
+FT_TEST(test_ft_dice_roll_zero_arguments_success, "ft_dice_roll returns zero when both parameters are zero")
+{
+    int result;
+
+    ft_errno = FT_EINVAL;
+    result = ft_dice_roll(0, 0);
+    FT_ASSERT_EQ(0, result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_dice_roll_invalid_arguments, "ft_dice_roll rejects counts or faces below one")
+{
+    int result;
+
+    ft_errno = ER_SUCCESS;
+    result = ft_dice_roll(0, 6);
+    FT_ASSERT_EQ(-1, result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+
+    ft_errno = ER_SUCCESS;
+    result = ft_dice_roll(2, 0);
+    FT_ASSERT_EQ(-1, result);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_dice_roll_single_face_returns_number, "ft_dice_roll returns the number of dice when faces is one")
+{
+    int result;
+
+    ft_errno = FT_EINVAL;
+    result = ft_dice_roll(5, 1);
+    FT_ASSERT_EQ(5, result);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_stringbuf.cpp
+++ b/Test/Test/test_stringbuf.cpp
@@ -1,0 +1,85 @@
+#include "../../CPP_class/class_stringbuf.hpp"
+#include "../../CPP_class/class_string_class.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_ft_stringbuf_read_basic, "ft_stringbuf::read copies data sequentially")
+{
+    ft_string source("hello");
+    ft_stringbuf buffer(source);
+    char storage[8];
+    std::size_t bytes_read;
+
+    ft_errno = FT_EINVAL;
+    bytes_read = buffer.read(storage, 5);
+    storage[bytes_read] = '\0';
+    FT_ASSERT_EQ(static_cast<std::size_t>(5), bytes_read);
+    FT_ASSERT_EQ(0, ft_strcmp(storage, "hello"));
+    FT_ASSERT_EQ(ER_SUCCESS, buffer.get_error());
+    FT_ASSERT_EQ(false, buffer.is_bad());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_stringbuf_read_null_buffer_sets_error, "ft_stringbuf::read reports errors for null buffers")
+{
+    ft_string source("data");
+    ft_stringbuf buffer(source);
+    std::size_t bytes_read;
+
+    ft_errno = ER_SUCCESS;
+    bytes_read = buffer.read(ft_nullptr, 3);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), bytes_read);
+    FT_ASSERT_EQ(true, buffer.is_bad());
+    FT_ASSERT_EQ(FT_EINVAL, buffer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_stringbuf_str_returns_remaining, "ft_stringbuf::str exposes unread portion and clears errors")
+{
+    ft_string source("abcdef");
+    ft_stringbuf buffer(source);
+    char storage[4];
+    std::size_t bytes_read;
+    ft_string remaining;
+
+    ft_errno = FT_EINVAL;
+    bytes_read = buffer.read(storage, 3);
+    storage[bytes_read] = '\0';
+    FT_ASSERT_EQ(static_cast<std::size_t>(3), bytes_read);
+    FT_ASSERT_EQ(0, ft_strcmp(storage, "abc"));
+
+    ft_errno = FT_EINVAL;
+    remaining = buffer.str();
+    FT_ASSERT_EQ(0, ft_strcmp(remaining.c_str(), "def"));
+    FT_ASSERT_EQ(ER_SUCCESS, buffer.get_error());
+    FT_ASSERT_EQ(false, buffer.is_bad());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_stringbuf_read_past_end_returns_zero, "ft_stringbuf::read returns zero after reaching the end")
+{
+    ft_string source("xy");
+    ft_stringbuf buffer(source);
+    char storage[4];
+    std::size_t bytes_read;
+
+    ft_errno = FT_EINVAL;
+    bytes_read = buffer.read(storage, 2);
+    storage[bytes_read] = '\0';
+    FT_ASSERT_EQ(static_cast<std::size_t>(2), bytes_read);
+    FT_ASSERT_EQ(0, ft_strcmp(storage, "xy"));
+    FT_ASSERT_EQ(ER_SUCCESS, buffer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+
+    ft_errno = FT_EINVAL;
+    bytes_read = buffer.read(storage, 2);
+    FT_ASSERT_EQ(static_cast<std::size_t>(0), bytes_read);
+    FT_ASSERT_EQ(ER_SUCCESS, buffer.get_error());
+    FT_ASSERT_EQ(false, buffer.is_bad());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_time_monotonic_point.cpp
+++ b/Test/Test/test_time_monotonic_point.cpp
@@ -1,0 +1,84 @@
+#include "../../Time/time.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_time_monotonic_point_add_ms_positive_offset,
+        "time_monotonic_point_add_ms adds positive offsets to the baseline")
+{
+    t_monotonic_time_point baseline;
+    t_monotonic_time_point adjusted;
+
+    baseline.milliseconds = 1250;
+    adjusted = time_monotonic_point_add_ms(baseline, 750);
+    FT_ASSERT_EQ(2000LL, adjusted.milliseconds);
+    return (1);
+}
+
+FT_TEST(test_time_monotonic_point_add_ms_negative_offset,
+        "time_monotonic_point_add_ms supports negative offsets")
+{
+    t_monotonic_time_point baseline;
+    t_monotonic_time_point adjusted;
+
+    baseline.milliseconds = 500;
+    adjusted = time_monotonic_point_add_ms(baseline, -250);
+    FT_ASSERT_EQ(250LL, adjusted.milliseconds);
+    return (1);
+}
+
+FT_TEST(test_time_monotonic_point_diff_ms_forward_interval,
+        "time_monotonic_point_diff_ms returns positive deltas when end is after start")
+{
+    t_monotonic_time_point start_point;
+    t_monotonic_time_point end_point;
+    long long difference;
+
+    start_point.milliseconds = 100;
+    end_point.milliseconds = 425;
+    difference = time_monotonic_point_diff_ms(start_point, end_point);
+    FT_ASSERT_EQ(325LL, difference);
+    return (1);
+}
+
+FT_TEST(test_time_monotonic_point_diff_ms_reverse_interval,
+        "time_monotonic_point_diff_ms reports negative deltas when end precedes start")
+{
+    t_monotonic_time_point start_point;
+    t_monotonic_time_point end_point;
+    long long difference;
+
+    start_point.milliseconds = 900;
+    end_point.milliseconds = 450;
+    difference = time_monotonic_point_diff_ms(start_point, end_point);
+    FT_ASSERT_EQ(-450LL, difference);
+    return (1);
+}
+
+FT_TEST(test_time_monotonic_point_compare_orders_points,
+        "time_monotonic_point_compare orders points by millisecond value")
+{
+    t_monotonic_time_point first_point;
+    t_monotonic_time_point second_point;
+
+    first_point.milliseconds = 5000;
+    second_point.milliseconds = 7500;
+    FT_ASSERT_EQ(-1, time_monotonic_point_compare(first_point, second_point));
+    FT_ASSERT_EQ(1, time_monotonic_point_compare(second_point, first_point));
+    second_point.milliseconds = 5000;
+    FT_ASSERT_EQ(0, time_monotonic_point_compare(first_point, second_point));
+    return (1);
+}
+
+FT_TEST(test_time_monotonic_point_now_is_monotonic,
+        "time_monotonic_point_now produces non-decreasing millisecond readings")
+{
+    t_monotonic_time_point first_point;
+    t_monotonic_time_point second_point;
+    long long elapsed;
+
+    first_point = time_monotonic_point_now();
+    time_sleep_ms(2);
+    second_point = time_monotonic_point_now();
+    elapsed = time_monotonic_point_diff_ms(first_point, second_point);
+    FT_ASSERT(elapsed >= 0);
+    return (1);
+}

--- a/Test/Test/test_time_timer.cpp
+++ b/Test/Test/test_time_timer.cpp
@@ -1,0 +1,154 @@
+#include "../../Time/timer.hpp"
+#include "../../Time/time.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_time_timer_start_rejects_negative_duration, "time_timer::start rejects negative durations")
+{
+    time_timer timer;
+    long update_result;
+
+    ft_errno = ER_SUCCESS;
+    timer.start(-5);
+    FT_ASSERT_EQ(FT_EINVAL, timer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+
+    ft_errno = ER_SUCCESS;
+    update_result = timer.update();
+    FT_ASSERT_EQ(static_cast<long>(-1), update_result);
+    FT_ASSERT_EQ(FT_EINVAL, timer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_timer_update_counts_down_to_completion, "time_timer::update tracks elapsed time and signals completion")
+{
+    time_timer timer;
+    long remaining_before_wait;
+    long update_after_completion;
+
+    ft_errno = FT_EINVAL;
+    timer.start(25);
+    remaining_before_wait = timer.update();
+    FT_ASSERT(remaining_before_wait >= 0);
+    FT_ASSERT(remaining_before_wait <= 25);
+    FT_ASSERT_EQ(ER_SUCCESS, timer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+
+    time_sleep_ms(40);
+    FT_ASSERT_EQ(static_cast<long>(0), timer.update());
+    FT_ASSERT_EQ(ER_SUCCESS, timer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+
+    ft_errno = ER_SUCCESS;
+    update_after_completion = timer.update();
+    FT_ASSERT_EQ(static_cast<long>(-1), update_after_completion);
+    FT_ASSERT_EQ(FT_EINVAL, timer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_timer_add_time_extends_active_timer, "time_timer::add_time extends an active countdown")
+{
+    time_timer timer;
+    long remaining_after_add;
+    long remaining_midway;
+
+    ft_errno = ER_SUCCESS;
+    timer.start(30);
+    remaining_after_add = timer.add_time(60);
+    FT_ASSERT(remaining_after_add > 0);
+    FT_ASSERT(remaining_after_add <= 90);
+    FT_ASSERT_EQ(ER_SUCCESS, timer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+
+    time_sleep_ms(40);
+    remaining_midway = timer.update();
+    FT_ASSERT(remaining_midway > 0);
+    FT_ASSERT_EQ(ER_SUCCESS, timer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+
+    time_sleep_ms(70);
+    FT_ASSERT_EQ(static_cast<long>(0), timer.update());
+    FT_ASSERT_EQ(ER_SUCCESS, timer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_timer_add_time_requires_running_timer, "time_timer::add_time rejects stopped timers")
+{
+    time_timer timer;
+    long add_result;
+
+    ft_errno = ER_SUCCESS;
+    add_result = timer.add_time(5);
+    FT_ASSERT_EQ(static_cast<long>(-1), add_result);
+    FT_ASSERT_EQ(FT_EINVAL, timer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_timer_remove_time_can_force_expiration, "time_timer::remove_time can expire the timer immediately")
+{
+    time_timer timer;
+    long update_result;
+
+    ft_errno = ER_SUCCESS;
+    timer.start(50);
+    FT_ASSERT_EQ(static_cast<long>(0), timer.remove_time(100));
+    FT_ASSERT_EQ(ER_SUCCESS, timer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+
+    ft_errno = ER_SUCCESS;
+    update_result = timer.update();
+    FT_ASSERT_EQ(static_cast<long>(-1), update_result);
+    FT_ASSERT_EQ(FT_EINVAL, timer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_timer_remove_time_requires_running_timer, "time_timer::remove_time rejects stopped timers and negative adjustments")
+{
+    time_timer timer;
+    long remove_result;
+
+    ft_errno = ER_SUCCESS;
+    remove_result = timer.remove_time(10);
+    FT_ASSERT_EQ(static_cast<long>(-1), remove_result);
+    FT_ASSERT_EQ(FT_EINVAL, timer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+
+    timer.start(20);
+    ft_errno = ER_SUCCESS;
+    remove_result = timer.remove_time(-5);
+    FT_ASSERT_EQ(static_cast<long>(-1), remove_result);
+    FT_ASSERT_EQ(FT_EINVAL, timer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_timer_sleep_remaining_waits_until_finished, "time_timer::sleep_remaining blocks until the timer completes")
+{
+    time_timer timer;
+
+    timer.start(25);
+    ft_errno = FT_EINVAL;
+    timer.sleep_remaining();
+    FT_ASSERT_EQ(ER_SUCCESS, timer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    FT_ASSERT_EQ(static_cast<long>(0), timer.update());
+    FT_ASSERT_EQ(ER_SUCCESS, timer.get_error());
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_time_timer_sleep_remaining_preserves_error_on_inactive_timer, "time_timer::sleep_remaining leaves errors when timer is inactive")
+{
+    time_timer timer;
+
+    ft_errno = ER_SUCCESS;
+    timer.sleep_remaining();
+    FT_ASSERT_EQ(FT_EINVAL, timer.get_error());
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add regression coverage for cnfg_parse_flags including unique short flag detection and null argument validation
- add cnfg_parse_long_flags tests to ensure duplicate suppression, cleanup, and error reporting
- exercise cnfg_flag_parser flag counting, lookup helpers, and failure state reset

## Testing
- make -C Test objs/Test/test_config_flag_parser.o

------
https://chatgpt.com/codex/tasks/task_e_68deb65bddc883318a003b3d9b1565dc