### PR TITLE
Add tests for ft_getenv, ft_unsetenv, and ft_time_ms edge cases

### DIFF
--- a/Test/Test/test_environment.cpp
+++ b/Test/Test/test_environment.cpp
@@ -22,6 +22,14 @@ FT_TEST(test_ft_getenv_empty_name_sets_errno, "ft_getenv rejects empty names")
     return (1);
 }
 
+FT_TEST(test_ft_getenv_null_name_sets_errno, "ft_getenv rejects null names")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(ft_nullptr, ft_getenv(ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_ft_getenv_missing_clears_errno, "ft_getenv clears errno when variable absent")
 {
     const char *variable_name;
@@ -136,6 +144,14 @@ FT_TEST(test_ft_unsetenv_rejects_equals_sign, "ft_unsetenv rejects names contain
 {
     ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(-1, ft_unsetenv("INVALID=NAME"));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_ft_unsetenv_null_name_sets_errno, "ft_unsetenv rejects null names")
+{
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(-1, ft_unsetenv(ft_nullptr));
     FT_ASSERT_EQ(FT_EINVAL, ft_errno);
     return (1);
 }

--- a/Test/Test/test_strtol.cpp
+++ b/Test/Test/test_strtol.cpp
@@ -180,3 +180,31 @@ FT_TEST(test_strtol_mixed_case_digits_custom_base,
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
+
+FT_TEST(test_strtol_rejects_at_symbol_in_high_base,
+        "ft_strtol rejects characters preceding '0' even in high bases")
+{
+    char *end_pointer;
+    long parsed_value;
+
+    ft_errno = FT_EINVAL;
+    parsed_value = ft_strtol("@123", &end_pointer, 36);
+    FT_ASSERT_EQ(0L, parsed_value);
+    FT_ASSERT_EQ('@', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strtol_stops_before_brace_character,
+        "ft_strtol stops parsing when encountering characters beyond 'z'")
+{
+    char *end_pointer;
+    long parsed_value;
+
+    ft_errno = FT_EINVAL;
+    parsed_value = ft_strtol("Zz{", &end_pointer, 36);
+    FT_ASSERT_EQ(1295L, parsed_value);
+    FT_ASSERT_EQ('{', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_strtoul.cpp
+++ b/Test/Test/test_strtoul.cpp
@@ -155,3 +155,31 @@ FT_TEST(test_strtoul_mixed_case_digits_custom_base,
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
+
+FT_TEST(test_strtoul_rejects_at_symbol_in_high_base,
+        "ft_strtoul rejects characters that precede '0' in the digit table")
+{
+    char *end_pointer;
+    unsigned long parsed_value;
+
+    ft_errno = FT_EINVAL;
+    parsed_value = ft_strtoul("@777", &end_pointer, 36);
+    FT_ASSERT_EQ(0UL, parsed_value);
+    FT_ASSERT_EQ('@', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_strtoul_stops_before_brace_character,
+        "ft_strtoul stops parsing when encountering characters beyond 'z'")
+{
+    char *end_pointer;
+    unsigned long parsed_value;
+
+    ft_errno = FT_EINVAL;
+    parsed_value = ft_strtoul("Zz{", &end_pointer, 36);
+    FT_ASSERT_EQ(static_cast<unsigned long>(1295), parsed_value);
+    FT_ASSERT_EQ('{', *end_pointer);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}

--- a/Test/Test/test_time.cpp
+++ b/Test/Test/test_time.cpp
@@ -362,6 +362,21 @@ FT_TEST(test_time_ms_failure, "ft_time_ms reports gettimeofday failure")
     return (1);
 }
 
+FT_TEST(test_time_ms_failure_without_errno, "ft_time_ms falls back to FT_ETERM when errno missing")
+{
+    int64_t result;
+
+    g_time_force_failure = true;
+    g_time_failure_errno = 0;
+    errno = 0;
+    ft_errno = ER_SUCCESS;
+    result = ft_time_ms();
+    g_time_force_failure = false;
+    FT_ASSERT_EQ(-1, result);
+    FT_ASSERT_EQ(FT_ETERM, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_time_parse_iso8601_timezone_independent, "time_parse_iso8601 handles UTC Z regardless of TZ")
 {
     char *original_timezone;


### PR DESCRIPTION
## Summary
- add an ft_getenv test covering null names to ensure FT_EINVAL is reported
- add an ft_unsetenv test validating null-name handling leaves ft_errno at FT_EINVAL
- add an ft_time_ms regression test for failures without errno to confirm FT_ETERM fallback

## Testing
- not run (building the full test suite via `make -C Test` is too heavy for this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ded19335308331978fa9ef8d718788