### PR TITLE
Use CMA free for JSON cleanup

### DIFF
--- a/JSon/json_create_item.cpp
+++ b/JSon/json_create_item.cpp
@@ -34,7 +34,7 @@ json_item* json_create_item(const char *key, const char *value)
     item->value = cma_strdup(value);
     if (!item->value)
     {
-        delete[] item->key;
+        cma_free(item->key);
         delete item;
         ft_errno = JSON_MALLOC_FAIL;
         return (ft_nullptr);
@@ -70,7 +70,7 @@ json_item* json_create_item(const char *key, const bool value)
         item->value = cma_strdup("false");
     if (!item->value)
     {
-        delete[] item->key;
+        cma_free(item->key);
         delete item;
         ft_errno = JSON_MALLOC_FAIL;
         return (ft_nullptr);
@@ -103,7 +103,7 @@ json_item* json_create_item(const char *key, const int value)
     item->value = cma_itoa(value);
     if (!item->value)
     {
-        delete[] item->key;
+        cma_free(item->key);
         delete item;
         ft_errno = JSON_MALLOC_FAIL;
         return (ft_nullptr);

--- a/JSon/json_parsing.cpp
+++ b/JSon/json_parsing.cpp
@@ -158,9 +158,9 @@ void json_free_items(json_item *item)
     {
         json_item *next_item = item->next;
         if (item->key)
-            delete[] item->key;
+            cma_free(item->key);
         if (item->value)
-            delete[] item->value;
+            cma_free(item->value);
         if (item->big_number)
             delete item->big_number;
         delete item;
@@ -175,7 +175,7 @@ void json_free_groups(json_group *group)
     {
         json_group *next_group = group->next;
         if (group->name)
-            delete[] group->name;
+            cma_free(group->name);
         json_free_items(group->items);
         delete group;
         group = next_group;

--- a/JSon/json_utils.cpp
+++ b/JSon/json_utils.cpp
@@ -66,9 +66,9 @@ void json_remove_item(json_group *group, const char *key)
             else
                 group->items = current->next;
             if (current->key)
-                delete[] current->key;
+                cma_free(current->key);
             if (current->value)
-                delete[] current->value;
+                cma_free(current->value);
             if (current->big_number)
                 delete current->big_number;
             delete current;
@@ -102,7 +102,7 @@ void json_update_item(json_group *group, const char *key, const char *value)
     }
     item->is_big_number = false;
     if (item->value)
-        delete[] item->value;
+        cma_free(item->value);
     item->value = cma_strdup(value);
     if (!item->value)
     {
@@ -134,7 +134,7 @@ void json_update_item(json_group *group, const char *key, const int value)
     }
     item->is_big_number = false;
     if (item->value)
-        delete[] item->value;
+        cma_free(item->value);
     item->value = cma_itoa(value);
     if (!item->value)
     {
@@ -166,7 +166,7 @@ void json_update_item(json_group *group, const char *key, const bool value)
     }
     item->is_big_number = false;
     if (item->value)
-        delete[] item->value;
+        cma_free(item->value);
     if (value == true)
         item->value = cma_strdup("true");
     else
@@ -201,7 +201,7 @@ void json_update_item(json_group *group, const char *key, const ft_big_number &v
     }
     item->is_big_number = false;
     if (item->value)
-        delete[] item->value;
+        cma_free(item->value);
     item->value = cma_strdup(value.c_str());
     if (!item->value)
     {
@@ -231,7 +231,7 @@ void json_remove_group(json_group **head, const char *name)
             else
                 *head = current->next;
             if (current->name)
-                delete[] current->name;
+                cma_free(current->name);
             json_free_items(current->items);
             delete current;
             ft_errno = ER_SUCCESS;


### PR DESCRIPTION
## Summary
- replace JSON key, value, and group name cleanup paths to use `cma_free`
- release `item->key` with `cma_free` in `json_create_item` error branches to keep allocators paired

## Testing
- ./json_tests

------
https://chatgpt.com/codex/tasks/task_e_68df72a88b9c8331beee7a04a85f00e3