### PR TITLE
Handle case-insensitive headers in TLS client

### DIFF
--- a/Test/Test/test_api_tls_client.cpp
+++ b/Test/Test/test_api_tls_client.cpp
@@ -151,7 +151,7 @@ FT_TEST(test_api_tls_client_chunked_response, "api_tls_client handles chunked bo
 
     prepare_mock_client(client);
     mock_tls_reset_reads();
-    mock_tls_add_read("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n");
+    mock_tls_add_read("HTTP/1.1 200 OK\r\nTrAnSfEr-EnCoDiNg: gzip, Chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n");
     g_mock_tls_io_enabled = true;
     int status_value;
     char *body;
@@ -170,6 +170,36 @@ FT_TEST(test_api_tls_client_chunked_response, "api_tls_client handles chunked bo
     if (client.get_error() != ER_SUCCESS)
         result = 0;
     cma_free(body);
+    client._ssl = ft_nullptr;
+    return (result);
+}
+
+FT_TEST(test_api_tls_client_header_case_insensitive, "api_tls_client handles case insensitive headers")
+{
+    api_tls_client client(ft_nullptr, 0, 0);
+
+    prepare_mock_client(client);
+    mock_tls_reset_reads();
+    mock_tls_add_read("HTTP/1.1 200 OK\r\ncontent-length: 5\r\n\r\nHello");
+    g_mock_tls_io_enabled = true;
+    int status_value;
+    char *body;
+    int result;
+
+    status_value = -1;
+    body = client.request("GET", "/case", ft_nullptr, ft_nullptr, &status_value);
+    g_mock_tls_io_enabled = false;
+    result = 1;
+    if (!body)
+        result = 0;
+    if (body && ft_strcmp(body, "Hello") != 0)
+        result = 0;
+    if (status_value != 200)
+        result = 0;
+    if (client.get_error() != ER_SUCCESS)
+        result = 0;
+    if (body)
+        cma_free(body);
     client._ssl = ft_nullptr;
     return (result);
 }


### PR DESCRIPTION
## Summary
- update the TLS client to scan response headers line by line and match Content-Length and Transfer-Encoding without case sensitivity
- extend the TLS client tests to cover lowercase and mixed-case headers when reading fixed-length and chunked responses

## Testing
- `make -C Test` *(interrupted after lengthy build setup)*

------
https://chatgpt.com/codex/tasks/task_e_68deed60609c8331b6bb9b1ba37d46ed