### PR TITLE
Fix TLS send helpers and align mocks for tests

### DIFF
--- a/Test/Test/test_time.cpp
+++ b/Test/Test/test_time.cpp
@@ -31,6 +31,13 @@ static int g_time_local_failure_errno = EINVAL;
 static bool g_time_now_force_failure = false;
 static int g_time_now_failure_errno = EINVAL;
 
+void time_now_set_force_failure(bool enable_failure, int error_code)
+{
+    g_time_now_force_failure = enable_failure;
+    g_time_now_failure_errno = error_code;
+    return ;
+}
+
 extern t_time_format_gmtime_override_function g_time_format_gmtime_override;
 extern t_time_format_strftime_override_function g_time_format_strftime_override;
 extern t_time_format_mutex_override_function g_time_format_lock_override;

--- a/Test/Test/test_time_now.cpp
+++ b/Test/Test/test_time_now.cpp
@@ -5,47 +5,8 @@
 #include <cerrno>
 #include <chrono>
 #include <ctime>
-#include <dlfcn.h>
 
-static bool g_time_now_force_failure = false;
-static int g_time_now_forced_errno = EINVAL;
-
-static void time_now_set_force_failure(bool enable_failure, int error_code)
-{
-    g_time_now_force_failure = enable_failure;
-    g_time_now_forced_errno = error_code;
-    return ;
-}
-
-extern "C" std::time_t time(std::time_t *time_value)
-{
-    typedef std::time_t (*time_function_pointer)(std::time_t *);
-    static time_function_pointer real_time_function = ft_nullptr;
-
-    if (g_time_now_force_failure)
-    {
-        errno = g_time_now_forced_errno;
-        if (time_value != ft_nullptr)
-            *time_value = static_cast<std::time_t>(-1);
-        return (static_cast<std::time_t>(-1));
-    }
-    if (real_time_function == ft_nullptr)
-    {
-        void *symbol_pointer;
-
-        symbol_pointer = dlsym(RTLD_NEXT, "time");
-        if (symbol_pointer != ft_nullptr)
-            real_time_function = reinterpret_cast<time_function_pointer>(symbol_pointer);
-    }
-    if (real_time_function != ft_nullptr)
-        return (real_time_function(time_value));
-    errno = 0;
-    std::chrono::system_clock::time_point current_time_point = std::chrono::system_clock::now();
-    std::time_t fallback_time = std::chrono::system_clock::to_time_t(current_time_point);
-    if (time_value != ft_nullptr)
-        *time_value = fallback_time;
-    return (fallback_time);
-}
+void time_now_set_force_failure(bool enable_failure, int error_code);
 
 FT_TEST(test_time_now_success_resets_errno, "time_now success resets ft_errno")
 {


### PR DESCRIPTION
## Summary
- add ft_string helpers so the TLS client can retry send loops without writing through immutable data
- update the TLS client regression test to verify retry attempts without overriding networking_check_ssl_after_send
- consolidate SSL_get_error and time() test overrides so the suite links cleanly

## Testing
- make -C Test OPT_LEVEL=0
- ./Test/libft_tests *(fails: terminates with "Segmentation fault" after `api_request_string_async large send retries complete` reports KO)*

------
https://chatgpt.com/codex/tasks/task_e_68df93584b848331b387ecea6fee6a6e