### PR TITLE
Adjust memcpy overlap handling

### DIFF
--- a/Libft/libft_memcpy.cpp
+++ b/Libft/libft_memcpy.cpp
@@ -22,7 +22,7 @@ void* ft_memcpy(void* destination, const void* source, size_t size)
 
     dest_end = dest + size;
     src_end = src + size;
-    if (dest < src_end && src < dest_end)
+    if (dest != src && dest < src_end && src < dest_end)
     {
         ft_errno = FT_EOVERLAP;
         return (destination);

--- a/Test/Test/test_memcpy.cpp
+++ b/Test/Test/test_memcpy.cpp
@@ -81,8 +81,10 @@ FT_TEST(test_memcpy_same_pointer, "ft_memcpy same pointer")
     ft_errno = ER_SUCCESS;
     FT_ASSERT_EQ(buffer, ft_memcpy(buffer, buffer, 4));
     FT_ASSERT_EQ('a', buffer[0]);
+    FT_ASSERT_EQ('b', buffer[1]);
+    FT_ASSERT_EQ('c', buffer[2]);
     FT_ASSERT_EQ('d', buffer[3]);
-    FT_ASSERT_EQ(FT_EOVERLAP, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 


### PR DESCRIPTION
## Summary
- refine ft_memcpy overlap detection to allow identical source and destination pointers
- update memcpy unit test to assert success and unchanged buffer for same-pointer copies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f4255aa48331af6d5fcb49006def