### PR TITLE
Handle ft_strtok end-of-input as success

### DIFF
--- a/Libft/libft_strtok.cpp
+++ b/Libft/libft_strtok.cpp
@@ -29,11 +29,13 @@ char    *ft_strtok(char *string, const char *delimiters)
         cached_delimiters_length = 0;
         cached_delimiters_hash = 0;
     }
-    if (saved_string == ft_nullptr || delimiters == ft_nullptr)
+    if (delimiters == ft_nullptr)
     {
         ft_errno = FT_EINVAL;
         return (ft_nullptr);
     }
+    if (saved_string == ft_nullptr)
+        return (ft_nullptr);
     new_delimiters_hash = 5381;
     delimiter_index = 0;
     while (delimiters[delimiter_index] != '\0')
@@ -80,7 +82,6 @@ char    *ft_strtok(char *string, const char *delimiters)
     if (*current_pointer == '\0')
     {
         saved_string = ft_nullptr;
-        ft_errno = FT_EINVAL;
         return (ft_nullptr);
     }
     token_start = current_pointer;

--- a/Test/Test/test_strtok.cpp
+++ b/Test/Test/test_strtok.cpp
@@ -18,7 +18,7 @@ FT_TEST(test_strtok_basic, "ft_strtok basic")
     FT_ASSERT_EQ(0, ft_strcmp("three", token));
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, " "));
-    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -26,9 +26,9 @@ FT_TEST(test_strtok_edge, "ft_strtok edge")
 {
     char buffer[4] = ",,,";
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(buffer, ","));
-    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, ","));
-    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
 
     char second[4] = "abc";
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(second, ft_nullptr));
@@ -70,7 +70,7 @@ FT_TEST(test_strtok_reinitialize, "ft_strtok resets when given a new string")
     FT_ASSERT_EQ(0, ft_strcmp("delta", token));
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, " "));
-    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -84,7 +84,7 @@ FT_TEST(test_strtok_skips_leading_delimiters, "ft_strtok skips leading separator
     FT_ASSERT_EQ(0, ft_strcmp("token", token));
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, ","));
-    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
 
@@ -137,6 +137,6 @@ FT_TEST(test_strtok_empty_delimiter_returns_full_string, "ft_strtok treats empty
     FT_ASSERT_EQ(0, ft_strcmp("token", token));
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     FT_ASSERT_EQ(ft_nullptr, ft_strtok(ft_nullptr, ""));
-    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }


### PR DESCRIPTION
## Summary
- ensure `ft_strtok` leaves `ft_errno` at `ER_SUCCESS` when no tokens remain while still flagging invalid delimiters
- update the strtok tests to expect `ER_SUCCESS` after token exhaustion and keep coverage for invalid delimiter usage

## Testing
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68e0f52c7d688331babb7b7552b15baa