### PR TITLE
Handle time_now failure in ft_time_format

### DIFF
--- a/Libft/libft_time.cpp
+++ b/Libft/libft_time.cpp
@@ -37,6 +37,10 @@ char *ft_time_format(char *buffer, size_t buffer_size)
     }
     ft_errno = ER_SUCCESS;
     current_time = time_now();
+    if (current_time == static_cast<t_time>(-1) && ft_errno != ER_SUCCESS)
+    {
+        return (ft_nullptr);
+    }
     time_local(current_time, &time_info);
     if (ft_errno != ER_SUCCESS)
     {

--- a/Test/Test/test_time.cpp
+++ b/Test/Test/test_time.cpp
@@ -291,6 +291,26 @@ FT_TEST(test_time_format_time_local_failure, "ft_time_format propagates time_loc
     return (1);
 }
 
+FT_TEST(test_time_format_time_now_failure, "ft_time_format propagates time_now failure")
+{
+    char buffer[32];
+    char *format_result;
+    int failure_errno;
+
+    std::memset(buffer, 'X', sizeof(buffer));
+    failure_errno = EBUSY;
+    g_time_now_force_failure = true;
+    g_time_now_failure_errno = failure_errno;
+    errno = 0;
+    ft_errno = ER_SUCCESS;
+    format_result = ft_time_format(buffer, sizeof(buffer));
+    g_time_now_force_failure = false;
+    FT_ASSERT_EQ(ft_nullptr, format_result);
+    FT_ASSERT_EQ('X', buffer[0]);
+    FT_ASSERT_EQ(failure_errno + ERRNO_OFFSET, ft_errno);
+    return (1);
+}
+
 FT_TEST(test_time_format_iso8601_success_sets_errno, "time_format_iso8601 reports success in errno")
 {
     ft_string formatted;


### PR DESCRIPTION
## Summary
- guard `ft_time_format` against `time_now` failures to avoid calling `time_local` on invalid times
- add a regression test confirming the formatter leaves the buffer untouched and preserves errno when `time_now` fails

## Testing
- make -C Test *(fails: interrupted to avoid rebuilding the entire project)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fac7fb9083318eedddc7481e1f6d