### PR TITLE
Handle strlcat buffers without terminators

### DIFF
--- a/Libft/libft_strlcat.cpp
+++ b/Libft/libft_strlcat.cpp
@@ -14,13 +14,13 @@ size_t ft_strlcat(char *destination, const char *source, size_t buffer_size)
         ft_errno = FT_EINVAL;
         return (0);
     }
-    destination_length = ft_strlen_size_t(destination);
-    if (ft_errno != ER_SUCCESS)
-        return (0);
     source_length = ft_strlen_size_t(source);
     if (ft_errno != ER_SUCCESS)
         return (0);
-    if (buffer_size <= destination_length)
+    destination_length = 0;
+    while (destination_length < buffer_size && destination[destination_length] != '\0')
+        destination_length++;
+    if (destination_length == buffer_size)
         return (buffer_size + source_length);
     copy_index = 0;
     while ((destination_length + copy_index + 1) < buffer_size && source[copy_index])

--- a/Test/Test/test_strlcat.cpp
+++ b/Test/Test/test_strlcat.cpp
@@ -111,3 +111,27 @@ FT_TEST(test_strlcat_truncated_destination, "ft_strlcat handles unterminated des
     return (1);
 }
 
+FT_TEST(test_strlcat_unterminated_buffer_exact_size, "ft_strlcat avoids writing when destination lacks terminator within size")
+{
+    char destination[5];
+    const char *source;
+    size_t result;
+
+    destination[0] = '1';
+    destination[1] = '2';
+    destination[2] = '3';
+    destination[3] = '4';
+    destination[4] = '5';
+    source = "abc";
+    ft_errno = FT_EINVAL;
+    result = ft_strlcat(destination, source, 5);
+    FT_ASSERT_EQ(8u, result);
+    FT_ASSERT_EQ('1', destination[0]);
+    FT_ASSERT_EQ('2', destination[1]);
+    FT_ASSERT_EQ('3', destination[2]);
+    FT_ASSERT_EQ('4', destination[3]);
+    FT_ASSERT_EQ('5', destination[4]);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- stop `ft_strlcat` from scanning past the provided buffer size by manually counting the existing destination bytes
- ensure concatenation works from the bounded length and only terminates when space permits
- add a regression test covering a buffer without a terminator within its size

## Testing
- Not run (no `make test` target)

------
https://chatgpt.com/codex/tasks/task_e_68e10fe5d8448331870cd7431701bd13