### PR TITLE
Fix ft_strnstr handling of identical buffers with length limit

### DIFF
--- a/Libft/libft_strnstr.cpp
+++ b/Libft/libft_strnstr.cpp
@@ -19,7 +19,9 @@ char *ft_strnstr(const char *haystack, const char *needle, size_t max_length)
     if (ft_errno != ER_SUCCESS)
         return (ft_nullptr);
     haystack_pointer = const_cast<char *>(haystack);
-    if (needle_length == 0 || haystack == needle)
+    if (needle_length > max_length)
+        return (ft_nullptr);
+    if (needle_length == 0)
         return (haystack_pointer);
     haystack_index = 0;
     while (haystack_pointer[haystack_index] != '\0' && haystack_index < max_length)

--- a/Test/Test/test_strnstr.cpp
+++ b/Test/Test/test_strnstr.cpp
@@ -87,3 +87,13 @@ FT_TEST(test_strnstr_restart_within_limit, "ft_strnstr restarts search within li
     FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
     return (1);
 }
+
+FT_TEST(test_strnstr_same_buffer_with_length_limit, "ft_strnstr same buffer respects length limit")
+{
+    char buffer[] = "abcdef";
+
+    ft_errno = FT_EINVAL;
+    FT_ASSERT_EQ(ft_nullptr, ft_strnstr(buffer, buffer, 3));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- ensure ft_strnstr only shortcuts on empty needles and respects the provided maximum length before searching
- add a regression test confirming identical haystack and needle pointers honor the length limit

## Testing
- make test (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68e112c70d84833189c1391da6f0b664