### PR TITLE
Fix cma_substr length handling for large buffers

### DIFF
--- a/CMA/cma_substr.cpp
+++ b/CMA/cma_substr.cpp
@@ -5,23 +5,45 @@
 char    *cma_substr(const char *source, unsigned int start, size_t length)
 {
     size_t  source_length;
+    size_t  start_index;
+    size_t  available_length;
     size_t  index;
     char    *substring;
 
     if (!source)
         return (ft_nullptr);
-    source_length = ft_strlen(source);
-    if (start >= source_length)
+    ft_errno = ER_SUCCESS;
+    source_length = ft_strlen_size_t(source);
+    if (ft_errno != ER_SUCCESS)
+    {
+        ft_errno = FT_ERANGE;
+        return (ft_nullptr);
+    }
+    start_index = static_cast<size_t>(start);
+    if (start_index >= source_length)
         return (cma_strdup(""));
-    if (length > source_length - start)
-        length = source_length - start;
+    available_length = source_length - start_index;
+    if (length > available_length)
+    {
+        if (available_length >= static_cast<size_t>(FT_SYSTEM_SIZE_MAX))
+        {
+            ft_errno = FT_ERANGE;
+            return (ft_nullptr);
+        }
+        length = available_length;
+    }
+    if (length >= static_cast<size_t>(FT_SYSTEM_SIZE_MAX))
+    {
+        ft_errno = FT_ERANGE;
+        return (ft_nullptr);
+    }
     substring = static_cast<char *>(cma_malloc(length + 1));
     if (!substring)
         return (ft_nullptr);
     index = 0;
-    while (index < length && source[start + index])
+    while (index < length && source[start_index + index])
     {
-        substring[index] = source[start + index];
+        substring[index] = source[start_index + index];
         index++;
     }
     substring[index] = '\0';

--- a/Test/Test/test_cma_strings.cpp
+++ b/Test/Test/test_cma_strings.cpp
@@ -214,6 +214,51 @@ FT_TEST(test_cma_substr_truncates_when_length_exceeds,
     return (1);
 }
 
+FT_TEST(test_cma_substr_large_buffer_tail_segment,
+        "cma_substr returns the tail segment of a large buffer")
+{
+    size_t  buffer_size;
+    char    *buffer;
+    const char    *tail_segment;
+    size_t  tail_length;
+    size_t  index;
+    unsigned int    start_index;
+    char    *substring;
+
+    buffer_size = static_cast<size_t>(1) << 20;
+    tail_segment = "tail-substring";
+    tail_length = ft_strlen_size_t(tail_segment);
+    buffer = static_cast<char *>(cma_malloc(buffer_size + 1));
+    if (!buffer)
+        return (0);
+    index = 0;
+    while (index < buffer_size - tail_length)
+    {
+        buffer[index] = 'a';
+        index++;
+    }
+    index = 0;
+    while (index < tail_length)
+    {
+        buffer[(buffer_size - tail_length) + index] = tail_segment[index];
+        index++;
+    }
+    buffer[buffer_size] = '\0';
+    start_index = static_cast<unsigned int>(buffer_size - tail_length);
+    ft_errno = FT_EALLOC;
+    substring = cma_substr(buffer, start_index, tail_length);
+    if (!substring)
+    {
+        cma_free(buffer);
+        return (0);
+    }
+    FT_ASSERT_EQ(0, ft_strcmp(substring, tail_segment));
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    cma_free(substring);
+    cma_free(buffer);
+    return (1);
+}
+
 FT_TEST(test_cma_substr_handles_out_of_range_start,
         "cma_substr returns an empty string when start is outside the source")
 {


### PR DESCRIPTION
## Summary
- use ft_strlen_size_t in cma_substr and propagate FT_ERANGE when measurements or adjustments exceed size_t limits
- rely on the full size_t bounds during copying to avoid truncating large substrings
- add a regression test that exercises substring extraction at the tail of a large buffer

## Testing
- make -C CMA

------
https://chatgpt.com/codex/tasks/task_e_68e1205bd8fc8331a858f71589dfe0a5