### PR TITLE
Fix UTF-8 encode edge cases and clean warnings

### DIFF
--- a/Compatebility/Compatebility_pthread.cpp
+++ b/Compatebility/Compatebility_pthread.cpp
@@ -114,7 +114,7 @@ int cmp_thread_sleep(unsigned int milliseconds)
 
 int cmp_thread_wait_uint32(std::atomic<uint32_t> *address, uint32_t expected_value)
 {
-    int syscall_result;
+    long syscall_result;
 
     while (1)
     {
@@ -144,7 +144,7 @@ int cmp_thread_wait_uint32(std::atomic<uint32_t> *address, uint32_t expected_val
 
 int cmp_thread_wake_one_uint32(std::atomic<uint32_t> *address)
 {
-    int syscall_result;
+    long syscall_result;
 
     syscall_result = syscall(SYS_futex, reinterpret_cast<uint32_t *>(address),
 # ifdef FUTEX_WAKE_PRIVATE

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -25,6 +25,7 @@
 #include "JSon/json.hpp"
 #include "JSon/document.hpp"
 #include "Libft/libft.hpp"
+#include "Libft/libft_utf8.hpp"
 #include "Libft/limits.hpp"
 #include "Math/math.hpp"
 #include "Math/roll.hpp"

--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -41,7 +41,11 @@ SRCS := libft_atoi.cpp \
     libft_fgets.cpp \
     libft_time.cpp \
     libft_validate_int.cpp \
-    libft_to_string.cpp
+    libft_to_string.cpp \
+    libft_utf8_case.cpp \
+    libft_utf8_decode.cpp \
+    libft_utf8_grapheme.cpp \
+    libft_utf8_length.cpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/Libft/libft_utf8.hpp
+++ b/Libft/libft_utf8.hpp
@@ -1,0 +1,28 @@
+#ifndef LIBFT_UTF8_HPP
+# define LIBFT_UTF8_HPP
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef uint32_t (*ft_utf8_case_hook)(uint32_t code_point);
+
+int         ft_utf8_next(const char *string, size_t string_length,
+                size_t *index_pointer, uint32_t *code_point_pointer,
+                size_t *sequence_length_pointer);
+int         ft_utf8_count(const char *string, size_t *code_point_count_pointer);
+int         ft_utf8_encode(uint32_t code_point, char *buffer, size_t buffer_size,
+                size_t *encoded_length_pointer);
+int         ft_utf8_transform(const char *input, size_t input_length,
+                char *output_buffer, size_t output_buffer_size,
+                ft_utf8_case_hook case_hook);
+int         ft_utf8_transform_alloc(const char *input, char **output_pointer,
+                ft_utf8_case_hook case_hook);
+uint32_t    ft_utf8_case_ascii_lower(uint32_t code_point);
+uint32_t    ft_utf8_case_ascii_upper(uint32_t code_point);
+int         ft_utf8_is_combining_code_point(uint32_t code_point);
+int         ft_utf8_next_grapheme(const char *string, size_t string_length,
+                size_t *index_pointer, size_t *grapheme_length_pointer);
+int         ft_utf8_duplicate_grapheme(const char *string, size_t string_length,
+                size_t *index_pointer, char **grapheme_pointer);
+
+#endif

--- a/Libft/libft_utf8_case.cpp
+++ b/Libft/libft_utf8_case.cpp
@@ -1,0 +1,183 @@
+#include "libft.hpp"
+#include "libft_utf8.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
+#include "../CMA/CMA.hpp"
+
+uint32_t ft_utf8_case_ascii_lower(uint32_t code_point)
+{
+    if (code_point >= 'A' && code_point <= 'Z')
+        return (code_point + 32);
+    return (code_point);
+}
+
+uint32_t ft_utf8_case_ascii_upper(uint32_t code_point)
+{
+    if (code_point >= 'a' && code_point <= 'z')
+        return (code_point - 32);
+    return (code_point);
+}
+
+int ft_utf8_encode(uint32_t code_point, char *buffer, size_t buffer_size,
+        size_t *encoded_length_pointer)
+{
+    size_t required_length;
+
+    ft_errno = ER_SUCCESS;
+    if (buffer == ft_nullptr && buffer_size != 0)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    if (code_point > 0x10FFFF)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    if (code_point >= 0xD800 && code_point <= 0xDFFF)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    if (code_point <= 0x7F)
+        required_length = 1;
+    else if (code_point <= 0x7FF)
+        required_length = 2;
+    else if (code_point <= 0xFFFF)
+        required_length = 3;
+    else
+        required_length = 4;
+    if (buffer_size <= required_length)
+    {
+        ft_errno = FT_ERANGE;
+        return (FT_FAILURE);
+    }
+    if (required_length == 1)
+        buffer[0] = static_cast<char>(code_point);
+    else if (required_length == 2)
+    {
+        buffer[0] = static_cast<char>(0xC0 | ((code_point >> 6) & 0x1F));
+        buffer[1] = static_cast<char>(0x80 | (code_point & 0x3F));
+    }
+    else if (required_length == 3)
+    {
+        buffer[0] = static_cast<char>(0xE0 | ((code_point >> 12) & 0x0F));
+        buffer[1] = static_cast<char>(0x80 | ((code_point >> 6) & 0x3F));
+        buffer[2] = static_cast<char>(0x80 | (code_point & 0x3F));
+    }
+    else
+    {
+        buffer[0] = static_cast<char>(0xF0 | ((code_point >> 18) & 0x07));
+        buffer[1] = static_cast<char>(0x80 | ((code_point >> 12) & 0x3F));
+        buffer[2] = static_cast<char>(0x80 | ((code_point >> 6) & 0x3F));
+        buffer[3] = static_cast<char>(0x80 | (code_point & 0x3F));
+    }
+    buffer[required_length] = '\0';
+    if (encoded_length_pointer != ft_nullptr)
+        *encoded_length_pointer = required_length;
+    return (FT_SUCCESS);
+}
+
+int ft_utf8_transform(const char *input, size_t input_length,
+        char *output_buffer, size_t output_buffer_size,
+        ft_utf8_case_hook case_hook)
+{
+    size_t effective_length;
+    size_t input_index;
+    size_t output_index;
+
+    ft_errno = ER_SUCCESS;
+    if (input == ft_nullptr || output_buffer == ft_nullptr
+        || case_hook == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    effective_length = input_length;
+    if (effective_length == 0)
+        effective_length = ft_strlen_size_t(input);
+    input_index = 0;
+    output_index = 0;
+    while (input_index < effective_length)
+    {
+        size_t working_index;
+        uint32_t decoded_code_point;
+        size_t sequence_length;
+        uint32_t mapped_code_point;
+        char encoded_buffer[5];
+        size_t encoded_length;
+        size_t copy_index;
+
+        working_index = input_index;
+        decoded_code_point = 0;
+        sequence_length = 0;
+        if (ft_utf8_next(input, effective_length, &working_index,
+                &decoded_code_point, &sequence_length) != FT_SUCCESS)
+            return (FT_FAILURE);
+        mapped_code_point = case_hook(decoded_code_point);
+        encoded_length = 0;
+        if (ft_utf8_encode(mapped_code_point, encoded_buffer,
+                sizeof(encoded_buffer), &encoded_length) != FT_SUCCESS)
+            return (FT_FAILURE);
+        if (output_index + encoded_length >= output_buffer_size)
+        {
+            ft_errno = FT_ERANGE;
+            return (FT_FAILURE);
+        }
+        copy_index = 0;
+        while (copy_index < encoded_length)
+        {
+            output_buffer[output_index] = encoded_buffer[copy_index];
+            output_index++;
+            copy_index++;
+        }
+        input_index = working_index;
+    }
+    if (output_index >= output_buffer_size)
+    {
+        ft_errno = FT_ERANGE;
+        return (FT_FAILURE);
+    }
+    output_buffer[output_index] = '\0';
+    return (FT_SUCCESS);
+}
+
+int ft_utf8_transform_alloc(const char *input, char **output_pointer,
+        ft_utf8_case_hook case_hook)
+{
+    size_t code_point_count;
+    size_t allocation_size;
+    char *allocated_buffer;
+
+    ft_errno = ER_SUCCESS;
+    if (input == ft_nullptr || output_pointer == ft_nullptr
+        || case_hook == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    *output_pointer = ft_nullptr;
+    code_point_count = 0;
+    if (ft_utf8_count(input, &code_point_count) != FT_SUCCESS)
+        return (FT_FAILURE);
+    allocation_size = (code_point_count * 4) + 1;
+    allocated_buffer = static_cast<char *>(cma_malloc(static_cast<ft_size_t>(allocation_size)));
+    if (allocated_buffer == ft_nullptr)
+    {
+        ft_errno = FT_EALLOC;
+        return (FT_FAILURE);
+    }
+    if (ft_utf8_transform(input, ft_strlen_size_t(input), allocated_buffer,
+            allocation_size, case_hook) != FT_SUCCESS)
+    {
+        int transform_error;
+
+        transform_error = ft_errno;
+        cma_free(allocated_buffer);
+        *output_pointer = ft_nullptr;
+        ft_errno = transform_error;
+        return (FT_FAILURE);
+    }
+    *output_pointer = allocated_buffer;
+    return (FT_SUCCESS);
+}

--- a/Libft/libft_utf8_decode.cpp
+++ b/Libft/libft_utf8_decode.cpp
@@ -1,0 +1,117 @@
+#include "libft.hpp"
+#include "libft_utf8.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
+
+static int ft_utf8_is_trailing_byte(unsigned char byte_value)
+{
+    if ((byte_value & 0xC0) == 0x80)
+        return (1);
+    return (0);
+}
+
+static int ft_utf8_detect_sequence(unsigned char first_byte, size_t *expected_length,
+        uint32_t *initial_value, uint32_t *minimum_value)
+{
+    if (first_byte <= 0x7F)
+    {
+        *expected_length = 1;
+        *initial_value = first_byte;
+        *minimum_value = 0;
+        return (FT_SUCCESS);
+    }
+    if ((first_byte & 0xE0) == 0xC0)
+    {
+        *expected_length = 2;
+        *initial_value = first_byte & 0x1F;
+        *minimum_value = 0x80;
+        return (FT_SUCCESS);
+    }
+    if ((first_byte & 0xF0) == 0xE0)
+    {
+        *expected_length = 3;
+        *initial_value = first_byte & 0x0F;
+        *minimum_value = 0x800;
+        return (FT_SUCCESS);
+    }
+    if ((first_byte & 0xF8) == 0xF0)
+    {
+        *expected_length = 4;
+        *initial_value = first_byte & 0x07;
+        *minimum_value = 0x10000;
+        return (FT_SUCCESS);
+    }
+    return (FT_FAILURE);
+}
+
+int ft_utf8_next(const char *string, size_t string_length,
+        size_t *index_pointer, uint32_t *code_point_pointer,
+        size_t *sequence_length_pointer)
+{
+    size_t current_index;
+    unsigned char first_byte;
+    size_t expected_length;
+    uint32_t decoded_value;
+    size_t processed_bytes;
+    uint32_t minimum_value;
+
+    ft_errno = ER_SUCCESS;
+    if (string == ft_nullptr || index_pointer == ft_nullptr
+        || code_point_pointer == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    if (*index_pointer >= string_length)
+        return (FT_FAILURE);
+    current_index = *index_pointer;
+    first_byte = static_cast<unsigned char>(string[current_index]);
+    expected_length = 0;
+    decoded_value = 0;
+    minimum_value = 0;
+    if (ft_utf8_detect_sequence(first_byte, &expected_length,
+            &decoded_value, &minimum_value) != FT_SUCCESS)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    if (current_index + expected_length > string_length)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    processed_bytes = 1;
+    while (processed_bytes < expected_length)
+    {
+        unsigned char continuation_byte;
+
+        continuation_byte = static_cast<unsigned char>(string[current_index + processed_bytes]);
+        if (!ft_utf8_is_trailing_byte(continuation_byte))
+        {
+            ft_errno = FT_EINVAL;
+            return (FT_FAILURE);
+        }
+        decoded_value = (decoded_value << 6) | (continuation_byte & 0x3F);
+        processed_bytes++;
+    }
+    if (decoded_value < minimum_value)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    if (decoded_value > 0x10FFFF)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    if (decoded_value >= 0xD800 && decoded_value <= 0xDFFF)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    *code_point_pointer = decoded_value;
+    if (sequence_length_pointer != ft_nullptr)
+        *sequence_length_pointer = expected_length;
+    *index_pointer = current_index + expected_length;
+    return (FT_SUCCESS);
+}

--- a/Libft/libft_utf8_grapheme.cpp
+++ b/Libft/libft_utf8_grapheme.cpp
@@ -1,0 +1,116 @@
+#include "libft.hpp"
+#include "libft_utf8.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
+#include "../CMA/CMA.hpp"
+
+static int ft_utf8_code_point_in_range(uint32_t code_point, uint32_t start_value,
+        uint32_t end_value)
+{
+    if (code_point >= start_value && code_point <= end_value)
+        return (1);
+    return (0);
+}
+
+int ft_utf8_is_combining_code_point(uint32_t code_point)
+{
+    if (ft_utf8_code_point_in_range(code_point, 0x0300, 0x036F))
+        return (1);
+    if (ft_utf8_code_point_in_range(code_point, 0x1AB0, 0x1AFF))
+        return (1);
+    if (ft_utf8_code_point_in_range(code_point, 0x1DC0, 0x1DFF))
+        return (1);
+    if (ft_utf8_code_point_in_range(code_point, 0x20D0, 0x20FF))
+        return (1);
+    if (ft_utf8_code_point_in_range(code_point, 0xFE20, 0xFE2F))
+        return (1);
+    return (0);
+}
+
+int ft_utf8_next_grapheme(const char *string, size_t string_length,
+        size_t *index_pointer, size_t *grapheme_length_pointer)
+{
+    size_t current_index;
+    size_t grapheme_end_index;
+    uint32_t code_point_value;
+    size_t sequence_length;
+
+    ft_errno = ER_SUCCESS;
+    if (string == ft_nullptr || index_pointer == ft_nullptr
+        || grapheme_length_pointer == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    if (*index_pointer >= string_length)
+        return (FT_FAILURE);
+    current_index = *index_pointer;
+    code_point_value = 0;
+    sequence_length = 0;
+    if (ft_utf8_next(string, string_length, &current_index,
+            &code_point_value, &sequence_length) != FT_SUCCESS)
+        return (FT_FAILURE);
+    grapheme_end_index = current_index;
+    while (1)
+    {
+        size_t lookahead_index;
+        uint32_t lookahead_code_point;
+        size_t lookahead_length;
+
+        lookahead_index = grapheme_end_index;
+        if (lookahead_index >= string_length)
+            break ;
+        lookahead_code_point = 0;
+        lookahead_length = 0;
+        if (ft_utf8_next(string, string_length, &lookahead_index,
+                &lookahead_code_point, &lookahead_length) != FT_SUCCESS)
+            return (FT_FAILURE);
+        if (!ft_utf8_is_combining_code_point(lookahead_code_point))
+            break ;
+        grapheme_end_index = lookahead_index;
+    }
+    *grapheme_length_pointer = grapheme_end_index - *index_pointer;
+    *index_pointer = grapheme_end_index;
+    return (FT_SUCCESS);
+}
+
+int ft_utf8_duplicate_grapheme(const char *string, size_t string_length,
+        size_t *index_pointer, char **grapheme_pointer)
+{
+    size_t start_index;
+    size_t local_index;
+    size_t grapheme_length;
+    char *allocated_grapheme;
+    size_t copy_index;
+
+    ft_errno = ER_SUCCESS;
+    if (string == ft_nullptr || index_pointer == ft_nullptr
+        || grapheme_pointer == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    *grapheme_pointer = ft_nullptr;
+    start_index = *index_pointer;
+    local_index = *index_pointer;
+    grapheme_length = 0;
+    if (ft_utf8_next_grapheme(string, string_length, &local_index,
+            &grapheme_length) != FT_SUCCESS)
+        return (FT_FAILURE);
+    allocated_grapheme = static_cast<char *>(cma_malloc(static_cast<ft_size_t>(grapheme_length + 1)));
+    if (allocated_grapheme == ft_nullptr)
+    {
+        ft_errno = FT_EALLOC;
+        return (FT_FAILURE);
+    }
+    copy_index = 0;
+    while (copy_index < grapheme_length)
+    {
+        allocated_grapheme[copy_index] = string[start_index + copy_index];
+        copy_index++;
+    }
+    allocated_grapheme[grapheme_length] = '\0';
+    *index_pointer = local_index;
+    *grapheme_pointer = allocated_grapheme;
+    return (FT_SUCCESS);
+}

--- a/Libft/libft_utf8_length.cpp
+++ b/Libft/libft_utf8_length.cpp
@@ -1,0 +1,38 @@
+#include "libft.hpp"
+#include "libft_utf8.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+#include "../Errno/errno.hpp"
+
+int ft_utf8_count(const char *string, size_t *code_point_count_pointer)
+{
+    size_t string_length;
+    size_t byte_index;
+    size_t decoded_count;
+
+    ft_errno = ER_SUCCESS;
+    if (string == ft_nullptr || code_point_count_pointer == ft_nullptr)
+    {
+        ft_errno = FT_EINVAL;
+        return (FT_FAILURE);
+    }
+    string_length = ft_strlen_size_t(string);
+    byte_index = 0;
+    decoded_count = 0;
+    while (byte_index < string_length)
+    {
+        size_t working_index;
+        uint32_t code_point_value;
+        size_t sequence_length;
+
+        working_index = byte_index;
+        code_point_value = 0;
+        sequence_length = 0;
+        if (ft_utf8_next(string, string_length, &working_index,
+                &code_point_value, &sequence_length) != FT_SUCCESS)
+            return (FT_FAILURE);
+        byte_index = working_index;
+        decoded_count++;
+    }
+    *code_point_count_pointer = decoded_count;
+    return (FT_SUCCESS);
+}

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ entering their directory and running `make`.
 Standard C utilities located in `Libft/`. Headers: `libft.hpp` and `limits.hpp`. Source files use the `libft_` prefix.
 
 ```
+typedef uint32_t (*ft_utf8_case_hook)(uint32_t code_point);
 size_t  ft_strlen_size_t(const char *string);
 int     ft_strlen(const char *string);
 char   *ft_strchr(const char *string, int char_to_find);
@@ -125,10 +126,34 @@ int     ft_fclose(FILE *stream);
 int64_t ft_time_ms(void);
 char   *ft_time_format(char *buffer, size_t buffer_size);
 ft_string ft_to_string(long number);
+int     ft_utf8_next(const char *string, size_t string_length, size_t *index_pointer,
+            uint32_t *code_point_pointer, size_t *sequence_length_pointer);
+int     ft_utf8_count(const char *string, size_t *code_point_count_pointer);
+int     ft_utf8_encode(uint32_t code_point, char *buffer, size_t buffer_size,
+            size_t *encoded_length_pointer);
+int     ft_utf8_transform(const char *input, size_t input_length, char *output_buffer,
+            size_t output_buffer_size, ft_utf8_case_hook case_hook);
+int     ft_utf8_transform_alloc(const char *input, char **output_pointer,
+            ft_utf8_case_hook case_hook);
+uint32_t ft_utf8_case_ascii_lower(uint32_t code_point);
+uint32_t ft_utf8_case_ascii_upper(uint32_t code_point);
+int     ft_utf8_is_combining_code_point(uint32_t code_point);
+int     ft_utf8_next_grapheme(const char *string, size_t string_length,
+            size_t *index_pointer, size_t *grapheme_length_pointer);
+int     ft_utf8_duplicate_grapheme(const char *string, size_t string_length,
+            size_t *index_pointer, char **grapheme_pointer);
 ```
 
 `ft_strtol` clamps values that exceed `FT_LONG_MAX` or `FT_LONG_MIN` and sets
 `ft_errno` to `FT_ERANGE` when overflow is detected.
+
+`ft_utf8_next` and `ft_utf8_count` decode UTF-8 sequences while mirroring invalid
+byte sequences through `FT_EINVAL`. The transformation helpers keep ASCII case
+conversion on the existing hooks, set `FT_ERANGE` if the destination buffer is
+too small, and surface allocation failures as `FT_EALLOC`. Optional grapheme
+wrappers reuse the CMA allocation utilities to duplicate composed characters
+while leaving successful iterations with `ER_SUCCESS` so callers can detect the
+end of input without spurious errors.
 
 `ft_fgets` sets `ft_errno` to `FILE_END_OF_FILE` when the stream reaches end of
 file without an input error, allowing callers to differentiate EOF from other

--- a/Template/function.hpp
+++ b/Template/function.hpp
@@ -386,12 +386,12 @@ ReturnType ft_function<ReturnType(Args...)>::operator()(Args... args) const
         }
         return (ReturnType());
     }
-    ReturnType (*invoke)(void *, Args...);
+    ReturnType (*invoke_target)(void *, Args...);
     void *callable;
 
-    invoke = this->_invoke;
+    invoke_target = this->_invoke;
     callable = this->_callable;
-    if (!invoke || !callable)
+    if (!invoke_target || !callable)
     {
         this->set_error(FT_EINVAL);
         guard.unlock();
@@ -418,10 +418,10 @@ ReturnType ft_function<ReturnType(Args...)>::operator()(Args... args) const
     }
     if constexpr (std::is_void<ReturnType>::value)
     {
-        invoke(callable, args...);
+        invoke_target(callable, args...);
         return ;
     }
-    return (invoke(callable, args...));
+    return (invoke_target(callable, args...));
 }
 
 template <typename ReturnType, typename... Args>

--- a/Template/pair.hpp
+++ b/Template/pair.hpp
@@ -20,8 +20,8 @@ class Pair
         KeyType key;
         ValueType value;
         Pair();
-        Pair(const KeyType &key, const ValueType &value);
-        Pair(const KeyType &key, ValueType &&value);
+        Pair(const KeyType &input_key, const ValueType &input_value);
+        Pair(const KeyType &input_key, ValueType &&input_value);
         Pair(const Pair &other);
         Pair(Pair &&other);
         ~Pair();
@@ -31,10 +31,10 @@ class Pair
 
         KeyType get_key() const;
         ValueType get_value() const;
-        void set_key(const KeyType &key);
-        void set_key(KeyType &&key);
-        void set_value(const ValueType &value);
-        void set_value(ValueType &&value);
+        void set_key(const KeyType &input_key);
+        void set_key(KeyType &&input_key);
+        void set_value(const ValueType &input_value);
+        void set_value(ValueType &&input_value);
         int get_error() const;
         const char *get_error_str() const;
 };
@@ -56,16 +56,16 @@ Pair<KeyType, ValueType>::Pair()
 }
 
 template <typename KeyType, typename ValueType>
-Pair<KeyType, ValueType>::Pair(const KeyType &key, const ValueType &value)
-        : _mutex(), _error_code(ER_SUCCESS), key(key), value(value)
+Pair<KeyType, ValueType>::Pair(const KeyType &input_key, const ValueType &input_value)
+        : _mutex(), _error_code(ER_SUCCESS), key(input_key), value(input_value)
 {
     this->set_error(ER_SUCCESS);
     return ;
 }
 
 template <typename KeyType, typename ValueType>
-Pair<KeyType, ValueType>::Pair(const KeyType &key, ValueType &&value)
-        : _mutex(), _error_code(ER_SUCCESS), key(key), value(ft_move(value))
+Pair<KeyType, ValueType>::Pair(const KeyType &input_key, ValueType &&input_value)
+        : _mutex(), _error_code(ER_SUCCESS), key(input_key), value(ft_move(input_value))
 {
     this->set_error(ER_SUCCESS);
     return ;
@@ -227,7 +227,7 @@ ValueType Pair<KeyType, ValueType>::get_value() const
 }
 
 template <typename KeyType, typename ValueType>
-void Pair<KeyType, ValueType>::set_key(const KeyType &key)
+void Pair<KeyType, ValueType>::set_key(const KeyType &input_key)
 {
     ft_unique_lock<pt_mutex> guard(this->_mutex);
     if (guard.get_error() != ER_SUCCESS)
@@ -235,13 +235,13 @@ void Pair<KeyType, ValueType>::set_key(const KeyType &key)
         this->set_error(guard.get_error());
         return ;
     }
-    this->key = key;
+    this->key = input_key;
     this->set_error(ER_SUCCESS);
     return ;
 }
 
 template <typename KeyType, typename ValueType>
-void Pair<KeyType, ValueType>::set_key(KeyType &&key)
+void Pair<KeyType, ValueType>::set_key(KeyType &&input_key)
 {
     ft_unique_lock<pt_mutex> guard(this->_mutex);
     if (guard.get_error() != ER_SUCCESS)
@@ -249,13 +249,13 @@ void Pair<KeyType, ValueType>::set_key(KeyType &&key)
         this->set_error(guard.get_error());
         return ;
     }
-    this->key = ft_move(key);
+    this->key = ft_move(input_key);
     this->set_error(ER_SUCCESS);
     return ;
 }
 
 template <typename KeyType, typename ValueType>
-void Pair<KeyType, ValueType>::set_value(const ValueType &value)
+void Pair<KeyType, ValueType>::set_value(const ValueType &input_value)
 {
     ft_unique_lock<pt_mutex> guard(this->_mutex);
     if (guard.get_error() != ER_SUCCESS)
@@ -263,13 +263,13 @@ void Pair<KeyType, ValueType>::set_value(const ValueType &value)
         this->set_error(guard.get_error());
         return ;
     }
-    this->value = value;
+    this->value = input_value;
     this->set_error(ER_SUCCESS);
     return ;
 }
 
 template <typename KeyType, typename ValueType>
-void Pair<KeyType, ValueType>::set_value(ValueType &&value)
+void Pair<KeyType, ValueType>::set_value(ValueType &&input_value)
 {
     ft_unique_lock<pt_mutex> guard(this->_mutex);
     if (guard.get_error() != ER_SUCCESS)
@@ -277,7 +277,7 @@ void Pair<KeyType, ValueType>::set_value(ValueType &&value)
         this->set_error(guard.get_error());
         return ;
     }
-    this->value = ft_move(value);
+    this->value = ft_move(input_value);
     this->set_error(ER_SUCCESS);
     return ;
 }

--- a/Test/Test/test_libft_utf8.cpp
+++ b/Test/Test/test_libft_utf8.cpp
@@ -1,0 +1,272 @@
+#include "../../Libft/libft.hpp"
+#include "../../Libft/libft_utf8.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+FT_TEST(test_utf8_count_ascii, "ft_utf8_count counts ascii code points")
+{
+    size_t code_point_count;
+
+    code_point_count = 0;
+    ft_errno = FT_ERANGE;
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_count("hello", &code_point_count));
+    FT_ASSERT_EQ(static_cast<size_t>(5), code_point_count);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_utf8_next_multibyte, "ft_utf8_next decodes multibyte sequences")
+{
+    const char *utf8_string;
+    size_t string_length;
+    size_t index_pointer;
+    uint32_t code_point_value;
+    size_t sequence_length;
+
+    utf8_string = "héllo";
+    string_length = ft_strlen_size_t(utf8_string);
+    index_pointer = 0;
+    code_point_value = 0;
+    sequence_length = 0;
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_next(utf8_string, string_length,
+            &index_pointer, &code_point_value, &sequence_length));
+    FT_ASSERT_EQ(static_cast<uint32_t>('h'), code_point_value);
+    FT_ASSERT_EQ(static_cast<size_t>(1), sequence_length);
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_next(utf8_string, string_length,
+            &index_pointer, &code_point_value, &sequence_length));
+    FT_ASSERT_EQ(static_cast<uint32_t>(0xE9), code_point_value);
+    FT_ASSERT_EQ(static_cast<size_t>(2), sequence_length);
+    return (1);
+}
+
+FT_TEST(test_utf8_next_four_byte_sequence, "ft_utf8_next decodes emoji code points")
+{
+    const char *utf8_string;
+    size_t string_length;
+    size_t index_pointer;
+    uint32_t code_point_value;
+    size_t sequence_length;
+
+    utf8_string = "A" "\xF0\x9F\x98\x80" "B";
+    string_length = ft_strlen_size_t(utf8_string);
+    index_pointer = 0;
+    code_point_value = 0;
+    sequence_length = 0;
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_next(utf8_string, string_length,
+            &index_pointer, &code_point_value, &sequence_length));
+    FT_ASSERT_EQ(static_cast<uint32_t>('A'), code_point_value);
+    FT_ASSERT_EQ(static_cast<size_t>(1), sequence_length);
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_next(utf8_string, string_length,
+            &index_pointer, &code_point_value, &sequence_length));
+    FT_ASSERT_EQ(static_cast<uint32_t>(0x1F600), code_point_value);
+    FT_ASSERT_EQ(static_cast<size_t>(4), sequence_length);
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_next(utf8_string, string_length,
+            &index_pointer, &code_point_value, &sequence_length));
+    FT_ASSERT_EQ(static_cast<uint32_t>('B'), code_point_value);
+    FT_ASSERT_EQ(static_cast<size_t>(1), sequence_length);
+    return (1);
+}
+
+FT_TEST(test_utf8_next_invalid_sequence_sets_errno, "ft_utf8_next reports invalid byte sequences")
+{
+    char invalid_sequence[3];
+    size_t string_length;
+    size_t index_pointer;
+    uint32_t code_point_value;
+
+    invalid_sequence[0] = static_cast<char>(0xC0);
+    invalid_sequence[1] = static_cast<char>(0xAF);
+    invalid_sequence[2] = '\0';
+    string_length = static_cast<size_t>(2);
+    index_pointer = 0;
+    code_point_value = 0;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_utf8_next(invalid_sequence, string_length,
+            &index_pointer, &code_point_value, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+static uint32_t ft_utf8_test_invalid_hook(uint32_t code_point)
+{
+    (void)code_point;
+    return (0x110000);
+}
+
+FT_TEST(test_utf8_transform_alloc_lowercase, "ft_utf8_transform_alloc applies ascii lower hook")
+{
+    char *transformed_string;
+
+    transformed_string = ft_nullptr;
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_transform_alloc("TeSt",
+            &transformed_string, ft_utf8_case_ascii_lower));
+    FT_ASSERT(transformed_string != ft_nullptr);
+    FT_ASSERT_EQ(0, ft_strcmp("test", transformed_string));
+    cma_free(transformed_string);
+    return (1);
+}
+
+FT_TEST(test_utf8_transform_alloc_uppercase, "ft_utf8_transform_alloc applies ascii upper hook")
+{
+    char *transformed_string;
+
+    transformed_string = ft_nullptr;
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_transform_alloc("emoji: " "\xF0\x9F\x98\x80", &transformed_string,
+            ft_utf8_case_ascii_upper));
+    FT_ASSERT(transformed_string != ft_nullptr);
+    FT_ASSERT_EQ(0, ft_strcmp("EMOJI: " "\xF0\x9F\x98\x80", transformed_string));
+    cma_free(transformed_string);
+    return (1);
+}
+
+FT_TEST(test_utf8_grapheme_duplicate_combining_mark, "ft_utf8_duplicate_grapheme copies composed characters")
+{
+    const char *grapheme_string;
+    size_t string_length;
+    size_t index_pointer;
+    char *grapheme_copy;
+
+    grapheme_string = "e\xCC\x81o";
+    string_length = ft_strlen_size_t(grapheme_string);
+    index_pointer = 0;
+    grapheme_copy = ft_nullptr;
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_duplicate_grapheme(grapheme_string,
+            string_length, &index_pointer, &grapheme_copy));
+    FT_ASSERT(grapheme_copy != ft_nullptr);
+    FT_ASSERT_EQ(static_cast<size_t>(3), ft_strlen_size_t(grapheme_copy));
+    FT_ASSERT_EQ(0, ft_strcmp("e\xCC\x81", grapheme_copy));
+    cma_free(grapheme_copy);
+    FT_ASSERT_EQ(static_cast<size_t>(3), index_pointer);
+    return (1);
+}
+
+FT_TEST(test_utf8_count_invalid_sets_errno, "ft_utf8_count mirrors invalid bytes")
+{
+    char invalid_sequence[3];
+    size_t code_point_count;
+
+    invalid_sequence[0] = static_cast<char>(0xE0);
+    invalid_sequence[1] = static_cast<char>(0x80);
+    invalid_sequence[2] = '\0';
+    code_point_count = 0;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_utf8_count(invalid_sequence, &code_point_count));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_utf8_encode_emoji, "ft_utf8_encode writes four byte sequence")
+{
+    char buffer[5];
+    size_t encoded_length;
+
+    buffer[0] = '\0';
+    buffer[1] = '\0';
+    buffer[2] = '\0';
+    buffer[3] = '\0';
+    buffer[4] = '\0';
+    encoded_length = 0;
+    FT_ASSERT_EQ(FT_SUCCESS, ft_utf8_encode(0x1F642, buffer, sizeof(buffer),
+            &encoded_length));
+    FT_ASSERT_EQ(static_cast<size_t>(4), encoded_length);
+    FT_ASSERT_EQ(static_cast<char>(0xF0), buffer[0]);
+    FT_ASSERT_EQ(static_cast<char>(0x9F), buffer[1]);
+    FT_ASSERT_EQ(static_cast<char>(0x99), buffer[2]);
+    FT_ASSERT_EQ(static_cast<char>(0x82), buffer[3]);
+    FT_ASSERT_EQ('\0', buffer[4]);
+    return (1);
+}
+
+FT_TEST(test_utf8_encode_reports_small_buffer, "ft_utf8_encode mirrors range errors")
+{
+    char buffer[3];
+
+    buffer[0] = '\0';
+    buffer[1] = '\0';
+    buffer[2] = '\0';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_utf8_encode(0x20AC, buffer, sizeof(buffer), ft_nullptr));
+    FT_ASSERT_EQ(FT_ERANGE, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_utf8_next_rejects_surrogate, "ft_utf8_next rejects utf16 surrogate code points")
+{
+    const char *invalid_string;
+    size_t string_length;
+    size_t index_pointer;
+    uint32_t code_point_value;
+
+    invalid_string = "\xED\xA0\x80";
+    string_length = static_cast<size_t>(3);
+    index_pointer = 0;
+    code_point_value = 0;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_utf8_next(invalid_string, string_length,
+            &index_pointer, &code_point_value, ft_nullptr));
+    FT_ASSERT_EQ(static_cast<size_t>(0), index_pointer);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_utf8_next_detects_truncated_sequence, "ft_utf8_next rejects truncated multibyte sequences")
+{
+    const char *invalid_string;
+    size_t string_length;
+    size_t index_pointer;
+    uint32_t code_point_value;
+
+    invalid_string = "\xE2\x82";
+    string_length = static_cast<size_t>(2);
+    index_pointer = 0;
+    code_point_value = 0;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_utf8_next(invalid_string, string_length,
+            &index_pointer, &code_point_value, ft_nullptr));
+    FT_ASSERT_EQ(static_cast<size_t>(0), index_pointer);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_utf8_next_null_pointer_guard, "ft_utf8_next validates pointers before decoding")
+{
+    size_t index_pointer;
+    uint32_t code_point_value;
+
+    index_pointer = 0;
+    code_point_value = 0;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_utf8_next(ft_nullptr, static_cast<size_t>(0),
+            &index_pointer, &code_point_value, ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_utf8_encode_rejects_surrogate, "ft_utf8_encode rejects utf16 surrogate values")
+{
+    char buffer[4];
+
+    buffer[0] = '\0';
+    buffer[1] = '\0';
+    buffer[2] = '\0';
+    buffer[3] = '\0';
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_utf8_encode(0xD800, buffer, sizeof(buffer), ft_nullptr));
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_utf8_transform_alloc_propagates_hook_error, "ft_utf8_transform_alloc surfaces hook produced invalid code point")
+{
+    char *transformed_string;
+
+    transformed_string = ft_nullptr;
+    ft_errno = ER_SUCCESS;
+    FT_ASSERT_EQ(FT_FAILURE, ft_utf8_transform_alloc("abc", &transformed_string,
+            ft_utf8_test_invalid_hook));
+    FT_ASSERT_EQ(ft_nullptr, transformed_string);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}


### PR DESCRIPTION
## Summary
- adjust the futex wrappers to use long syscall results so conversion warnings no longer break the build
- harden the UTF-8 helpers to reject surrogate/out-of-range code points, require terminator space, and preserve ft_errno on transform failures
- rename shadowing identifiers in the function wrapper and pair helpers to satisfy -Wshadow

## Testing
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68e1562dbcc88331b3f53fce28749d91