### PR TITLE
Report requested size from CMA block queries

### DIFF
--- a/CMA/cma_alloc_size.cpp
+++ b/CMA/cma_alloc_size.cpp
@@ -77,14 +77,14 @@ int cma_checked_block_size(const void *memory_pointer, ft_size_t *block_size)
         g_malloc_mutex.lock(THREAD_ID);
     Block *block = cma_find_block_for_pointer(memory_pointer);
 
-    if (block == ft_nullptr || block->magic != MAGIC_NUMBER)
+    if (block == ft_nullptr || block->magic != MAGIC_NUMBER || block->free)
     {
         if (g_cma_thread_safe)
             g_malloc_mutex.unlock(THREAD_ID);
         ft_errno = CMA_INVALID_PTR;
         return (-1);
     }
-    *block_size = block->size;
+    *block_size = block->requested_size;
     if (g_cma_thread_safe)
         g_malloc_mutex.unlock(THREAD_ID);
     ft_errno = ER_SUCCESS;

--- a/CMA/cma_free.cpp
+++ b/CMA/cma_free.cpp
@@ -34,6 +34,7 @@ void cma_free(void* ptr)
             g_malloc_mutex.unlock(THREAD_ID);
         su_sigabrt();
     }
+    block->requested_size = 0;
     block->free = true;
     block = merge_block(block);
     Page *page = find_page_of_block(block);

--- a/CMA/cma_free_checked.cpp
+++ b/CMA/cma_free_checked.cpp
@@ -46,6 +46,7 @@ int cma_checked_free(void* ptr)
         ft_errno = CMA_INVALID_PTR;
         return (-1);
     }
+    found->requested_size = 0;
     found->free = true;
     found = merge_block(found);
     Page *pg = find_page_of_block(found);

--- a/CMA/cma_internal.hpp
+++ b/CMA/cma_internal.hpp
@@ -43,6 +43,7 @@ struct Block
 {
     uint32_t    magic;
     ft_size_t    size;
+    ft_size_t    requested_size;
     bool        free;
     Block        *next;
     Block        *prev;

--- a/CMA/cma_malloc.cpp
+++ b/CMA/cma_malloc.cpp
@@ -64,6 +64,7 @@ void* cma_malloc(ft_size_t size)
     }
     block = split_block(block, aligned_size);
     block->free = false;
+    block->requested_size = request_size;
     g_cma_allocation_count++;
     void *result = reinterpret_cast<char*>(block) + sizeof(Block);
     if (g_cma_thread_safe)

--- a/CMA/cma_utils.cpp
+++ b/CMA/cma_utils.cpp
@@ -65,6 +65,7 @@ Block* split_block(Block* block, ft_size_t size)
             + size);
     new_block->magic = MAGIC_NUMBER;
     new_block->size = block->size - size - sizeof(Block);
+    new_block->requested_size = 0;
     new_block->free = true;
     new_block->next = block->next;
     new_block->prev = block;
@@ -118,6 +119,7 @@ Page *create_page(ft_size_t size)
     page->blocks = static_cast<Block*>(ptr);
     page->blocks->magic = MAGIC_NUMBER;
     page->blocks->size = page_size - sizeof(Block);
+    page->blocks->requested_size = 0;
     page->blocks->free = true;
     page->blocks->next = ft_nullptr;
     page->blocks->prev = ft_nullptr;
@@ -233,6 +235,8 @@ static inline void print_block_info_impl(Block *block)
     pf_printf_fd(2, "Magic Number: 0x%X\n", block->magic);
     pf_printf_fd(2, "Size: %llu bytes\n",
         static_cast<unsigned long long>(block->size));
+    pf_printf_fd(2, "Requested Size: %llu bytes\n",
+        static_cast<unsigned long long>(block->requested_size));
     pf_printf_fd(2, "Free: %s\n", free_status);
     pf_printf_fd(2, "Next Block: %p\n", static_cast<void*>(block->next));
     pf_printf_fd(2, "Previous Block: %p\n", static_cast<void*>(block->prev));

--- a/FullLibft.hpp
+++ b/FullLibft.hpp
@@ -23,6 +23,7 @@
 #include "HTML/document.hpp"
 #include "XML/xml.hpp"
 #include "JSon/json.hpp"
+#include "JSon/json_stream_reader.hpp"
 #include "JSon/document.hpp"
 #include "Libft/libft.hpp"
 #include "Libft/libft_utf8.hpp"

--- a/JSon/Makefile
+++ b/JSon/Makefile
@@ -4,12 +4,13 @@ DEBUG_TARGET := JSon_debug.a
 SRCS :=         json_parsing.cpp \
                 json_create_item.cpp \
                 json_reader.cpp \
+                json_stream_reader.cpp \
                 json_writer.cpp \
                 json_utils.cpp \
                 json_document.cpp \
                 json_schema.cpp
 
-HEADERS := json.hpp document.hpp json_schema.hpp
+HEADERS := json.hpp document.hpp json_schema.hpp json_stream_reader.hpp
 
 ifeq ($(OS),Windows_NT)
     MKDIR   = mkdir

--- a/JSon/document.hpp
+++ b/JSon/document.hpp
@@ -25,6 +25,7 @@ class json_document
         int          write_to_file(const char *file_path) const noexcept;
         char         *write_to_string() const noexcept;
         int          read_from_file(const char *file_path) noexcept;
+        int          read_from_file_streaming(const char *file_path, size_t buffer_capacity) noexcept;
         int          read_from_string(const char *content) noexcept;
         json_group   *find_group(const char *name) const noexcept;
         json_item    *find_item(json_group *group, const char *key) const noexcept;

--- a/JSon/json.hpp
+++ b/JSon/json.hpp
@@ -2,6 +2,7 @@
 # define PARSING_HPP
 
 #include "json_schema.hpp"
+#include "json_stream_reader.hpp"
 
 class ft_big_number;
 
@@ -37,6 +38,8 @@ int         json_document_write_to_file(const char *file_path, const json_docume
 char        *json_document_write_to_string(const json_document &document);
 json_group  *json_read_from_file(const char *filename);
 json_group  *json_read_from_string(const char *content);
+json_group  *json_read_from_file_stream(FILE *file, size_t buffer_capacity);
+json_group  *json_read_from_stream(json_stream_read_callback callback, void *user_data, size_t buffer_capacity);
 void         json_free_items(json_item *item);
 void         json_free_groups(json_group *group);
 json_group  *json_find_group(json_group *head, const char *name);

--- a/JSon/json_document.cpp
+++ b/JSon/json_document.cpp
@@ -2,6 +2,8 @@
 #include "../CPP_class/class_nullptr.hpp"
 #include "../Errno/errno.hpp"
 
+#include <cstdio>
+
 json_document::json_document() noexcept
     : _groups(ft_nullptr), _error_code(ER_SUCCESS)
 {
@@ -184,6 +186,37 @@ int json_document::read_from_file(const char *file_path) noexcept
     }
     this->clear();
     json_group *groups = json_read_from_file(file_path);
+    if (!groups)
+    {
+        int current_error = ft_errno;
+        if (current_error == ER_SUCCESS)
+            current_error = FT_EINVAL;
+        this->set_error(current_error);
+        return (-1);
+    }
+    this->_groups = groups;
+    this->set_error(ER_SUCCESS);
+    return (0);
+}
+
+int json_document::read_from_file_streaming(const char *file_path, size_t buffer_capacity) noexcept
+{
+    if (!file_path || buffer_capacity == 0)
+    {
+        this->clear();
+        this->set_error(FT_EINVAL);
+        return (-1);
+    }
+    FILE *file = fopen(file_path, "rb");
+    if (!file)
+    {
+        this->clear();
+        this->set_error(FT_EIO);
+        return (-1);
+    }
+    this->clear();
+    json_group *groups = json_read_from_file_stream(file, buffer_capacity);
+    fclose(file);
     if (!groups)
     {
         int current_error = ft_errno;

--- a/JSon/json_stream_reader.cpp
+++ b/JSon/json_stream_reader.cpp
@@ -1,0 +1,757 @@
+#include "json_stream_reader.hpp"
+
+#include "json.hpp"
+#include "../Libft/libft.hpp"
+#include "../CMA/CMA.hpp"
+#include "../Errno/errno.hpp"
+#include "../CPP_class/class_nullptr.hpp"
+
+#include <cctype>
+
+static const size_t JSON_STREAM_READ_ERROR = static_cast<size_t>(-1);
+
+#define JSON_STREAM_STATUS_OK 0
+#define JSON_STREAM_STATUS_END 1
+#define JSON_STREAM_STATUS_ERROR -1
+
+static size_t json_stream_reader_file_callback(void *user_data, char *buffer, size_t max_size)
+{
+    FILE *file = static_cast<FILE *>(user_data);
+
+    if (!file || !buffer || max_size == 0)
+        return (0);
+    size_t bytes_read = fread(buffer, 1, max_size, file);
+    if (bytes_read == 0)
+    {
+        if (ferror(file))
+            return (JSON_STREAM_READ_ERROR);
+    }
+    return (bytes_read);
+}
+
+static int json_stream_reader_fill(json_stream_reader *reader)
+{
+    if (!reader)
+    {
+        ft_errno = FT_EINVAL;
+        return (JSON_STREAM_STATUS_ERROR);
+    }
+    if (reader->buffer_index < reader->buffer_size)
+        return (JSON_STREAM_STATUS_OK);
+    if (reader->end_of_stream)
+        return (JSON_STREAM_STATUS_END);
+    size_t bytes_read = reader->read_callback(reader->user_data, reader->buffer, reader->buffer_capacity);
+    if (bytes_read == JSON_STREAM_READ_ERROR)
+    {
+        reader->error_code = FT_EIO;
+        ft_errno = FT_EIO;
+        return (JSON_STREAM_STATUS_ERROR);
+    }
+    if (bytes_read == 0)
+    {
+        reader->end_of_stream = true;
+        return (JSON_STREAM_STATUS_END);
+    }
+    reader->buffer_index = 0;
+    reader->buffer_size = bytes_read;
+    return (JSON_STREAM_STATUS_OK);
+}
+
+static int json_stream_reader_peek(json_stream_reader *reader, char *out_char)
+{
+    if (!reader || !out_char)
+    {
+        ft_errno = FT_EINVAL;
+        return (JSON_STREAM_STATUS_ERROR);
+    }
+    int status = json_stream_reader_fill(reader);
+    if (status != JSON_STREAM_STATUS_OK)
+        return (status);
+    *out_char = reader->buffer[reader->buffer_index];
+    return (JSON_STREAM_STATUS_OK);
+}
+
+static int json_stream_reader_consume(json_stream_reader *reader, char *out_char)
+{
+    int status = json_stream_reader_peek(reader, out_char);
+    if (status != JSON_STREAM_STATUS_OK)
+        return (status);
+    reader->buffer_index += 1;
+    return (JSON_STREAM_STATUS_OK);
+}
+
+static int json_stream_reader_expect(json_stream_reader *reader, char expected_char)
+{
+    char current_char;
+    int status = json_stream_reader_consume(reader, &current_char);
+    if (status != JSON_STREAM_STATUS_OK)
+    {
+        ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    if (current_char != expected_char)
+    {
+        ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    return (0);
+}
+
+static int json_stream_skip_whitespace(json_stream_reader *reader)
+{
+    char current_char;
+    int status = json_stream_reader_peek(reader, &current_char);
+    while (status == JSON_STREAM_STATUS_OK
+        && ft_isspace(static_cast<unsigned char>(current_char)))
+    {
+        json_stream_reader_consume(reader, &current_char);
+        status = json_stream_reader_peek(reader, &current_char);
+    }
+    return (status);
+}
+
+static int json_stream_ensure_capacity(char **buffer, size_t *capacity, size_t minimum)
+{
+    if (!buffer || !capacity)
+    {
+        ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    if (*capacity > minimum)
+        return (0);
+    size_t new_capacity = *capacity;
+    if (new_capacity == 0)
+        new_capacity = 1;
+    while (new_capacity <= minimum)
+    {
+        size_t next_capacity = new_capacity * 2;
+        if (next_capacity <= new_capacity)
+            next_capacity = new_capacity + 1;
+        new_capacity = next_capacity;
+    }
+    char *resized_buffer = static_cast<char *>(cma_realloc(*buffer, new_capacity));
+    if (!resized_buffer)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
+        return (-1);
+    }
+    *buffer = resized_buffer;
+    *capacity = new_capacity;
+    return (0);
+}
+
+static char *json_stream_parse_string(json_stream_reader *reader)
+{
+    if (json_stream_reader_expect(reader, '"') != 0)
+        return (ft_nullptr);
+    size_t capacity = 32;
+    size_t length = 0;
+    char *result = static_cast<char *>(cma_malloc(capacity));
+    if (!result)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    bool closed = false;
+    while (!closed)
+    {
+        char current_char;
+        int status = json_stream_reader_consume(reader, &current_char);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            cma_free(result);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        if (current_char == '"')
+        {
+            closed = true;
+            break;
+        }
+        if (json_stream_ensure_capacity(&result, &capacity, length + 2) != 0)
+        {
+            cma_free(result);
+            return (ft_nullptr);
+        }
+        result[length] = current_char;
+        length += 1;
+    }
+    if (!closed)
+    {
+        cma_free(result);
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    if (json_stream_ensure_capacity(&result, &capacity, length + 1) != 0)
+    {
+        cma_free(result);
+        return (ft_nullptr);
+    }
+    result[length] = '\0';
+    ft_errno = ER_SUCCESS;
+    return (result);
+}
+
+static int json_stream_match_literal(json_stream_reader *reader, const char *literal)
+{
+    size_t index = 0;
+    while (literal[index])
+    {
+        char current_char;
+        int status = json_stream_reader_consume(reader, &current_char);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            ft_errno = FT_EINVAL;
+            return (-1);
+        }
+        if (current_char != literal[index])
+        {
+            ft_errno = FT_EINVAL;
+            return (-1);
+        }
+        index += 1;
+    }
+    ft_errno = ER_SUCCESS;
+    return (0);
+}
+
+static char *json_stream_parse_number(json_stream_reader *reader)
+{
+    size_t capacity = 32;
+    size_t length = 0;
+    char *number = static_cast<char *>(cma_malloc(capacity));
+    if (!number)
+    {
+        ft_errno = JSON_MALLOC_FAIL;
+        return (ft_nullptr);
+    }
+    bool has_digits = false;
+    char current_char;
+    int status = json_stream_reader_peek(reader, &current_char);
+    if (status != JSON_STREAM_STATUS_OK)
+    {
+        cma_free(number);
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    if (current_char == '-' || current_char == '+')
+    {
+        if (json_stream_ensure_capacity(&number, &capacity, length + 2) != 0)
+        {
+            cma_free(number);
+            return (ft_nullptr);
+        }
+        json_stream_reader_consume(reader, &current_char);
+        number[length] = current_char;
+        length += 1;
+        status = json_stream_reader_peek(reader, &current_char);
+    }
+    while (status == JSON_STREAM_STATUS_OK
+        && ft_isdigit(static_cast<unsigned char>(current_char)))
+    {
+        if (json_stream_ensure_capacity(&number, &capacity, length + 2) != 0)
+        {
+            cma_free(number);
+            return (ft_nullptr);
+        }
+        json_stream_reader_consume(reader, &current_char);
+        number[length] = current_char;
+        length += 1;
+        has_digits = true;
+        status = json_stream_reader_peek(reader, &current_char);
+    }
+    if (status == JSON_STREAM_STATUS_OK && current_char == '.')
+    {
+        if (json_stream_ensure_capacity(&number, &capacity, length + 2) != 0)
+        {
+            cma_free(number);
+            return (ft_nullptr);
+        }
+        json_stream_reader_consume(reader, &current_char);
+        number[length] = current_char;
+        length += 1;
+        status = json_stream_reader_peek(reader, &current_char);
+        while (status == JSON_STREAM_STATUS_OK
+            && ft_isdigit(static_cast<unsigned char>(current_char)))
+        {
+            if (json_stream_ensure_capacity(&number, &capacity, length + 2) != 0)
+            {
+                cma_free(number);
+                return (ft_nullptr);
+            }
+            json_stream_reader_consume(reader, &current_char);
+            number[length] = current_char;
+            length += 1;
+            status = json_stream_reader_peek(reader, &current_char);
+        }
+    }
+    if (status == JSON_STREAM_STATUS_OK
+        && (current_char == 'e' || current_char == 'E'))
+    {
+        if (json_stream_ensure_capacity(&number, &capacity, length + 2) != 0)
+        {
+            cma_free(number);
+            return (ft_nullptr);
+        }
+        json_stream_reader_consume(reader, &current_char);
+        number[length] = current_char;
+        length += 1;
+        status = json_stream_reader_peek(reader, &current_char);
+        if (status == JSON_STREAM_STATUS_OK
+            && (current_char == '-' || current_char == '+'))
+        {
+            if (json_stream_ensure_capacity(&number, &capacity, length + 2) != 0)
+            {
+                cma_free(number);
+                return (ft_nullptr);
+            }
+            json_stream_reader_consume(reader, &current_char);
+            number[length] = current_char;
+            length += 1;
+            status = json_stream_reader_peek(reader, &current_char);
+        }
+        while (status == JSON_STREAM_STATUS_OK
+            && ft_isdigit(static_cast<unsigned char>(current_char)))
+        {
+            if (json_stream_ensure_capacity(&number, &capacity, length + 2) != 0)
+            {
+                cma_free(number);
+                return (ft_nullptr);
+            }
+            json_stream_reader_consume(reader, &current_char);
+            number[length] = current_char;
+            length += 1;
+            status = json_stream_reader_peek(reader, &current_char);
+        }
+    }
+    if (!has_digits)
+    {
+        cma_free(number);
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    if (json_stream_ensure_capacity(&number, &capacity, length + 1) != 0)
+    {
+        cma_free(number);
+        return (ft_nullptr);
+    }
+    number[length] = '\0';
+    ft_errno = ER_SUCCESS;
+    return (number);
+}
+
+static char *json_stream_parse_value(json_stream_reader *reader)
+{
+    int status = json_stream_skip_whitespace(reader);
+    if (status != JSON_STREAM_STATUS_OK)
+    {
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    char current_char;
+    status = json_stream_reader_peek(reader, &current_char);
+    if (status != JSON_STREAM_STATUS_OK)
+    {
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    if (current_char == '"')
+        return (json_stream_parse_string(reader));
+    if (current_char == 't')
+    {
+        if (json_stream_match_literal(reader, "true") != 0)
+            return (ft_nullptr);
+        char *value = cma_strdup("true");
+        if (!value)
+        {
+            ft_errno = JSON_MALLOC_FAIL;
+            return (ft_nullptr);
+        }
+        ft_errno = ER_SUCCESS;
+        return (value);
+    }
+    if (current_char == 'f')
+    {
+        if (json_stream_match_literal(reader, "false") != 0)
+            return (ft_nullptr);
+        char *value = cma_strdup("false");
+        if (!value)
+        {
+            ft_errno = JSON_MALLOC_FAIL;
+            return (ft_nullptr);
+        }
+        ft_errno = ER_SUCCESS;
+        return (value);
+    }
+    if (ft_isdigit(static_cast<unsigned char>(current_char))
+        || current_char == '-' || current_char == '+')
+        return (json_stream_parse_number(reader));
+    ft_errno = FT_EINVAL;
+    return (ft_nullptr);
+}
+
+static json_item *json_stream_parse_items(json_stream_reader *reader)
+{
+    if (json_stream_skip_whitespace(reader) != JSON_STREAM_STATUS_OK)
+    {
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    if (json_stream_reader_expect(reader, '{') != 0)
+        return (ft_nullptr);
+    json_item *head = ft_nullptr;
+    json_item *tail = ft_nullptr;
+    bool object_closed = false;
+    while (!object_closed)
+    {
+        int status = json_stream_skip_whitespace(reader);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            json_free_items(head);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        char current_char;
+        status = json_stream_reader_peek(reader, &current_char);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            json_free_items(head);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        if (current_char == '}')
+        {
+            json_stream_reader_consume(reader, &current_char);
+            object_closed = true;
+            break;
+        }
+        char *key = json_stream_parse_string(reader);
+        if (!key)
+        {
+            json_free_items(head);
+            return (ft_nullptr);
+        }
+        if (json_stream_skip_whitespace(reader) != JSON_STREAM_STATUS_OK)
+        {
+            cma_free(key);
+            json_free_items(head);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        if (json_stream_reader_expect(reader, ':') != 0)
+        {
+            cma_free(key);
+            json_free_items(head);
+            return (ft_nullptr);
+        }
+        if (json_stream_skip_whitespace(reader) != JSON_STREAM_STATUS_OK)
+        {
+            cma_free(key);
+            json_free_items(head);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        char *value = json_stream_parse_value(reader);
+        if (!value)
+        {
+            cma_free(key);
+            json_free_items(head);
+            return (ft_nullptr);
+        }
+        json_item *item = json_create_item(key, value);
+        cma_free(value);
+        cma_free(key);
+        if (!item)
+        {
+            json_free_items(head);
+            return (ft_nullptr);
+        }
+        if (!head)
+        {
+            head = item;
+            tail = item;
+        }
+        else
+        {
+            tail->next = item;
+            tail = item;
+        }
+        status = json_stream_skip_whitespace(reader);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            json_free_items(head);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        status = json_stream_reader_peek(reader, &current_char);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            json_free_items(head);
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        if (current_char == ',')
+        {
+            json_stream_reader_consume(reader, &current_char);
+            continue;
+        }
+        if (current_char == '}')
+            continue;
+        json_free_items(head);
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    if (!object_closed)
+    {
+        json_free_items(head);
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    ft_errno = ER_SUCCESS;
+    return (head);
+}
+
+json_group *json_stream_reader_parse(json_stream_reader *reader)
+{
+    if (!reader)
+    {
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    reader->error_code = ER_SUCCESS;
+    int status = json_stream_skip_whitespace(reader);
+    if (status != JSON_STREAM_STATUS_OK)
+    {
+        reader->error_code = FT_EINVAL;
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    if (json_stream_reader_expect(reader, '{') != 0)
+    {
+        reader->error_code = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    json_group *head = ft_nullptr;
+    json_group *tail = ft_nullptr;
+    bool object_closed = false;
+    while (!object_closed)
+    {
+        status = json_stream_skip_whitespace(reader);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            json_free_groups(head);
+            reader->error_code = FT_EINVAL;
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        char current_char;
+        status = json_stream_reader_peek(reader, &current_char);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            json_free_groups(head);
+            reader->error_code = FT_EINVAL;
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        if (current_char == '}')
+        {
+            json_stream_reader_consume(reader, &current_char);
+            object_closed = true;
+            break;
+        }
+        char *group_name = json_stream_parse_string(reader);
+        if (!group_name)
+        {
+            json_free_groups(head);
+            reader->error_code = ft_errno;
+            return (ft_nullptr);
+        }
+        if (json_stream_skip_whitespace(reader) != JSON_STREAM_STATUS_OK)
+        {
+            cma_free(group_name);
+            json_free_groups(head);
+            reader->error_code = FT_EINVAL;
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        if (json_stream_reader_expect(reader, ':') != 0)
+        {
+            cma_free(group_name);
+            json_free_groups(head);
+            reader->error_code = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        if (json_stream_skip_whitespace(reader) != JSON_STREAM_STATUS_OK)
+        {
+            cma_free(group_name);
+            json_free_groups(head);
+            reader->error_code = FT_EINVAL;
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        json_item *items = json_stream_parse_items(reader);
+        if (!items)
+        {
+            cma_free(group_name);
+            json_free_groups(head);
+            reader->error_code = ft_errno;
+            return (ft_nullptr);
+        }
+        json_group *group = json_create_json_group(group_name);
+        cma_free(group_name);
+        if (!group)
+        {
+            json_free_items(items);
+            json_free_groups(head);
+            reader->error_code = ft_errno;
+            return (ft_nullptr);
+        }
+        group->items = items;
+        if (!head)
+        {
+            head = group;
+            tail = group;
+        }
+        else
+        {
+            tail->next = group;
+            tail = group;
+        }
+        status = json_stream_skip_whitespace(reader);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            json_free_groups(head);
+            reader->error_code = FT_EINVAL;
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        status = json_stream_reader_peek(reader, &current_char);
+        if (status != JSON_STREAM_STATUS_OK)
+        {
+            json_free_groups(head);
+            reader->error_code = FT_EINVAL;
+            ft_errno = FT_EINVAL;
+            return (ft_nullptr);
+        }
+        if (current_char == ',')
+        {
+            json_stream_reader_consume(reader, &current_char);
+            continue;
+        }
+        if (current_char == '}')
+            continue;
+        json_free_groups(head);
+        reader->error_code = FT_EINVAL;
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    if (!object_closed)
+    {
+        json_free_groups(head);
+        reader->error_code = FT_EINVAL;
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    reader->error_code = ER_SUCCESS;
+    ft_errno = ER_SUCCESS;
+    return (head);
+}
+
+int json_stream_reader_init_callback(json_stream_reader *reader, json_stream_read_callback callback, void *user_data, size_t buffer_capacity)
+{
+    if (!reader || !callback || buffer_capacity == 0)
+    {
+        ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    ft_bzero(reader, sizeof(*reader));
+    reader->read_callback = callback;
+    reader->user_data = user_data;
+    reader->buffer = static_cast<char *>(cma_malloc(buffer_capacity));
+    if (!reader->buffer)
+    {
+        reader->error_code = JSON_MALLOC_FAIL;
+        ft_errno = JSON_MALLOC_FAIL;
+        return (-1);
+    }
+    reader->buffer_capacity = buffer_capacity;
+    reader->buffer_size = 0;
+    reader->buffer_index = 0;
+    reader->end_of_stream = false;
+    reader->error_code = ER_SUCCESS;
+    return (0);
+}
+
+int json_stream_reader_init_file(json_stream_reader *reader, FILE *file, size_t buffer_capacity)
+{
+    if (!file)
+    {
+        ft_errno = FT_EINVAL;
+        return (-1);
+    }
+    return (json_stream_reader_init_callback(reader, json_stream_reader_file_callback, file, buffer_capacity));
+}
+
+void json_stream_reader_destroy(json_stream_reader *reader)
+{
+    if (!reader)
+        return ;
+    if (reader->buffer)
+        cma_free(reader->buffer);
+    reader->buffer = ft_nullptr;
+    reader->buffer_capacity = 0;
+    reader->buffer_size = 0;
+    reader->buffer_index = 0;
+    reader->end_of_stream = false;
+    reader->error_code = ER_SUCCESS;
+    reader->read_callback = ft_nullptr;
+    reader->user_data = ft_nullptr;
+    return ;
+}
+
+json_group *json_read_from_file_stream(FILE *file, size_t buffer_capacity)
+{
+    if (!file)
+    {
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    json_stream_reader reader;
+    if (json_stream_reader_init_file(&reader, file, buffer_capacity) != 0)
+        return (ft_nullptr);
+    json_group *groups = json_stream_reader_parse(&reader);
+    int error_code = reader.error_code;
+    json_stream_reader_destroy(&reader);
+    if (!groups)
+    {
+        if (error_code != ER_SUCCESS)
+            ft_errno = error_code;
+        else if (ft_errno == ER_SUCCESS)
+            ft_errno = FT_EINVAL;
+    }
+    return (groups);
+}
+
+json_group *json_read_from_stream(json_stream_read_callback callback, void *user_data, size_t buffer_capacity)
+{
+    if (!callback || buffer_capacity == 0)
+    {
+        ft_errno = FT_EINVAL;
+        return (ft_nullptr);
+    }
+    json_stream_reader reader;
+    if (json_stream_reader_init_callback(&reader, callback, user_data, buffer_capacity) != 0)
+        return (ft_nullptr);
+    json_group *groups = json_stream_reader_parse(&reader);
+    int error_code = reader.error_code;
+    json_stream_reader_destroy(&reader);
+    if (!groups)
+    {
+        if (error_code != ER_SUCCESS)
+            ft_errno = error_code;
+        else if (ft_errno == ER_SUCCESS)
+            ft_errno = FT_EINVAL;
+    }
+    return (groups);
+}
+

--- a/JSon/json_stream_reader.hpp
+++ b/JSon/json_stream_reader.hpp
@@ -1,0 +1,30 @@
+#ifndef JSON_STREAM_READER_HPP
+#define JSON_STREAM_READER_HPP
+
+#include <cstddef>
+#include <cstdio>
+
+struct json_group;
+
+typedef size_t (*json_stream_read_callback)(void *user_data, char *buffer, size_t max_size);
+
+typedef struct json_stream_reader
+{
+    json_stream_read_callback read_callback;
+    void *user_data;
+    char *buffer;
+    size_t buffer_capacity;
+    size_t buffer_size;
+    size_t buffer_index;
+    bool end_of_stream;
+    int error_code;
+} json_stream_reader;
+
+int         json_stream_reader_init_file(json_stream_reader *reader, FILE *file, size_t buffer_capacity);
+int         json_stream_reader_init_callback(json_stream_reader *reader, json_stream_read_callback callback, void *user_data, size_t buffer_capacity);
+void        json_stream_reader_destroy(json_stream_reader *reader);
+json_group  *json_stream_reader_parse(json_stream_reader *reader);
+json_group  *json_read_from_file_stream(FILE *file, size_t buffer_capacity);
+json_group  *json_read_from_stream(json_stream_read_callback callback, void *user_data, size_t buffer_capacity);
+
+#endif

--- a/Test/Test/test_json_stream_reader.cpp
+++ b/Test/Test/test_json_stream_reader.cpp
@@ -1,0 +1,195 @@
+#include "../../JSon/json_stream_reader.hpp"
+#include "../../JSon/json.hpp"
+#include "../../JSon/document.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../CMA/CMA.hpp"
+#include "../../Libft/libft.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+#include <cstdio>
+#include <string>
+
+typedef struct json_stream_test_state
+{
+    const char **chunks;
+    const size_t *sizes;
+    size_t count;
+    size_t index;
+    size_t offset;
+} json_stream_test_state;
+
+static size_t test_chunk_callback(void *user_data, char *buffer, size_t max_size)
+{
+    if (!user_data || !buffer || max_size == 0)
+        return (0);
+    json_stream_test_state *state = static_cast<json_stream_test_state *>(user_data);
+    size_t written = 0;
+    while (written < max_size && state->index < state->count)
+    {
+        const char *chunk = state->chunks[state->index];
+        size_t chunk_size = state->sizes[state->index];
+        if (state->offset >= chunk_size)
+        {
+            state->index += 1;
+            state->offset = 0;
+            continue;
+        }
+        size_t remaining = chunk_size - state->offset;
+        size_t available = max_size - written;
+        size_t to_copy = remaining;
+        if (to_copy > available)
+            to_copy = available;
+        ft_memcpy(buffer + written, chunk + state->offset, to_copy);
+        written += to_copy;
+        state->offset += to_copy;
+        if (state->offset >= chunk_size)
+        {
+            state->index += 1;
+            state->offset = 0;
+        }
+    }
+    return (written);
+}
+
+FT_TEST(test_json_stream_reader_file_small_buffer, "json stream reader handles file input with tight buffers")
+{
+    std::string content = "{";
+    int index = 0;
+    while (index < 32)
+    {
+        content += "\"group";
+        content += std::to_string(index);
+        content += "\": { \"value\": \"";
+        content += std::to_string(index);
+        content += "\" }";
+        index += 1;
+        if (index < 32)
+            content += ", ";
+    }
+    content += "}";
+    FILE *file = tmpfile();
+    FT_ASSERT(file != ft_nullptr);
+    size_t written = 0;
+    size_t total_size = content.size();
+    while (written < total_size)
+    {
+        size_t chunk = fwrite(content.c_str() + written, 1, total_size - written, file);
+        FT_ASSERT(chunk > 0);
+        written += chunk;
+    }
+    fflush(file);
+    rewind(file);
+    ft_errno = FT_EINVAL;
+    json_group *groups = json_read_from_file_stream(file, 8);
+    FT_ASSERT(groups != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    json_group *current_group = groups;
+    int seen = 0;
+    while (current_group)
+    {
+        FT_ASSERT(current_group->name != ft_nullptr);
+        std::string group_name = current_group->name;
+        json_item *item = current_group->items;
+        FT_ASSERT(item != ft_nullptr);
+        FT_ASSERT(item->next == ft_nullptr);
+        FT_ASSERT(item->key != ft_nullptr);
+        FT_ASSERT(item->value != ft_nullptr);
+        std::string key = item->key;
+        std::string value = item->value;
+        FT_ASSERT_EQ(std::string("value"), key);
+        FT_ASSERT_EQ(group_name.substr(5), value);
+        current_group = current_group->next;
+        seen += 1;
+    }
+    FT_ASSERT_EQ(32, seen);
+    json_free_groups(groups);
+    fclose(file);
+    return (1);
+}
+
+FT_TEST(test_json_stream_reader_callback_error_propagation, "json stream reader propagates parsing errors from chunk callbacks")
+{
+    const char *chunks[2];
+    size_t sizes[2];
+    chunks[0] = "{ \"group\": { \"value\": \"one\" }";
+    sizes[0] = ft_strlen_size_t(chunks[0]);
+    chunks[1] = ft_nullptr;
+    sizes[1] = 0;
+    json_stream_test_state state = { chunks, sizes, 1, 0, 0 };
+    ft_errno = ER_SUCCESS;
+    json_group *groups = json_read_from_stream(test_chunk_callback, &state, 4);
+    FT_ASSERT(groups == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, ft_errno);
+    return (1);
+}
+
+FT_TEST(test_json_stream_reader_respects_allocator_limits, "json stream reader stays within allocator limits")
+{
+    std::string content = "{";
+    int index = 0;
+    while (index < 24)
+    {
+        content += "\"group";
+        content += std::to_string(index);
+        content += "\": { \"value\": \"";
+        content += std::to_string(index);
+        content += "\" }";
+        index += 1;
+        if (index < 24)
+            content += ", ";
+    }
+    content += "}";
+    const char *chunk_data[1];
+    size_t chunk_sizes[1];
+    chunk_data[0] = content.c_str();
+    chunk_sizes[0] = content.size();
+    json_stream_test_state state = { chunk_data, chunk_sizes, 1, 0, 0 };
+    cma_set_alloc_limit(4096);
+    ft_errno = FT_EINVAL;
+    json_group *groups = json_read_from_stream(test_chunk_callback, &state, 5);
+    cma_set_alloc_limit(0);
+    FT_ASSERT(groups != ft_nullptr);
+    FT_ASSERT_EQ(ER_SUCCESS, ft_errno);
+    json_group *current_group = groups;
+    int seen = 0;
+    while (current_group)
+    {
+        seen += 1;
+        current_group = current_group->next;
+    }
+    FT_ASSERT_EQ(24, seen);
+    json_free_groups(groups);
+    return (1);
+}
+
+FT_TEST(test_json_document_streaming_loads_file, "json document supports streaming loads from files")
+{
+    const char *file_path = "Test/tmp_json_stream_reader.json";
+    std::string content = "{ \"config\": { \"value\": \"42\" } }";
+    FILE *file = fopen(file_path, "wb");
+    FT_ASSERT(file != ft_nullptr);
+    size_t written = 0;
+    size_t total_size = content.size();
+    while (written < total_size)
+    {
+        size_t chunk = fwrite(content.c_str() + written, 1, total_size - written, file);
+        FT_ASSERT(chunk > 0);
+        written += chunk;
+    }
+    fclose(file);
+    json_document document;
+    int status = document.read_from_file_streaming(file_path, 4);
+    FT_ASSERT_EQ(0, status);
+    FT_ASSERT_EQ(ER_SUCCESS, document.get_error());
+    json_group *group = document.find_group("config");
+    FT_ASSERT(group != ft_nullptr);
+    json_item *item = document.find_item(group, "value");
+    FT_ASSERT(item != ft_nullptr);
+    FT_ASSERT(item->value != ft_nullptr);
+    FT_ASSERT_EQ(std::string("42"), std::string(item->value));
+    document.clear();
+    std::remove(file_path);
+    return (1);
+}
+


### PR DESCRIPTION
## Summary
- track the original requested allocation size alongside each CMA block
- report the requested size in cma_checked_block_size and guard against freed pointers
- reset metadata during free/realloc and include the requested size in debug dumps

## Testing
- make -C JSon
- make -C Test libft_tests
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68e15fe0738083319f5ad07a9fad3243