### PR TITLE
Add JSON pointer error handling tests

### DIFF
--- a/JSon/document.hpp
+++ b/JSon/document.hpp
@@ -29,6 +29,8 @@ class json_document
         int          read_from_string(const char *content) noexcept;
         json_group   *find_group(const char *name) const noexcept;
         json_item    *find_item(json_group *group, const char *key) const noexcept;
+        json_item    *find_item_by_pointer(const char *pointer) const noexcept;
+        const char   *get_value_by_pointer(const char *pointer) const noexcept;
         void         remove_group(const char *name) noexcept;
         void         remove_item(json_group *group, const char *key) noexcept;
         void         update_item(json_group *group, const char *key, const char *value) noexcept;

--- a/Test/Test/test_json_document.cpp
+++ b/Test/Test/test_json_document.cpp
@@ -1,0 +1,102 @@
+#include "../../JSon/document.hpp"
+#include "../../JSon/json.hpp"
+#include "../../Errno/errno.hpp"
+#include "../../CPP_class/class_nullptr.hpp"
+#include "../../System_utils/test_runner.hpp"
+
+#include <string>
+
+FT_TEST(test_json_document_find_item_by_pointer_success, "json document resolves pointers to items")
+{
+    json_document document;
+    json_group *group = document.create_group("config");
+    FT_ASSERT(group != ft_nullptr);
+    json_item *item = document.create_item("name", "value");
+    FT_ASSERT(item != ft_nullptr);
+    document.append_group(group);
+    document.add_item(group, item);
+    json_item *found_item = document.find_item_by_pointer("/config/name");
+    FT_ASSERT(found_item == item);
+    FT_ASSERT_EQ(ER_SUCCESS, document.get_error());
+    const char *value = document.get_value_by_pointer("/config/name");
+    FT_ASSERT(value != ft_nullptr);
+    FT_ASSERT_EQ(std::string("value"), std::string(value));
+    FT_ASSERT_EQ(ER_SUCCESS, document.get_error());
+    return (1);
+}
+
+FT_TEST(test_json_document_find_item_by_pointer_missing_path_sets_error, "json document reports missing pointer paths")
+{
+    json_document document;
+    json_group *group = document.create_group("config");
+    FT_ASSERT(group != ft_nullptr);
+    document.append_group(group);
+    json_item *missing = document.find_item_by_pointer("/missing/name");
+    FT_ASSERT(missing == ft_nullptr);
+    FT_ASSERT_EQ(MAP_KEY_NOT_FOUND, document.get_error());
+    return (1);
+}
+
+FT_TEST(test_json_document_pointer_unescapes_tokens, "json document pointer decoding supports escaped segments")
+{
+    json_document document;
+    json_group *group = document.create_group("config/advanced");
+    FT_ASSERT(group != ft_nullptr);
+    json_item *item = document.create_item("name~value", "42");
+    FT_ASSERT(item != ft_nullptr);
+    document.append_group(group);
+    document.add_item(group, item);
+    json_item *found_item = document.find_item_by_pointer("/config~1advanced/name~0value");
+    FT_ASSERT(found_item == item);
+    FT_ASSERT_EQ(ER_SUCCESS, document.get_error());
+    const char *value = document.get_value_by_pointer("/config~1advanced/name~0value");
+    FT_ASSERT(value != ft_nullptr);
+    FT_ASSERT_EQ(std::string("42"), std::string(value));
+    FT_ASSERT_EQ(ER_SUCCESS, document.get_error());
+    return (1);
+}
+
+FT_TEST(test_json_document_pointer_requires_leading_slash, "json document pointer requires a leading slash")
+{
+    json_document document;
+    json_group *group = document.create_group("config");
+    FT_ASSERT(group != ft_nullptr);
+    json_item *item = document.create_item("name", "value");
+    FT_ASSERT(item != ft_nullptr);
+    document.append_group(group);
+    document.add_item(group, item);
+    json_item *found_item = document.find_item_by_pointer("config/name");
+    FT_ASSERT(found_item == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, document.get_error());
+    return (1);
+}
+
+FT_TEST(test_json_document_pointer_rejects_empty_segment, "json document pointer rejects empty path segments")
+{
+    json_document document;
+    json_group *group = document.create_group("config");
+    FT_ASSERT(group != ft_nullptr);
+    json_item *item = document.create_item("name", "value");
+    FT_ASSERT(item != ft_nullptr);
+    document.append_group(group);
+    document.add_item(group, item);
+    json_item *found_item = document.find_item_by_pointer("/config//name");
+    FT_ASSERT(found_item == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, document.get_error());
+    return (1);
+}
+
+FT_TEST(test_json_document_pointer_invalid_escape_sets_error, "json document pointer invalid escapes set errors")
+{
+    json_document document;
+    json_group *group = document.create_group("config");
+    FT_ASSERT(group != ft_nullptr);
+    json_item *item = document.create_item("name", "value");
+    FT_ASSERT(item != ft_nullptr);
+    document.append_group(group);
+    document.add_item(group, item);
+    json_item *found_item = document.find_item_by_pointer("/config/~2name");
+    FT_ASSERT(found_item == ft_nullptr);
+    FT_ASSERT_EQ(FT_EINVAL, document.get_error());
+    return (1);
+}


### PR DESCRIPTION
## Summary
- add regression tests covering invalid JSON pointer formats (missing leading slash, empty segments, invalid escapes)

## Testing
- make -C Test
- ./Test/libft_tests

------
https://chatgpt.com/codex/tasks/task_e_68e26dae58d08331840060d849fd1817