### PR TITLE
Add guarded task scheduler metrics counters

### DIFF
--- a/Test/Test/test_pthread_task_scheduler_metrics.cpp
+++ b/Test/Test/test_pthread_task_scheduler_metrics.cpp
@@ -89,12 +89,18 @@ FT_TEST(test_task_scheduler_metrics_flow, "ft_task_scheduler tracks queue and wo
     queue_size = scheduler_instance.get_queue_size();
     FT_ASSERT_EQ(0, queue_size);
     FT_ASSERT_EQ(ER_SUCCESS, scheduler_instance.get_error());
+    FT_ASSERT_EQ(ft_errno, scheduler_instance.get_error());
     active_count = scheduler_instance.get_worker_active_count();
     FT_ASSERT_EQ(0, active_count);
     FT_ASSERT_EQ(ER_SUCCESS, scheduler_instance.get_error());
     idle_count = scheduler_instance.get_worker_idle_count();
     FT_ASSERT_EQ(1, idle_count);
     FT_ASSERT_EQ(ER_SUCCESS, scheduler_instance.get_error());
+    FT_ASSERT_EQ(ft_errno, scheduler_instance.get_error());
+    worker_total = scheduler_instance.get_worker_total_count();
+    FT_ASSERT_EQ(1, worker_total);
+    FT_ASSERT_EQ(ER_SUCCESS, scheduler_instance.get_error());
+    FT_ASSERT_EQ(ft_errno, scheduler_instance.get_error());
     return (1);
 }
 


### PR DESCRIPTION
## Summary
- guard task scheduler metrics with dedicated mutexes and replace atomic counters with coordinated updates
- expose helper routines that keep queue, scheduled, and worker counters synchronized inside existing critical sections
- extend the scheduler metrics test to assert errno propagation after queueing, delaying, and cancelling tasks

## Testing
- make test_pthread_task_scheduler_metrics *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_68e35fa395048331993fac2ed5e552fc