### PR TITLE
Improve HTTP streaming resilience to connection resets

### DIFF
--- a/API/api_http_plain.cpp
+++ b/API/api_http_plain.cpp
@@ -74,6 +74,13 @@ static bool api_http_should_retry_plain(int error_code)
 {
     if (api_http_is_recoverable_send_error(error_code))
         return (true);
+#ifdef _WIN32
+    if (error_code == (WSAECONNRESET + ERRNO_OFFSET))
+        return (true);
+#else
+    if (error_code == (ECONNRESET + ERRNO_OFFSET))
+        return (true);
+#endif
     if (error_code == SOCKET_RECEIVE_FAILED)
         return (true);
     if (error_code == SOCKET_CONNECT_FAILED)
@@ -1016,6 +1023,8 @@ bool api_http_execute_plain_streaming(
     int current_delay;
     int max_delay;
     int multiplier;
+    int allowed_attempts;
+    bool implicit_retry_added;
 
     max_attempts = api_retry_get_max_attempts(retry_policy);
     initial_delay = api_retry_get_initial_delay(retry_policy);
@@ -1023,7 +1032,9 @@ bool api_http_execute_plain_streaming(
     multiplier = api_retry_get_multiplier(retry_policy);
     current_delay = api_retry_prepare_delay(initial_delay, max_delay);
     attempt_index = 0;
-    while (attempt_index < max_attempts)
+    allowed_attempts = max_attempts;
+    implicit_retry_added = false;
+    while (attempt_index < allowed_attempts)
     {
         bool socket_ready;
         bool should_retry;
@@ -1050,9 +1061,14 @@ bool api_http_execute_plain_streaming(
         should_retry = api_http_should_retry_plain(error_code);
         if (!should_retry)
             return (false);
+        if (!implicit_retry_added && retry_policy == ft_nullptr)
+        {
+            allowed_attempts = 2;
+            implicit_retry_added = true;
+        }
         api_connection_pool_evict(connection_handle);
         attempt_index++;
-        if (attempt_index >= max_attempts)
+        if (attempt_index >= allowed_attempts)
             break ;
         if (current_delay > 0)
         {


### PR DESCRIPTION
## Summary
- drain the large-response test server's incoming request before writing the 2 MiB payload to avoid triggering kernel resets
- allow the plain and TLS streaming paths to grant a second attempt on recoverable transport errors when no retry policy is provided

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e3e59dbee88331bce612fb28bb35ff