### PR TITLE
Harden mutex wake handling and swap logger sink lock

### DIFF
--- a/Logger/logger_internal.hpp
+++ b/Logger/logger_internal.hpp
@@ -2,12 +2,12 @@
 #define LOGGER_INTERNAL_HPP
 
 #include <cstdarg>
+#include <pthread.h>
 #include "../Template/vector.hpp"
 #include "../CPP_class/class_string_class.hpp"
 #include "../Compatebility/compatebility_internal.hpp"
 #include "../Errno/errno.hpp"
 #include "logger.hpp"
-#include "../PThread/mutex.hpp"
 
 extern ft_logger *g_logger;
 extern t_log_level g_level;
@@ -38,7 +38,10 @@ struct s_network_sink
 };
 
 extern ft_vector<s_log_sink> g_sinks;
-extern pt_mutex g_sinks_mutex;
+extern pthread_mutex_t g_sinks_mutex;
+
+int logger_lock_sinks();
+int logger_unlock_sinks();
 
 void ft_log_rotate(s_file_sink *sink);
 void ft_file_sink(const char *message, void *user_data);

--- a/Logger/logger_log_add_sink.cpp
+++ b/Logger/logger_log_add_sink.cpp
@@ -13,8 +13,7 @@ int ft_log_add_sink(t_log_sink sink, void *user_data)
     s_log_sink entry;
     int final_error;
 
-    g_sinks_mutex.lock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_lock_sinks() != 0)
     {
         return (-1);
     }
@@ -24,8 +23,7 @@ int ft_log_add_sink(t_log_sink sink, void *user_data)
     if (g_sinks.get_error() != ER_SUCCESS)
     {
         final_error = g_sinks.get_error();
-        g_sinks_mutex.unlock(THREAD_ID);
-        if (g_sinks_mutex.get_error() != ER_SUCCESS)
+        if (logger_unlock_sinks() != 0)
         {
             return (-1);
         }
@@ -33,8 +31,7 @@ int ft_log_add_sink(t_log_sink sink, void *user_data)
         return (-1);
     }
     final_error = ER_SUCCESS;
-    g_sinks_mutex.unlock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_unlock_sinks() != 0)
     {
         return (-1);
     }

--- a/Logger/logger_log_async.cpp
+++ b/Logger/logger_log_async.cpp
@@ -22,23 +22,20 @@ static void ft_log_process_message(const ft_string &message)
     ft_vector<s_log_sink> sinks_snapshot;
     int    final_error;
 
-    g_sinks_mutex.lock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_lock_sinks() != 0)
         return ;
     sink_count = g_sinks.size();
     if (g_sinks.get_error() != ER_SUCCESS)
     {
         final_error = g_sinks.get_error();
-        g_sinks_mutex.unlock(THREAD_ID);
-        if (g_sinks_mutex.get_error() != ER_SUCCESS)
+        if (logger_unlock_sinks() != 0)
             return ;
         ft_errno = final_error;
         return ;
     }
     if (sink_count == 0)
     {
-        g_sinks_mutex.unlock(THREAD_ID);
-        if (g_sinks_mutex.get_error() != ER_SUCCESS)
+        if (logger_unlock_sinks() != 0)
             return ;
         ssize_t write_result;
         write_result = write(1, message.c_str(), message.size());
@@ -54,8 +51,7 @@ static void ft_log_process_message(const ft_string &message)
         if (g_sinks.get_error() != ER_SUCCESS)
         {
             final_error = g_sinks.get_error();
-            g_sinks_mutex.unlock(THREAD_ID);
-            if (g_sinks_mutex.get_error() != ER_SUCCESS)
+            if (logger_unlock_sinks() != 0)
             {
                 return ;
             }
@@ -66,16 +62,14 @@ static void ft_log_process_message(const ft_string &message)
         if (sinks_snapshot.get_error() != ER_SUCCESS)
         {
             final_error = sinks_snapshot.get_error();
-            g_sinks_mutex.unlock(THREAD_ID);
-            if (g_sinks_mutex.get_error() != ER_SUCCESS)
+            if (logger_unlock_sinks() != 0)
                 return ;
             ft_errno = final_error;
             return ;
         }
         index++;
     }
-    g_sinks_mutex.unlock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_unlock_sinks() != 0)
         return ;
     index = 0;
     while (index < sink_count)

--- a/Logger/logger_log_close.cpp
+++ b/Logger/logger_log_close.cpp
@@ -11,15 +11,13 @@ void ft_log_close()
     int    clear_error;
     int    final_error;
 
-    g_sinks_mutex.lock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_lock_sinks() != 0)
         return ;
     sink_count = g_sinks.size();
     if (g_sinks.get_error() != ER_SUCCESS)
     {
         final_error = g_sinks.get_error();
-        g_sinks_mutex.unlock(THREAD_ID);
-        if (g_sinks_mutex.get_error() != ER_SUCCESS)
+        if (logger_unlock_sinks() != 0)
             return ;
         ft_errno = final_error;
         return ;
@@ -33,8 +31,7 @@ void ft_log_close()
         if (g_sinks.get_error() != ER_SUCCESS)
         {
             final_error = g_sinks.get_error();
-            g_sinks_mutex.unlock(THREAD_ID);
-            if (g_sinks_mutex.get_error() != ER_SUCCESS)
+            if (logger_unlock_sinks() != 0)
                 return ;
             ft_errno = final_error;
             return ;
@@ -43,8 +40,7 @@ void ft_log_close()
         if (sinks_snapshot.get_error() != ER_SUCCESS)
         {
             final_error = sinks_snapshot.get_error();
-            g_sinks_mutex.unlock(THREAD_ID);
-            if (g_sinks_mutex.get_error() != ER_SUCCESS)
+            if (logger_unlock_sinks() != 0)
                 return ;
             ft_errno = final_error;
             return ;
@@ -53,8 +49,7 @@ void ft_log_close()
     }
     g_sinks.clear();
     clear_error = g_sinks.get_error();
-    g_sinks_mutex.unlock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_unlock_sinks() != 0)
         return ;
     if (clear_error != ER_SUCCESS)
     {

--- a/Logger/logger_log_remove_sink.cpp
+++ b/Logger/logger_log_remove_sink.cpp
@@ -8,8 +8,7 @@ void ft_log_remove_sink(t_log_sink sink, void *user_data)
     size_t sink_count;
     int    final_error;
 
-    g_sinks_mutex.lock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_lock_sinks() != 0)
         return ;
     index = 0;
     removed = false;
@@ -17,8 +16,7 @@ void ft_log_remove_sink(t_log_sink sink, void *user_data)
     if (g_sinks.get_error() != ER_SUCCESS)
     {
         final_error = g_sinks.get_error();
-        g_sinks_mutex.unlock(THREAD_ID);
-        if (g_sinks_mutex.get_error() != ER_SUCCESS)
+        if (logger_unlock_sinks() != 0)
             return ;
         ft_errno = final_error;
         return ;
@@ -31,8 +29,7 @@ void ft_log_remove_sink(t_log_sink sink, void *user_data)
         if (g_sinks.get_error() != ER_SUCCESS)
         {
             final_error = g_sinks.get_error();
-            g_sinks_mutex.unlock(THREAD_ID);
-            if (g_sinks_mutex.get_error() != ER_SUCCESS)
+            if (logger_unlock_sinks() != 0)
                 return ;
             ft_errno = final_error;
             return ;
@@ -43,8 +40,7 @@ void ft_log_remove_sink(t_log_sink sink, void *user_data)
             if (g_sinks.get_error() != ER_SUCCESS)
             {
                 final_error = g_sinks.get_error();
-                g_sinks_mutex.unlock(THREAD_ID);
-                if (g_sinks_mutex.get_error() != ER_SUCCESS)
+                if (logger_unlock_sinks() != 0)
                     return ;
                 ft_errno = final_error;
                 return ;
@@ -58,8 +54,7 @@ void ft_log_remove_sink(t_log_sink sink, void *user_data)
         final_error = FT_EINVAL;
     else
         final_error = ER_SUCCESS;
-    g_sinks_mutex.unlock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_unlock_sinks() != 0)
         return ;
     ft_errno = final_error;
     return ;

--- a/Logger/logger_log_state.cpp
+++ b/Logger/logger_log_state.cpp
@@ -2,5 +2,33 @@
 
 t_log_level g_level = LOG_LEVEL_INFO;
 ft_vector<s_log_sink> g_sinks;
-pt_mutex g_sinks_mutex;
+pthread_mutex_t g_sinks_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool g_use_color = true;
+
+int logger_lock_sinks()
+{
+    int lock_result;
+
+    lock_result = pthread_mutex_lock(&g_sinks_mutex);
+    if (lock_result != 0)
+    {
+        ft_errno = lock_result + ERRNO_OFFSET;
+        return (-1);
+    }
+    ft_errno = ER_SUCCESS;
+    return (0);
+}
+
+int logger_unlock_sinks()
+{
+    int unlock_result;
+
+    unlock_result = pthread_mutex_unlock(&g_sinks_mutex);
+    if (unlock_result != 0)
+    {
+        ft_errno = unlock_result + ERRNO_OFFSET;
+        return (-1);
+    }
+    ft_errno = ER_SUCCESS;
+    return (0);
+}

--- a/Logger/logger_log_vwrite.cpp
+++ b/Logger/logger_log_vwrite.cpp
@@ -72,8 +72,7 @@ void ft_log_vwrite(t_log_level level, const char *fmt, va_list args)
     ft_vector<s_log_sink> sinks_snapshot;
     int final_error;
 
-    g_sinks_mutex.lock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_lock_sinks() != 0)
     {
         return ;
     }
@@ -81,8 +80,7 @@ void ft_log_vwrite(t_log_level level, const char *fmt, va_list args)
     if (g_sinks.get_error() != ER_SUCCESS)
     {
         final_error = g_sinks.get_error();
-        g_sinks_mutex.unlock(THREAD_ID);
-        if (g_sinks_mutex.get_error() != ER_SUCCESS)
+        if (logger_unlock_sinks() != 0)
         {
             return ;
         }
@@ -109,6 +107,10 @@ void ft_log_vwrite(t_log_level level, const char *fmt, va_list args)
     length = pf_snprintf(final_buffer, sizeof(final_buffer), "[%s] [%s] %s\n", time_buffer, ft_level_to_str(level), message_buffer);
     if (length <= 0)
     {
+        if (logger_unlock_sinks() != 0)
+        {
+            return ;
+        }
         ft_errno = FT_EINVAL;
         return ;
     }
@@ -125,8 +127,7 @@ void ft_log_vwrite(t_log_level level, const char *fmt, va_list args)
             if (g_sinks.get_error() != ER_SUCCESS)
             {
                 final_error = g_sinks.get_error();
-                g_sinks_mutex.unlock(THREAD_ID);
-                if (g_sinks_mutex.get_error() != ER_SUCCESS)
+                if (logger_unlock_sinks() != 0)
                 {
                     return ;
                 }
@@ -141,8 +142,7 @@ void ft_log_vwrite(t_log_level level, const char *fmt, va_list args)
             if (contains_error != ER_SUCCESS)
             {
                 final_error = contains_error;
-                g_sinks_mutex.unlock(THREAD_ID);
-                if (g_sinks_mutex.get_error() != ER_SUCCESS)
+                if (logger_unlock_sinks() != 0)
                 {
                     return ;
                 }
@@ -158,8 +158,7 @@ void ft_log_vwrite(t_log_level level, const char *fmt, va_list args)
             if (sinks_snapshot.get_error() != ER_SUCCESS)
             {
                 final_error = sinks_snapshot.get_error();
-                g_sinks_mutex.unlock(THREAD_ID);
-                if (g_sinks_mutex.get_error() != ER_SUCCESS)
+                if (logger_unlock_sinks() != 0)
                 {
                     return ;
                 }
@@ -169,8 +168,7 @@ void ft_log_vwrite(t_log_level level, const char *fmt, va_list args)
             index++;
         }
     }
-    g_sinks_mutex.unlock(THREAD_ID);
-    if (g_sinks_mutex.get_error() != ER_SUCCESS)
+    if (logger_unlock_sinks() != 0)
     {
         return ;
     }

--- a/PThread/pthread_unlock_mutex.cpp
+++ b/PThread/pthread_unlock_mutex.cpp
@@ -2,6 +2,67 @@
 #include "mutex.hpp"
 #include "../Errno/errno.hpp"
 #include "../Libft/libft.hpp"
+#include <climits>
+#include <unistd.h>
+
+static void pt_mutex_report_wake_failure(int wake_error)
+{
+    char message_buffer[128];
+    const char *prefix_string;
+    size_t prefix_index;
+    int absolute_error;
+    char digit_buffer[16];
+    size_t digit_index;
+    size_t message_index;
+
+    prefix_string = "pt_mutex::unlock wake failure: ";
+    prefix_index = 0;
+    message_index = 0;
+    while (prefix_string[prefix_index] != '\0' && message_index < sizeof(message_buffer) - 1)
+    {
+        message_buffer[message_index] = prefix_string[prefix_index];
+        prefix_index += 1;
+        message_index += 1;
+    }
+    if (wake_error < 0 && message_index < sizeof(message_buffer) - 1)
+    {
+        message_buffer[message_index] = '-';
+        message_index += 1;
+        if (wake_error == INT_MIN)
+            wake_error = INT_MAX;
+        else
+            wake_error = -wake_error;
+    }
+    absolute_error = wake_error;
+    digit_index = 0;
+    if (absolute_error == 0)
+    {
+        digit_buffer[digit_index] = '0';
+        digit_index += 1;
+    }
+    else
+    {
+        while (absolute_error != 0 && digit_index < sizeof(digit_buffer))
+        {
+            digit_buffer[digit_index] = static_cast<char>('0' + (absolute_error % 10));
+            absolute_error = absolute_error / 10;
+            digit_index += 1;
+        }
+    }
+    while (digit_index > 0 && message_index < sizeof(message_buffer) - 1)
+    {
+        digit_index -= 1;
+        message_buffer[message_index] = digit_buffer[digit_index];
+        message_index += 1;
+    }
+    if (message_index < sizeof(message_buffer) - 1)
+    {
+        message_buffer[message_index] = '\n';
+        message_index += 1;
+    }
+    write(2, message_buffer, message_index);
+    return ;
+}
 
 
 int pt_mutex::unlock(pthread_t thread_id)
@@ -16,9 +77,27 @@ int pt_mutex::unlock(pthread_t thread_id)
     this->_owner.store(0, std::memory_order_relaxed);
     this->_lock = false;
     this->_serving.fetch_add(1, std::memory_order_release);
-    if (pt_thread_wake_one_uint32(&this->_serving) != 0)
+    int wake_result;
+    int wake_error;
+    int wake_attempts;
+
+    wake_error = ER_SUCCESS;
+    wake_attempts = 0;
+    while (1)
     {
-        this->set_error(ft_errno);
+        wake_result = pt_thread_wake_one_uint32(&this->_serving);
+        if (wake_result == 0)
+            break;
+        wake_error = ft_errno;
+        if (wake_attempts >= 4)
+            break;
+        wake_attempts += 1;
+    }
+    if (wake_result != 0)
+    {
+        ft_errno = wake_error;
+        this->set_error(wake_error);
+        pt_mutex_report_wake_failure(wake_error);
         return (-1);
     }
     return (FT_SUCCESS);

--- a/Test/Test/test_api_request.cpp
+++ b/Test/Test/test_api_request.cpp
@@ -1189,7 +1189,11 @@ FT_TEST(test_api_request_retry_policy_timeout, "api_request_string retries until
     status_value = -45;
     body = api_request_string("127.0.0.1", 54341, "GET", "/", ft_nullptr,
             ft_nullptr, &status_value, 50, &retry_policy);
+    int request_errno;
+
+    request_errno = ft_errno;
     server_thread.join();
+    ft_errno = request_errno;
     if (body)
     {
         cma_free(body);
@@ -1197,7 +1201,7 @@ FT_TEST(test_api_request_retry_policy_timeout, "api_request_string retries until
     }
     if (status_value != -45)
         return (0);
-    if (ft_errno != SOCKET_RECEIVE_FAILED && ft_errno != FT_EIO)
+    if (request_errno != SOCKET_RECEIVE_FAILED && request_errno != FT_EIO)
         return (0);
     return (1);
 }


### PR DESCRIPTION
## Summary
- replace the logger sink ticket mutex with a pthread mutex guarded by helper lock/unlock wrappers
- update all logger sink operations to use the new helpers and release the mutex on every failure path
- retry futex wakes in pt_mutex::unlock and log persistent failures to diagnose lost wakeups

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e40e92f838833198d1f7748ea62282