### PR TITLE
Guard logger sink mutex initialization at runtime

### DIFF
--- a/Logger/logger_log_state.cpp
+++ b/Logger/logger_log_state.cpp
@@ -2,13 +2,41 @@
 
 t_log_level g_level = LOG_LEVEL_INFO;
 ft_vector<s_log_sink> g_sinks;
-pthread_mutex_t g_sinks_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t g_sinks_mutex;
+static pthread_once_t g_sinks_mutex_once = PTHREAD_ONCE_INIT;
+static int g_sinks_mutex_init_error = 0;
 bool g_use_color = true;
+
+static void logger_initialize_sinks_mutex()
+{
+    int init_result;
+
+    init_result = pthread_mutex_init(&g_sinks_mutex, nullptr);
+    if (init_result != 0)
+    {
+        g_sinks_mutex_init_error = init_result;
+        return ;
+    }
+    g_sinks_mutex_init_error = 0;
+    return ;
+}
 
 int logger_lock_sinks()
 {
+    int once_result;
     int lock_result;
 
+    once_result = pthread_once(&g_sinks_mutex_once, logger_initialize_sinks_mutex);
+    if (once_result != 0)
+    {
+        ft_errno = once_result + ERRNO_OFFSET;
+        return (-1);
+    }
+    if (g_sinks_mutex_init_error != 0)
+    {
+        ft_errno = g_sinks_mutex_init_error + ERRNO_OFFSET;
+        return (-1);
+    }
     lock_result = pthread_mutex_lock(&g_sinks_mutex);
     if (lock_result != 0)
     {
@@ -21,8 +49,20 @@ int logger_lock_sinks()
 
 int logger_unlock_sinks()
 {
+    int once_result;
     int unlock_result;
 
+    once_result = pthread_once(&g_sinks_mutex_once, logger_initialize_sinks_mutex);
+    if (once_result != 0)
+    {
+        ft_errno = once_result + ERRNO_OFFSET;
+        return (-1);
+    }
+    if (g_sinks_mutex_init_error != 0)
+    {
+        ft_errno = g_sinks_mutex_init_error + ERRNO_OFFSET;
+        return (-1);
+    }
     unlock_result = pthread_mutex_unlock(&g_sinks_mutex);
     if (unlock_result != 0)
     {

--- a/PThread/pthread_unlock_mutex.cpp
+++ b/PThread/pthread_unlock_mutex.cpp
@@ -14,6 +14,8 @@ static void pt_mutex_report_wake_failure(int wake_error)
     char digit_buffer[16];
     size_t digit_index;
     size_t message_index;
+    size_t write_operation_index;
+    ssize_t write_operation_result;
 
     prefix_string = "pt_mutex::unlock wake failure: ";
     prefix_index = 0;
@@ -60,7 +62,16 @@ static void pt_mutex_report_wake_failure(int wake_error)
         message_buffer[message_index] = '\n';
         message_index += 1;
     }
-    write(2, message_buffer, message_index);
+    write_operation_index = 0;
+    while (write_operation_index < message_index)
+    {
+        write_operation_result = write(2, message_buffer + write_operation_index, message_index - write_operation_index);
+        if (write_operation_result <= 0)
+        {
+            break;
+        }
+        write_operation_index += static_cast<size_t>(write_operation_result);
+    }
     return ;
 }
 


### PR DESCRIPTION
## Summary
- replace the static `PTHREAD_MUTEX_INITIALIZER` with a `pthread_once` runtime initializer for the logger sink mutex
- surface initialization failures before locking or unlocking so `ft_errno` is accurate

## Testing
- make tests

------
https://chatgpt.com/codex/tasks/task_e_68e4abf78a8c83318527e1b4cea4e003