### PR TITLE
Add big number error accessors and tracking

### DIFF
--- a/CPP_class/class_big_number.hpp
+++ b/CPP_class/class_big_number.hpp
@@ -37,6 +37,7 @@ class ft_big_number
         ft_size_t       _size;
         ft_size_t       _capacity;
         bool            _is_negative;
+        mutable int     _error_code;
         mutable pt_recursive_mutex    _mutex;
         static thread_local error_stack _error_stack;
         static thread_local operation_error_stack _operation_errors;
@@ -103,6 +104,8 @@ class ft_big_number
         bool        empty() const noexcept;
         bool        is_negative() const noexcept;
         bool        is_positive() const noexcept;
+        int         get_error() const noexcept;
+        const char* get_error_str() const noexcept;
         ft_string   to_string_base(int base) noexcept;
         ft_big_number mod_pow(const ft_big_number& exponent, const ft_big_number& modulus) const noexcept;
         static const char *last_operation_error_str() noexcept;

--- a/CPP_class/cpp_class_big_number.cpp
+++ b/CPP_class/cpp_class_big_number.cpp
@@ -268,6 +268,8 @@ void ft_big_number::sleep_backoff() noexcept
 
 void ft_big_number::set_error_unlocked(int error_code) const noexcept
 {
+    this->_error_code = error_code;
+    ft_errno = error_code;
     ft_big_number::record_operation_error(error_code);
     return ;
 }
@@ -280,8 +282,7 @@ void ft_big_number::set_error(int error_code) const noexcept
 
 void ft_big_number::set_system_error_unlocked(int error_code) const noexcept
 {
-    if (error_code != FT_SYS_ERR_SUCCESS)
-        ft_big_number::record_operation_error(error_code);
+    ft_sys_errno = error_code;
     return ;
 }
 
@@ -512,6 +513,7 @@ ft_big_number::ft_big_number() noexcept
     , _size(0)
     , _capacity(0)
     , _is_negative(false)
+    , _error_code(FT_ERR_SUCCESSS)
     , _mutex()
 {
     this->set_error_unlocked(FT_ERR_SUCCESSS);
@@ -523,6 +525,7 @@ ft_big_number::ft_big_number(const ft_big_number& other) noexcept
     , _size(0)
     , _capacity(0)
     , _is_negative(false)
+    , _error_code(FT_ERR_SUCCESSS)
     , _mutex()
 {
     ft_big_number_mutex_guard other_guard;
@@ -559,6 +562,7 @@ ft_big_number::ft_big_number(ft_big_number&& other) noexcept
     , _size(0)
     , _capacity(0)
     , _is_negative(false)
+    , _error_code(FT_ERR_SUCCESSS)
     , _mutex()
 {
     ft_big_number_mutex_guard other_guard;
@@ -1898,6 +1902,31 @@ bool ft_big_number::is_positive() const noexcept
     else
         result = !this->_is_negative;
     return (result);
+}
+
+int ft_big_number::get_error() const noexcept
+{
+    ft_big_number_mutex_guard guard;
+    int lock_error;
+    int error_value;
+
+    lock_error = this->lock_self(guard);
+    if (lock_error != FT_ERR_SUCCESSS)
+    {
+        this->set_error_unlocked(lock_error);
+        return (lock_error);
+    }
+    error_value = this->_error_code;
+    ft_errno = error_value;
+    return (error_value);
+}
+
+const char* ft_big_number::get_error_str() const noexcept
+{
+    int error_value;
+
+    error_value = this->get_error();
+    return (ft_strerror(error_value));
 }
 
 ft_string ft_big_number::to_string_base(int base) noexcept


### PR DESCRIPTION
### Motivation
- Tests referenced `get_error()`/`get_error_str()` on `ft_big_number` but the class did not expose or track per-instance error state, causing test compile failures.
- Bring `ft_big_number` in line with the project's error-handling conventions of per-object `ft_errno`/`ft_sys_errno` usage and accessor helpers.

### Description
- Add a mutable `_error_code` member to `ft_big_number` and expose `get_error()` and `get_error_str()` in the header. 
- Initialize `_error_code` in all constructors and update move/copy semantics to preserve error initialization. 
- Implement `get_error()` to lock the object, return the stored error, and set `ft_errno`, and implement `get_error_str()` to return `ft_strerror(get_error())`. 
- Change `set_error_unlocked()` to update the instance `_error_code` and `ft_errno` and keep recording operation errors, and route system errors through `ft_sys_errno` in `set_system_error_unlocked()`.

### Testing
- No automated builds or tests were executed per instructions. 
- Changes were locally added and committed to the workspace. 
- Further verification requires running the test suite and a full build (not performed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd5bb34b083319b2bcc568a633052)