### PR TITLE
Include Libft header in Errno internal header to provide ft_size_t

### DIFF
--- a/Errno/errno_internal.hpp
+++ b/Errno/errno_internal.hpp
@@ -3,6 +3,7 @@
 
 #include <mutex>
 #include <cstdint>
+#include "../Libft/libft.hpp"
 
 class ft_errno_mutex_wrapper
 {


### PR DESCRIPTION
### Motivation
- Fix a compilation error where `ft_size_t` was not defined in `Errno/errno_internal.hpp`, which caused build failures for functions declared there.

### Description
- Added `#include "../Libft/libft.hpp"` to `Errno/errno_internal.hpp` so the `ft_size_t` typedef (and related definitions) are available.
- This change makes declarations such as `ft_global_error_stack_error_at` and `ft_global_error_stack_error_str_at` compile correctly.
- Only a single header include was added to the internal errno header.

### Testing
- No automated tests were run (per instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e1d2e43fc83319af8d1177ae78a87)